### PR TITLE
Liquibase: sproc updates with bug fixes

### DIFF
--- a/liquibase-service/src/main/resources/db/odse/001-fn_get_value_by_cd_ques-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/001-fn_get_value_by_cd_ques-001.sql
@@ -5,44 +5,44 @@ CREATE OR ALTER FUNCTION dbo.fn_get_value_by_cd_ques(
     returns table
     as return
 
-select
-    cvg.code_short_desc_txt
-from
-    nbs_odse.dbo.nbs_question nq with (nolock)
-	join nbs_srte.dbo.codeset cd with (nolock) on
-    cd.code_set_group_id = nq.code_set_group_id
-    join nbs_srte.dbo.code_value_general cvg with (nolock) on
-    cvg.code_set_nm = cd.code_set_nm
-    and nq.question_identifier = (@ques_identifier)
-    and @srte_code = cvg.code
-    and @srte_code is not null
-UNION
-select
-    cvg.code_short_desc_txt
-FROM
-    nbs_odse.dbo.nbs_question nq with (nolock),
-		nbs_srte.dbo.codeset cd with (nolock),
-    nbs_srte.dbo.naics_industry_code cvg with (nolock)
-where
-    nq.question_identifier = (@ques_identifier)
---( 'DEM139')
-  and @ques_identifier = 'DEM139'
-  and cd.code_set_group_id = nq.code_set_group_id
-  and cvg.code_set_nm = cd.code_set_nm
-  and @srte_code = cvg.code
-  and @srte_code is not null
-UNION
-select
-    cvg.code_short_desc_txt
-FROM
-    nbs_odse.dbo.nbs_question nq with (nolock),
-		nbs_srte.dbo.codeset cd with (nolock),
-    nbs_srte.dbo.language_code cvg with (nolock)
-where
-    nq.question_identifier = (@ques_identifier)
---( 'DEM142')
-  and @ques_identifier = 'DEM142'
-  and cd.code_set_group_id = nq.code_set_group_id
-  and cvg.code_set_nm = cd.code_set_nm
-  and @srte_code = cvg.code
-  and @srte_code is not null;
+    select
+        cvg.code_short_desc_txt
+    from
+        nbs_odse.dbo.nbs_question nq with (nolock)
+        join nbs_srte.dbo.codeset cd with (nolock) on
+        cd.code_set_group_id = nq.code_set_group_id
+        join nbs_srte.dbo.code_value_general cvg with (nolock) on
+        cvg.code_set_nm = cd.code_set_nm
+        and nq.question_identifier = (@ques_identifier)
+        and @srte_code = cvg.code
+        and @srte_code is not null
+    UNION
+    select
+        cvg.code_short_desc_txt
+    FROM
+        nbs_odse.dbo.nbs_question nq with (nolock),
+            nbs_srte.dbo.codeset cd with (nolock),
+        nbs_srte.dbo.naics_industry_code cvg with (nolock)
+    where
+        nq.question_identifier = (@ques_identifier)
+    --( 'DEM139')
+      and @ques_identifier = 'DEM139'
+      and cd.code_set_group_id = nq.code_set_group_id
+      and cvg.code_set_nm = cd.code_set_nm
+      and @srte_code = cvg.code
+      and @srte_code is not null
+    UNION
+    select
+        cvg.code_short_desc_txt
+    FROM
+        nbs_odse.dbo.nbs_question nq with (nolock),
+            nbs_srte.dbo.codeset cd with (nolock),
+        nbs_srte.dbo.language_code cvg with (nolock)
+    where
+        nq.question_identifier = (@ques_identifier)
+    --( 'DEM142')
+      and @ques_identifier = 'DEM142'
+      and cd.code_set_group_id = nq.code_set_group_id
+      and cvg.code_set_nm = cd.code_set_nm
+      and @srte_code = cvg.code
+      and @srte_code is not null;

--- a/liquibase-service/src/main/resources/db/odse/005-sp_organization_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/005-sp_organization_event-001.sql
@@ -2,197 +2,196 @@ CREATE OR ALTER PROCEDURE dbo.sp_organization_event @org_id_list nvarchar(max)
 AS
 Begin
 
-BEGIN TRY
- 	DECLARE @batch_id BIGINT;
- 	SET @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
-INSERT INTO [rdb_modern].[dbo].[job_flow_log]
-(
-      batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[Msg_Description1]
-)
-VALUES (
-    @batch_id
-        ,'Organization PRE-Processing Event'
-        ,'NBS_ODSE.sp_organization_event'
-        ,'START'
-        ,0
-        ,LEFT('Pre ID-' + @org_id_list,199)
-        ,0
-        ,LEFT(@org_id_list,199)
-    );
+    BEGIN TRY
+        DECLARE @batch_id BIGINT;
+        SET @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[Msg_Description1]
+        )
+        VALUES (
+                 @batch_id
+               ,'Organization PRE-Processing Event'
+               ,'NBS_ODSE.sp_organization_event'
+               ,'START'
+               ,0
+               ,LEFT('Pre ID-' + @org_id_list,199)
+               ,0
+               ,LEFT(@org_id_list,199)
+               );
 
-SELECT o.organization_uid,
-       LTRIM(RTRIM(SUBSTRING(o.description,1,1000))) as description,
-       o.cd,
-       LTRIM(RTRIM(SUBSTRING(o.electronic_ind,1,1))) as electronic_ind,
-       LTRIM(RTRIM(SUBSTRING(dbo.fn_get_record_status(o.record_status_cd),1,20))) as record_status_cd,
-       o.record_status_time,
-       o.status_cd,
-       o.status_time,
-       LTRIM(RTRIM(o.local_id)) as local_id,
-       o.version_ctrl_nbr,
-       o.edx_ind,
-       LTRIM(RTRIM(naics.code_short_desc_txt)) as 'stand_ind_class',
-        o.add_user_id,
-       case
-           when o.add_user_id > 0 then (select * from dbo.fn_get_user_name(o.add_user_id))
-           end                   as add_user_name,
-       o.last_chg_user_id,
-       case
-           when o.last_chg_user_id > 0 then (select * from dbo.fn_get_user_name(o.last_chg_user_id))
-           end                   as last_chg_user_name,
-       o.add_time,
-       o.last_chg_time,
-       nested.name               AS 'organization_name',
-        nested.address            AS 'organization_address',
-        nested.phone              AS 'organization_telephone',
-        nested.fax                AS 'organization_fax',
-        nested.entity_id          AS 'organization_entity_id'
-FROM NBS_ODSE.dbo.Organization o WITH (NOLOCK)
-             OUTER apply (SELECT *
-                          FROM
-                              -- address
-                              (SELECT (SELECT elp.cd                 AS               [addr_elp_cd],
-                                              elp.use_cd             AS               [addr_elp_use_cd],
-                                              pl.postal_locator_uid  AS               [addr_pl_uid],
-                                              STRING_ESCAPE(pl.street_addr1, 'json')  street_addr1,
-                                              STRING_ESCAPE(pl.street_addr2, 'json')  street_addr2,
-                                              STRING_ESCAPE(pl.city_desc_txt, 'json') city,
-                                              pl.zip_cd                               zip,
-                                              pl.cnty_cd                              cnty_cd,
-                                              pl.state_cd                             state,
-                                              pl.cntry_cd                             cntry_cd,
-                                              sc.code_desc_txt                        state_desc,
-                                              scc.code_desc_txt                       county,
-                                              pl.within_city_limits_ind               within_city_limits_ind,
-                                              cc.code_short_desc_txt AS               [country],
-                                              elp.locator_desc_txt   AS               [address_comments],
-                                              ccv.code_desc_txt      as               [county_desc]
-                                       FROM entity_locator_participation elp with (nolock)
-                                                left outer join postal_locator pl with (nolock)
-                                                                on elp.locator_uid = pl.postal_locator_uid
-                                                left outer join nbs_srte.dbo.state_code sc with (nolock) on sc.state_cd = pl.state_cd
-                                                left outer join nbs_srte.dbo.state_county_code_value scc with (nolock)
-                                                              on scc.code = pl.cnty_cd
-                                                left outer join nbs_srte.dbo.country_code cc with (nolock) on cc.code = pl.cntry_cd
-                                                left outer join nbs_srte.dbo.state_county_code_value ccv with (nolock)
-                                                                on ccv.code = pl.cnty_cd
-               WHERE elp.entity_uid = o.organization_uid
-                                         AND elp.class_cd = 'PST'
-                                         AND elp.use_cd = 'WP'
-                                         AND elp.cd = 'O'
-                                       FOR json path, INCLUDE_NULL_VALUES) AS address) AS address,
-                              -- org name
-                              (SELECT (SELECT on2.organization_uid                       AS [on_org_uid],
-                                              LTRIM(RTRIM(SUBSTRING(on2.nm_txt, 1, 50))) AS [organization_name]
-                                       FROM NBS_ODSE.dbo.Organization_name on2
-                                       WHERE o.organization_uid = on2.organization_uid
-                                       FOR json path, INCLUDE_NULL_VALUES) AS name) AS name,
-                              -- org phone
-                              (SELECT (SELECT tl.tele_locator_uid  AS                              [ph_tl_uid],
-                                              elp.cd               AS                              [ph_elp_cd],
-                                              elp.use_cd           AS                              [ph_elp_use_cd],
-                                              REPLACE(REPLACE(tl.phone_nbr_txt, '-', ''), ' ', '') telephone_nbr,
-                                              tl.extension_txt                                     extension_txt,
-                                              STRING_ESCAPE(tl.email_address, 'json')              email_address,
-                                              elp.locator_desc_txt as                              [phone_comments]
-                                       FROM Entity_locator_participation elp WITH (NOLOCK)
-                                                JOIN Tele_locator tl WITH (NOLOCK) ON elp.locator_uid = tl.tele_locator_uid
-                                       WHERE elp.entity_uid = o.organization_uid
-                                         AND elp.class_cd = 'TELE'
-                                         AND elp.use_cd = 'WP'
-                                         AND elp.cd = 'PH'
-                                       FOR json path, INCLUDE_NULL_VALUES) AS phone) AS phone,
-                              -- org fax
-                              (SELECT (SELECT tl.tele_locator_uid                              AS [fax_tl_uid],
-                                              elp.cd                                           AS [fax_elp_cd],
-                                              elp.use_cd                                       AS [fax_elp_use_cd],
-                                              LTRIM(RTRIM(SUBSTRING(tl.phone_nbr_txt, 1, 20))) as [org_fax]
-                                       FROM Entity_locator_participation elp WITH (NOLOCK)
-                                                JOIN Tele_locator tl WITH (NOLOCK) ON elp.locator_uid = tl.tele_locator_uid
-                                       WHERE elp.entity_uid = o.organization_uid
-                                         AND elp.class_cd = 'TELE'
-                                         AND elp.use_cd = 'WP'
-                                         AND elp.cd = 'FAX'
-                                       FOR json path, INCLUDE_NULL_VALUES) AS fax) AS fax,
-                              -- Entity id
-                              (SELECT (SELECT ei.entity_uid,
-                      						  ei.type_cd          AS [type_cd],
-                                 			  ei.record_status_cd AS [record_status_cd],
-                                              STRING_ESCAPE(
-                                                      REPLACE(REPLACE(ei.root_extension_txt, '-', ''), ' ', ''),
-                                                      'json')     AS [root_extension_txt],
-                                              ei.entity_id_seq,
-                                           	  ei.assigning_authority_cd,
-                                              case
-                                                  when (ei.type_cd = 'FI' and ei.assigning_authority_cd is not null)
-                                                      then (select *
-                                                            from dbo.fn_get_value_by_cvg(ei.assigning_authority_cd, 'EI_AUTH_ORG'))
-                                                  end             as facility_id_auth
-                                       FROM entity_id ei WITH (NOLOCK)
-                                       WHERE ei.entity_uid = o.organization_uid
-                                       FOR json path, INCLUDE_NULL_VALUES) AS entity_id) AS entity_id) AS nested
-             LEFT JOIN nbs_srte.dbo.NAICS_INDUSTRY_CODE naics ON (NAICS.CODE = o.STANDARD_INDUSTRY_CLASS_CD)
-WHERE o.organization_uid in (SELECT value FROM STRING_SPLIT(@org_id_list, ','))
+        SELECT o.organization_uid,
+               LTRIM(RTRIM(SUBSTRING(o.description,1,1000))) as description,
+               o.cd,
+               LTRIM(RTRIM(SUBSTRING(o.electronic_ind,1,1))) as electronic_ind,
+               LTRIM(RTRIM(SUBSTRING(dbo.fn_get_record_status(o.record_status_cd),1,20))) as record_status_cd,
+               o.record_status_time,
+               o.status_cd,
+               o.status_time,
+               LTRIM(RTRIM(o.local_id)) as local_id,
+               o.version_ctrl_nbr,
+               o.edx_ind,
+               LTRIM(RTRIM(naics.code_short_desc_txt)) as 'stand_ind_class',
+               o.add_user_id,
+               case
+                   when o.add_user_id > 0 then (select * from dbo.fn_get_user_name(o.add_user_id))
+                   end                   as add_user_name,
+               o.last_chg_user_id,
+               case
+                   when o.last_chg_user_id > 0 then (select * from dbo.fn_get_user_name(o.last_chg_user_id))
+                   end                   as last_chg_user_name,
+               o.add_time,
+               o.last_chg_time,
+               nested.name               AS 'organization_name',
+               nested.address            AS 'organization_address',
+               nested.phone              AS 'organization_telephone',
+               nested.fax                AS 'organization_fax',
+               nested.entity_id          AS 'organization_entity_id'
+        FROM NBS_ODSE.dbo.Organization o WITH (NOLOCK)
+                 OUTER apply (SELECT *
+                              FROM
+                                  -- address
+                                  (SELECT (SELECT elp.cd                 AS               [addr_elp_cd],
+                                                  elp.use_cd             AS               [addr_elp_use_cd],
+                                                  pl.postal_locator_uid  AS               [addr_pl_uid],
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr1, 'json'),1,50))) AS street_addr1,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr2, 'json'),1,50))) AS street_addr2,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.city_desc_txt, 'json'),1,50))) AS city,
+                                                  pl.zip_cd                               zip,
+                                                  pl.cnty_cd                              cnty_cd,
+                                                  pl.state_cd                             state,
+                                                  pl.cntry_cd                             cntry_cd,
+                                                  sc.code_desc_txt                        state_desc,
+                                                  scc.code_desc_txt                       county,
+                                                  pl.within_city_limits_ind               within_city_limits_ind,
+                                                  LTRIM(RTRIM(SUBSTRING(cc.code_short_desc_txt,1,50))) AS [country],
+                                                  LTRIM(RTRIM(SUBSTRING(elp.locator_desc_txt,1,2000))) AS [address_comments],
+                                                  LTRIM(RTRIM(SUBSTRING(ccv.code_desc_txt,1,50))) AS [county_desc]
+                                           FROM entity_locator_participation elp with (nolock)
+                                                    left outer join postal_locator pl with (nolock)
+                                                                    on elp.locator_uid = pl.postal_locator_uid
+                                                    left outer join nbs_srte.dbo.state_code sc with (nolock) on sc.state_cd = pl.state_cd
+                                                    left outer join nbs_srte.dbo.state_county_code_value scc with (nolock)
+                                                                    on scc.code = pl.cnty_cd
+                                                    left outer join nbs_srte.dbo.country_code cc with (nolock) on cc.code = pl.cntry_cd
+                                                    left outer join nbs_srte.dbo.state_county_code_value ccv with (nolock)
+                                                                    on ccv.code = pl.cnty_cd
+                                           WHERE elp.entity_uid = o.organization_uid
+                                             AND elp.class_cd = 'PST'
+                                             AND elp.use_cd = 'WP'
+                                             AND elp.cd = 'O'
+                                           FOR json path, INCLUDE_NULL_VALUES) AS address) AS address,
+                                  -- org name
+                                  (SELECT (SELECT on2.organization_uid                       AS [on_org_uid],
+                                                  LTRIM(RTRIM(SUBSTRING(on2.nm_txt, 1, 50))) AS [organization_name]
+                                           FROM NBS_ODSE.dbo.Organization_name on2
+                                           WHERE o.organization_uid = on2.organization_uid
+                                           FOR json path, INCLUDE_NULL_VALUES) AS name) AS name,
+                                  -- org phone
+                                  (SELECT (SELECT tl.tele_locator_uid  AS                              [ph_tl_uid],
+                                                  elp.cd               AS                              [ph_elp_cd],
+                                                  elp.use_cd           AS                              [ph_elp_use_cd],
+                                                  REPLACE(tl.phone_nbr_txt, ' ', '')                   telephone_nbr,
+                                                  tl.extension_txt                                     extension_txt,
+                                                  STRING_ESCAPE(tl.email_address, 'json')              email_address,
+                                                  elp.locator_desc_txt as                              [phone_comments]
+                                           FROM Entity_locator_participation elp WITH (NOLOCK)
+                                                    JOIN Tele_locator tl WITH (NOLOCK) ON elp.locator_uid = tl.tele_locator_uid
+                                           WHERE elp.entity_uid = o.organization_uid
+                                             AND elp.class_cd = 'TELE'
+                                             AND elp.use_cd = 'WP'
+                                             AND elp.cd = 'PH'
+                                           FOR json path, INCLUDE_NULL_VALUES) AS phone) AS phone,
+                                  -- org fax
+                                  (SELECT (SELECT tl.tele_locator_uid                              AS [fax_tl_uid],
+                                                  elp.cd                                           AS [fax_elp_cd],
+                                                  elp.use_cd                                       AS [fax_elp_use_cd],
+                                                  LTRIM(RTRIM(SUBSTRING(tl.phone_nbr_txt, 1, 20))) as [org_fax]
+                                           FROM Entity_locator_participation elp WITH (NOLOCK)
+                                                    JOIN Tele_locator tl WITH (NOLOCK) ON elp.locator_uid = tl.tele_locator_uid
+                                           WHERE elp.entity_uid = o.organization_uid
+                                             AND elp.class_cd = 'TELE'
+                                             AND elp.use_cd = 'WP'
+                                             AND elp.cd = 'FAX'
+                                           FOR json path, INCLUDE_NULL_VALUES) AS fax) AS fax,
+                                  -- Entity id
+                                  (SELECT (SELECT ei.entity_uid,
+                                                  ei.type_cd          AS [type_cd],
+                                                  ei.record_status_cd AS [record_status_cd],
+                                                  STRING_ESCAPE(REPLACE(ei.root_extension_txt, ' ', ''),
+                                                                'json')    AS [root_extension_txt],
+                                                  ei.entity_id_seq,
+                                                  ei.assigning_authority_cd,
+                                                  case
+                                                      when (ei.type_cd = 'FI' and ei.assigning_authority_cd is not null)
+                                                          then (select *
+                                                                from dbo.fn_get_value_by_cvg(ei.assigning_authority_cd, 'EI_AUTH_ORG'))
+                                                      end             as facility_id_auth
+                                           FROM entity_id ei WITH (NOLOCK)
+                                           WHERE ei.entity_uid = o.organization_uid
+                                           FOR json path, INCLUDE_NULL_VALUES) AS entity_id) AS entity_id) AS nested
+                 LEFT JOIN nbs_srte.dbo.NAICS_INDUSTRY_CODE naics ON (NAICS.CODE = o.STANDARD_INDUSTRY_CLASS_CD)
+        WHERE o.organization_uid in (SELECT value FROM STRING_SPLIT(@org_id_list, ','))
 
-INSERT INTO [rdb_modern].[dbo].[job_flow_log]
-(
-      batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[Msg_Description1]
-)
-VALUES (
-    @batch_id
-        ,'Organization PRE-Processing Event'
-        ,'NBS_ODSE.sp_organization_event'
-        ,'COMPLETE'
-        ,0
-        ,LEFT('Pre ID-' + @org_id_list,199)
-        ,0
-        ,LEFT(@org_id_list,199)
-    );
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[Msg_Description1]
+        )
+        VALUES (
+                 @batch_id
+               ,'Organization PRE-Processing Event'
+               ,'NBS_ODSE.sp_organization_event'
+               ,'COMPLETE'
+               ,0
+               ,LEFT('Pre ID-' + @org_id_list,199)
+               ,0
+               ,LEFT(@org_id_list,199)
+               );
 
-end try
+    end try
 
-BEGIN CATCH
+    BEGIN CATCH
 
 
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
-    	DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-    batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[Msg_Description1]
-)
-VALUES (
-    @batch_id
-        ,'Organization PRE-Processing Event'
-        ,'NBS_ODSE.sp_organization_event'
-        ,'ERROR: ' + @ErrorMessage
-        ,0
-        ,LEFT('Pre ID-' + @org_id_list,199)
-        ,0
-        ,LEFT(@org_id_list,199)
-    );
-return @ErrorMessage;
+        DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
+                                                        batch_id
+                                                      ,[Dataflow_Name]
+                                                      ,[package_Name]
+                                                      ,[Status_Type]
+                                                      ,[step_number]
+                                                      ,[step_name]
+                                                      ,[row_count]
+                                                      ,[Msg_Description1]
+        )
+        VALUES (
+                 @batch_id
+               ,'Organization PRE-Processing Event'
+               ,'NBS_ODSE.sp_organization_event'
+               ,'ERROR: ' + @ErrorMessage
+               ,0
+               ,LEFT('Pre ID-' + @org_id_list,199)
+               ,0
+               ,LEFT(@org_id_list,199)
+               );
+        return @ErrorMessage;
 
-END CATCH
+    END CATCH
 
 end;

--- a/liquibase-service/src/main/resources/db/odse/006-sp_provider_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/006-sp_provider_event-001.sql
@@ -64,9 +64,9 @@ BEGIN
                                   (SELECT (SELECT elp.cd                AS                [addr_elp_cd],
                                                   elp.use_cd            AS                [addr_elp_use_cd],
                                                   pl.postal_locator_uid as                [addr_pl_uid],
-                                                  STRING_ESCAPE(pl.street_addr1, 'json')  streetAddr1,
-                                                  STRING_ESCAPE(pl.street_addr2, 'json')  streetAddr2,
-                                                  STRING_ESCAPE(pl.city_desc_txt, 'json') city,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr1, 'json'),1,50))) as street_addr1,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr2, 'json'),1,50))) as street_addr2,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.city_desc_txt, 'json'),1,50))) as city,
                                                   pl.zip_cd                               zip,
                                                   pl.cnty_cd                              cntyCd,
                                                   pl.state_cd                             state,
@@ -92,7 +92,7 @@ BEGIN
                                   (SELECT (SELECT tl.tele_locator_uid AS                               [ph_tl_uid],
                                                   elp.cd              AS                               [ph_elp_cd],
                                                   elp.use_cd          AS                               [ph_elp_use_cd],
-                                                  REPLACE(REPLACE(tl.phone_nbr_txt, '-', ''), ' ', '') telephoneNbr,
+                                                  REPLACE(tl.phone_nbr_txt, ' ', '') 				   telephoneNbr,
                                                   tl.extension_txt                                     extensionTxt,
                                                   elp.locator_desc_txt                                 phone_comments
                                            FROM nbs_odse.dbo.Entity_locator_participation elp WITH (NOLOCK)
@@ -100,6 +100,7 @@ BEGIN
                                                          ON elp.locator_uid = tl.tele_locator_uid
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.CLASS_CD = 'TELE'
+                                             AND elp.CD IN ('O', 'CP')
                                              AND elp.RECORD_STATUS_CD = 'ACTIVE'
                                              AND tl.phone_nbr_txt IS NOT NULL
                                            FOR json path, INCLUDE_NULL_VALUES) AS phone) AS phone,
@@ -113,6 +114,8 @@ BEGIN
                                                          ON elp.locator_uid = tl.tele_locator_uid
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'TELE'
+                                             AND elp.USE_CD='WP'
+                                             AND elp.CD='O'
                                              AND elp.RECORD_STATUS_CD = 'ACTIVE'
                                              AND tl.email_address IS NOT NULL
                                            FOR json path, INCLUDE_NULL_VALUES) AS email) AS email,
@@ -145,9 +148,8 @@ BEGIN
                                   (SELECT (SELECT ei.entity_uid,
                                                   ei.type_cd          typeCd,
                                                   ei.record_status_cd recordStatusCd,
-                                                  STRING_ESCAPE(
-                                                          REPLACE(REPLACE(ei.root_extension_txt, '-', ''), ' ', ''),
-                                                          'json')     rootExtensionTxt,
+                                                  STRING_ESCAPE(REPLACE(ei.root_extension_txt, ' ', ''),
+                                                                'json')      rootExtensionTxt,
                                                   ei.entity_id_seq,
                                                   ei.assigning_authority_cd
                                            FROM nbs_odse.dbo.entity_id ei WITH (NOLOCK)

--- a/liquibase-service/src/main/resources/db/odse/008-sp_patient_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/008-sp_patient_event-001.sql
@@ -209,9 +209,9 @@ BEGIN
                                   (SELECT (SELECT elp.cd                                                                 AS [addr_elp_cd],
                                                   elp.use_cd                                                             AS [addr_elp_use_cd],
                                                   pl.postal_locator_uid                                                  as [addr_pl_uid],
-                                                  STRING_ESCAPE(pl.street_addr1, 'json')                                 AS [streetAddr1],
-                                                  STRING_ESCAPE(pl.street_addr2, 'json')                                 AS [streetAddr2],
-                                                  STRING_ESCAPE(pl.city_desc_txt, 'json')                                AS [city],
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr1, 'json'),1,50)))   AS street_addr1,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.street_addr2, 'json'),1,50)))   AS street_addr2,
+                                                  LTRIM(RTRIM(SUBSTRING(STRING_ESCAPE(pl.city_desc_txt, 'json'),1,50)))  AS city,
                                                   pl.zip_cd                                                              AS [zip],
                                                   pl.cnty_cd                                                             AS [cntyCd],
                                                   pl.state_cd                                                            AS [state],
@@ -234,6 +234,7 @@ BEGIN
                                                     LEFT OUTER JOIN nbs_srte.dbo.Country_code cc with (nolock) ON cc.code = pl.cntry_cd
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
+                                             AND elp.use_cd IN ('H', 'BIR')
                                              AND elp.RECORD_STATUS_CD = 'ACTIVE'
                                            FOR json path, INCLUDE_NULL_VALUES) AS address) AS address,
                                   -- person phone
@@ -319,8 +320,8 @@ BEGIN
                                                   race_white_all,
                                                   race_all
                                            FROM nbs_odse.dbo.person_race pr WITH (NOLOCK)
-                                                    left outer join nbs_srte.dbo.race_code src ON pr.race_cd = src.code
-                                                    left outer join #temp_race_table trt on trt.patient_uid_race_out = p.person_uid
+                                                    left outer join nbs_srte.dbo.race_code src WITH (NOLOCK) ON pr.race_cd = src.code
+                                                    left outer join #temp_race_table trt WITH (NOLOCK) on trt.patient_uid_race_out = p.person_uid
                                            WHERE person_uid = p.person_uid
                                            FOR json path, INCLUDE_NULL_VALUES) AS race) AS race,
                                   -- Entity id
@@ -356,7 +357,7 @@ BEGIN
                ,0
                ,LEFT(@user_id_list, 199));
 
-    end try
+    END TRY
     BEGIN CATCH
 
 
@@ -384,4 +385,4 @@ BEGIN
 
     END CATCH
 
-end;
+END;

--- a/liquibase-service/src/main/resources/db/odse/010-sp_investigation_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/010-sp_investigation_event-001.sql
@@ -1,2650 +1,649 @@
-CREATE OR ALTER PROCEDURE dbo.sp_public_health_case_fact_datamart_event @phc_id_list nvarchar(max)
+CREATE OR ALTER PROCEDURE [dbo].[sp_investigation_event] @phc_id_list nvarchar(max)
 AS
 BEGIN
-	DECLARE @RowCount_no INT;
-	DECLARE @Proc_Step_no FLOAT = 0;
-	DECLARE @Proc_Step_Name VARCHAR(200) = '';
-	DECLARE @batch_id BIGINT;
-	DECLARE @batch_start_time DATETIME2(7) = NULL;
-	DECLARE @batch_end_time DATETIME2(7) = NULL;
-	DECLARE @type_code VARCHAR(200) = 'PHCMartETL';
-	DECLARE @type_description VARCHAR(200) = 'PHCMartETL Process';
-	DECLARE @return_value INT = 0;
 
-BEGIN TRY
+    BEGIN TRY
+
+        DECLARE @batch_id BIGINT;
+
+        /*NBS case answer section
+         * TODO: Bring in null rows*/
+
+        SET @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log]
+        (      batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES (
+                 @batch_id
+               , 'Investigation PRE-Processing Event'
+               , 'NBS_ODSE.sp_investigation_event'
+               , 'START'
+               , 0
+               , LEFT ('Pre ID-' + @phc_id_list, 199)
+               , 0
+               , LEFT (@phc_id_list, 199)
+               );
+
+
+        SELECT *
+        into
+            #temp_page_case_answer_table
+        FROM (SELECT *,
+                     ROW_NUMBER() OVER (PARTITION BY NBS_QUESTION_UID
+                         order by
+                             NBS_QUESTION_UID,
+                             other_value_ind_cd desc) rowid
+              FROM (SELECT distinct nbs_case_answer_uid,
+                                    nuim.nbs_ui_metadata_uid,
+                                    nrdbm.nbs_rdb_metadata_uid,
+                                    nrdbm.rdb_table_nm,
+                                    nrdbm.rdb_column_nm,
+                                    nuim.code_set_group_id,
+                                    cast(replace(answer_txt, char(13)+ char(10), ' ') as varchar(2000)) as answer_txt,
+                                    pa.act_uid,
+                                    pa.record_status_cd,
+                                    nuim.nbs_question_uid,
+                                    nuim.investigation_form_cd,
+                                    nuim.unit_value,
+                                    nuim.question_identifier,
+                                    pa.answer_group_seq_nbr,
+                                    nuim.data_location,
+                                    question_label,
+                                    other_value_ind_cd,
+                                    unit_type_cd,
+                                    mask,
+                                    nuim.block_nm,
+                                    question_group_seq_nbr,
+                                    data_type,
+                                    pa.last_chg_time
+                    from nbs_odse.dbo.nbs_rdb_metadata nrdbm with (nolock)
+                             inner join nbs_odse.dbo.nbs_ui_metadata nuim
+                        with (nolock)
+                                        on
+                                            nrdbm.nbs_ui_metadata_uid = nuim.nbs_ui_metadata_uid
+                             left outer join nbs_odse.dbo.nbs_case_answer pa
+                        with (nolock)
+                                             on
+                                                 nuim.nbs_question_uid = pa.nbs_question_uid
+                             inner join nbs_srte.dbo.code_value_general cvg
+                        with (nolock)
+                                        on
+                                            cvg.code = nuim.data_type
+                    where
+                        cvg.code_set_nm = 'NBS_DATA_TYPE'
+                      and
+                        act_uid in (
+                            SELECT
+                                value
+                            FROM
+                                STRING_SPLIT(@phc_id_list
+                                    , ','))) as answer_table) as answer_table
+        where rowid = 1;
+
+        /*Complete Investigation section*/
+        SELECT results.public_health_case_uid,
+               results.program_jurisdiction_oid as program_jurisdiction_oid,
+               jc.code                          as jurisdiction_code,
+               jc.code_desc_txt                 as jurisdiction_nm,
+               act.mood_cd,
+               act.class_cd,
+               results.case_type_cd,
+               results.case_class_cd,
+               results.inv_case_status,
+               results.outbreak_name,
+               results.cd,
+               results.cd_desc_txt,
+               results.prog_area_cd,
+               results.jurisdiction_cd,
+               results.pregnant_ind_cd,
+               results.pregnant_ind,
+               results.local_id                    local_id,
+               results.rpt_form_cmplt_time,
+               results.activity_to_time,
+               results.activity_from_time,
+               results.add_user_id,
+               case
+                   when results.add_user_id > 0 then (select * from dbo.fn_get_user_name(results.add_user_id))
+                   end                          as add_user_name,
+               results.add_time,
+               results.last_chg_user_id,
+               case
+                   when results.last_chg_user_id > 0 then (select * from dbo.fn_get_user_name(results.last_chg_user_id))
+                   end                          as last_chg_user_name,
+               results.last_chg_time,
+               results.curr_process_state_cd,
+               results.curr_process_state,
+               results.investigation_status_cd,
+               results.investigation_status,
+               case
+                   when (results.record_status_cd is not null or results.record_status_cd != '')
+                       then dbo.fn_get_record_status(results.record_status_cd)
+                   end                          as record_status_cd,
+               results.shared_ind,
+               results.txt,
+               results.effective_from_time,
+               results.effective_to_time,
+               results.rpt_source_cd,
+               results.rpt_src_cd_desc,
+               results.rpt_to_county_time,
+               results.rpt_to_state_time,
+               results.mmwr_week,
+               results.mmwr_year,
+               results.disease_imported_cd,
+               results.disease_imported_ind,
+               results.imported_country_cd,
+               results.imported_state_cd,
+               results.imported_county_cd,
+               results.imported_from_country,
+               sc.state_nm                         imported_from_state,
+               sccv.code_desc_txt                  imported_from_county,
+               results.imported_city_desc_txt,
+               results.diagnosis_time,
+               results.hospitalized_admin_time,
+               results.hospitalized_discharge_time,
+               results.hospitalized_duration_amt,
+               results.outbreak_ind,
+               results.outbreak_ind_val,
+               results.hospitalized_ind_cd,
+               results.hospitalized_ind,
+               results.transmission_mode_cd,
+               results.transmission_mode,
+               results.outcome_cd,
+               results.die_frm_this_illness_ind,
+               results.day_care_ind_cd,
+               results.day_care_ind,
+               results.food_handler_ind_cd,
+               results.food_handler_ind,
+               results.deceased_time,
+               results.pat_age_at_onset,
+               results.pat_age_at_onset_unit_cd,
+               results.pat_age_at_onset_unit,
+               results.detection_method_cd,
+               results.priority_cd,
+               results.contact_inv_status_cd,
+               cvg.code_desc_txt                   detection_method_desc_txt,
+               cvg1.code_short_desc_txt            contact_inv_priority,
+               cvg2.code_short_desc_txt            contact_inv_status,
+               results.investigator_assigned_time,
+               results.effective_duration_amt,
+               results.effective_duration_unit_cd,
+               results.illness_duration_unit,
+               results.infectious_from_date,
+               results.infectious_to_date,
+               results.referral_basis_cd,
+               results.referral_basis,
+               results.inv_priority_cd,
+               results.coinfection_id,
+               results.contact_inv_txt,
+               pac.prog_area_desc_txt              program_area_description,
+               notification.local_id               notification_local_id,
+               notification.add_time               notification_add_time,
+               notification.record_status_cd       notification_record_status_cd,
+               notification.last_chg_time          notification_last_chg_time,
+               cm.case_management_uid,
+               investigation_act_entity.nac_page_case_uid,
+               investigation_act_entity.nac_last_chg_time,
+               investigation_act_entity.nac_add_time,
+               investigation_act_entity.person_as_reporter_uid,
+               investigation_act_entity.hospital_uid,
+               investigation_act_entity.ordering_facility_uid,
+               results.act_ids,
+               results.observation_notification_ids,
+               results.person_participations,
+               results.organization_participations,
+               results.investigation_confirmation_method,
+               results.investigation_case_answer,
+               results.investigation_notifications
+        --con.investigation_form_cd,
+        -- ,results.investigation_act_entity
+        -- ,results.ldf_public_health_case
+        -- into dbo.Investigation_Dim_Event
+        FROM (SELECT phc.public_health_case_uid,
+                     phc.program_jurisdiction_oid program_jurisdiction_oid,
+                     phc.case_type_cd,
+                     phc.case_class_cd,
+                     case
+                         when (phc.case_class_cd is not null or phc.case_class_cd != '') then (select *
+                                                                                               from dbo.fn_get_value_by_cd_codeset(phc.case_class_cd, 'INV163'))
+                         end as                   inv_case_status,
+                     phc.outbreak_name,
+                     phc.cd,
+                     phc.cd_desc_txt              cd_desc_txt,
+                     phc.prog_area_cd             prog_area_cd,
+                     phc.jurisdiction_cd          jurisdiction_cd,
+                     phc.pregnant_ind_cd          pregnant_ind_cd,
+                     case
+                         when (phc.pregnant_ind_cd is not null or phc.pregnant_ind_cd != '') then (select *
+                                                                                                   from dbo.fn_get_value_by_cd_codeset(phc.pregnant_ind_cd, 'INV178'))
+                         end as                   pregnant_ind,
+                     phc.local_id                 local_id,
+                     phc.rpt_form_cmplt_time      rpt_form_cmplt_time,
+                     phc.activity_to_time         activity_to_time,
+                     phc.add_time                 add_time,
+                     phc.activity_from_time       activity_from_time,
+                     phc.last_chg_time,
+                     phc.add_user_id              add_user_id,
+                     phc.last_chg_user_id         last_chg_user_id,
+                     phc.curr_process_state_cd    curr_process_state_cd,
+                     case
+                         when (phc.curr_process_state_cd is not null or phc.curr_process_state_cd != '') then (select *
+                                                                                                               from dbo.fn_get_value_by_cvg(
+                                                                                                                       phc.curr_process_state_cd,
+                                                                                                                       'CM_PROCESS_STAGE'))
+                         end as                   curr_process_state,
+                     phc.investigation_status_cd,
+                     case
+                         when (phc.investigation_status_cd is not null or phc.investigation_status_cd != '') then (select *
+                                                                                                                   from dbo.fn_get_value_by_cd_codeset(
+                                                                                                                           phc.investigation_status_cd,
+                                                                                                                           'INV109'))
+                         end as                   investigation_status,
+                     phc.record_status_cd,
+                     phc.shared_ind,
+                     phc.txt,
+                     phc.effective_from_time,
+                     phc.effective_to_time,
+                     phc.rpt_source_cd,
+                     case
+                         when (phc.rpt_source_cd is not null or phc.rpt_source_cd != '') then (select *
+                                                                                               from dbo.fn_get_value_by_cd_codeset(phc.rpt_source_cd, 'INV112'))
+                         end as                   rpt_src_cd_desc,
+                     phc.rpt_to_county_time,
+                     phc.rpt_to_state_time,
+                     phc.mmwr_week,
+                     phc.mmwr_year,
+                     phc.disease_imported_cd,
+                     case
+                         when (phc.disease_imported_cd is not null or phc.disease_imported_cd != '') then (select *
+                                                                                                           from dbo.fn_get_value_by_cd_codeset(phc.disease_imported_cd, 'INV152'))
+                         end as                   disease_imported_ind,
+                     phc.imported_city_desc_txt,
+                     phc.imported_country_cd,
+                     case
+                         when (phc.imported_country_cd is not null or phc.imported_country_cd != '') then (select *
+                                                                                                           from dbo.fn_get_value_by_cd_codeset(phc.imported_country_cd, 'INV153'))
+                         end as                   imported_from_country,
+                     phc.imported_state_cd,
+                     phc.imported_county_cd,
+                     phc.diagnosis_time,
+                     phc.hospitalized_admin_time,
+                     phc.hospitalized_discharge_time,
+                     phc.hospitalized_duration_amt,
+                     phc.outbreak_ind,
+                     case
+                         when (phc.outbreak_ind is not null or phc.outbreak_ind != '') then (select *
+                                                                                             from dbo.fn_get_value_by_cd_codeset(phc.outbreak_ind, 'INV150'))
+                         end as                   outbreak_ind_val,
+                     phc.hospitalized_ind_cd,
+                     case
+                         when (phc.hospitalized_ind_cd is not null or phc.hospitalized_ind_cd != '') then (select *
+                                                                                                           from dbo.fn_get_value_by_cd_codeset(phc.hospitalized_ind_cd, 'INV128'))
+                         end as                   hospitalized_ind,
+                     phc.transmission_mode_cd,
+                     case
+                         when (phc.transmission_mode_cd is not null or phc.transmission_mode_cd != '') then (select *
+                                                                                                             from dbo.fn_get_value_by_cd_codeset(phc.transmission_mode_cd, 'INV157'))
+                         end as                   transmission_mode,
+                     phc.outcome_cd,
+                     case
+                         when (phc.outcome_cd != '') then (select *
+                                                           from dbo.fn_get_value_by_cd_codeset(phc.outcome_cd, 'INV145'))
+                         end as                   die_frm_this_illness_ind,
+                     phc.day_care_ind_cd,
+                     case
+                         when (phc.day_care_ind_cd is not null or phc.day_care_ind_cd != '') then (select *
+                                                                                                   from dbo.fn_get_value_by_cd_codeset(phc.day_care_ind_cd, 'INV148'))
+                         end as                   day_care_ind,
+                     phc.food_handler_ind_cd,
+                     case
+                         when (phc.food_handler_ind_cd is not null or phc.food_handler_ind_cd != '') then (select *
+                                                                                                           from dbo.fn_get_value_by_cd_codeset(phc.food_handler_ind_cd, 'INV149'))
+                         end as                   food_handler_ind,
+                     phc.deceased_time,
+                     phc.pat_age_at_onset,
+                     phc.pat_age_at_onset_unit_cd,
+                     case
+                         when (phc.pat_age_at_onset_unit_cd is not null or phc.pat_age_at_onset_unit_cd != '') then (select *
+                                                                                                                     from dbo.fn_get_value_by_cd_codeset(
+                                                                                                                             phc.pat_age_at_onset_unit_cd,
+                                                                                                                             'INV144'))
+                         end as                   pat_age_at_onset_unit,
+                     phc.detection_method_cd,
+                     phc.priority_cd,
+                     phc.investigator_assigned_time,
+                     phc.effective_duration_amt,
+                     phc.effective_duration_unit_cd,
+                     case
+                         when (phc.effective_duration_unit_cd is not null or phc.effective_duration_unit_cd != '')
+                             then (select * from dbo.fn_get_value_by_cd_codeset(phc.effective_duration_unit_cd, 'INV144'))
+                         end as                   illness_duration_unit,
+                     phc.infectious_from_date,
+                     phc.infectious_to_date,
+                     phc.referral_basis_cd,
+                     case
+                         when (phc.referral_basis_cd is not null or phc.referral_basis_cd != '') then (select *
+                                                                                                       from dbo.fn_get_value_by_cvg(phc.referral_basis_cd, 'REFERRAL_BASIS'))
+                         end as                   referral_basis,
+                     phc.inv_priority_cd,
+                     phc.contact_inv_status_cd,
+                     phc.coinfection_id,
+                     phc.contact_inv_txt,
+                     nesteddata.act_ids,
+                     nesteddata.observation_notification_ids,
+                     nesteddata.person_participations,
+                     nesteddata.organization_participations,
+                     nesteddata.investigation_confirmation_method,
+                     nesteddata.investigation_case_answer
+                      ,
+                     nesteddata.investigation_notifications
+              --,nesteddata.ldf_public_health_case
+              FROM
+                  --public health case
+                  public_health_case phc WITH (NOLOCK)
+                      OUTER apply (
+                      SELECT
+                          *
+                      FROM
+                          (
+                              -- persons associated with public_health_case
+                              SELECT
+                                  (
+                                      SELECT
+                                          p.act_uid AS [act_uid],
+                                          p.type_cd AS [type_cd],
+                                          p.subject_entity_uid AS [entity_id],
+                                          p.subject_class_cd AS [subject_class_cd],
+                                          p.record_status_cd AS [participation_record_status],
+                                          p.last_chg_time AS [participation_last_change_time],
+                                          STRING_ESCAPE(person.first_nm, 'json') AS [first_name],
+                                          STRING_ESCAPE(person.last_nm, 'json') AS [last_name],
+                                          person.local_id AS [local_id],
+                                          person.birth_time AS [birth_time],
+                                          person.curr_sex_cd AS [curr_sex_cd],
+                                          person.cd AS [person_cd],
+                                          person.person_parent_uid AS [person_parent_uid],
+                                          person.record_status_cd AS [person_record_status],
+                                          person.last_chg_time AS [person_last_chg_time]
+                                      FROM
+                                          participation p
+                                              WITH (NOLOCK)
+                                              JOIN person WITH (NOLOCK) ON person.person_uid = (
+                                              select
+                                                  person.person_parent_uid
+                                              from
+                                                  person
+                                              where
+                                                  person.person_uid = p.subject_entity_uid
+                                          )
+                                      WHERE
+                                          p.act_uid = phc.public_health_case_uid FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS person_participations
+                          ) AS person_participations,
+                          (
+                              SELECT
+                                  (
+                                      SELECT
+                                          p.act_uid AS [act_uid],
+                                          p.type_cd AS [type_cd],
+                                          p.subject_entity_uid AS [entity_id],
+                                          p.subject_class_cd AS [subject_class_cd],
+                                          p.record_status_cd AS [record_status],
+                                          p.last_chg_time AS [participation_last_change_time],
+                                          STRING_ESCAPE(org.display_nm, 'json') AS [name],
+                                          org.last_chg_time AS [org_last_change_time]
+                                      FROM
+                                          participation p
+                                              WITH (NOLOCK)
+                                              JOIN organization org WITH (NOLOCK) ON org.organization_uid = p.subject_entity_uid
+                                      WHERE
+                                          p.act_uid = phc.public_health_case_uid FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS organization_participations
+                          ) AS organization_participations
+                          -- act_ids associated with public health case
+                              ,(
+                              SELECT
+                                  (
+                                      SELECT
+                                          act.source_act_uid ,
+                                          act.target_Act_uid as public_health_case_uid,
+                                          act.source_class_cd,
+                                          act.target_class_cd,
+                                          act.type_cd as act_type_cd,
+                                          act.status_cd,
+                                          act.add_time act_add_time,
+                                          act.add_user_id act_add_user_id,
+                                          case when act.add_user_id > 0 then (select * from dbo.fn_get_user_name(act.add_user_id))
+                                              end as add_user_name,
+                                          act.last_chg_user_id act_last_chg_user_id,
+                                          case when act.last_chg_user_id > 0 then (select * from dbo.fn_get_user_name(act.last_chg_user_id))
+                                              end as last_chg_user_name,
+                                          act.last_chg_time as act_last_chg_time
+                                      FROM
+                                          act_id WITH (NOLOCK)
+                                              join act_relationship act WITH (NOLOCK) on act_id.act_uid = act.target_act_uid
+                                      WHERE
+                                          act.target_act_uid = phc.public_health_case_uid FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS observation_notification_ids
+                          ) AS observation_notification_ids
+                          -- act_ids associated with public health case
+                              ,(
+                              SELECT
+                                  (
+                                      SELECT
+                                          act_id.act_uid AS [id],
+                                          act_id_seq AS [act_id_seq],
+                                          act_id.record_status_cd AS [record_status],
+                                          act_id.root_extension_txt AS [root_extension_txt],
+                                          act_id.type_cd AS [type_cd],
+                                          act_id.type_desc_txt AS [type_desc_txt],
+                                          act_id.add_time act_id_add_time,
+                                          act_id.add_user_id act_id_add_user_id,
+                                          act_id.last_chg_user_id act_id_last_chg_user_id,
+                                          act_id.last_chg_time AS [act_id_last_change_time]
+                                      FROM
+                                          act_id WITH (NOLOCK)
+                                      WHERE
+                                          act_uid = phc.public_health_case_uid FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS act_ids
+                          ) AS act_ids,
+                          -- get assocaited confirmation method
+                          (
+                              SELECT
+                                  (
+                                      select cm.public_health_case_uid,
+                                             cm.confirmation_method_cd,
+                                             cvg.CODE_SHORT_DESC_TXT as confirmation_method_desc_txt,
+                                             cm.confirmation_method_time,
+                                             phc1.last_chg_time as phc_last_chg_time
+                                      from dbo.Confirmation_method cm
+                                               join nbs_srte.dbo.Code_value_general cvg WITH (NOLOCK) on cvg.code = cm.confirmation_method_cd and cvg.code_set_nm='PHC_CONF_M'
+                                               join dbo.Public_health_case phc1 WITH (NOLOCK) on cm.public_health_case_uid = phc1.public_health_case_uid
+                                      WHERE
+                                          cm.public_health_case_uid = phc.public_health_case_uid  FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS investigation_confirmation_method
+                          ) AS investigation_confirmation_method,
+                          -- NBS case answer associated with phc
+                          (
+                              SELECT
+                                  (
+                                      select
+                                          nbs_case_answer_uid,
+                                          nca.nbs_ui_metadata_uid,
+                                          nca.nbs_rdb_metadata_uid,
+                                          nca.rdb_table_nm,
+                                          nca.rdb_column_nm,
+                                          nca.code_set_group_id,
+                                          nca.answer_txt,
+                                          nca.act_uid,
+                                          nca.record_status_cd,
+                                          nca.nbs_question_uid,
+                                          nca.investigation_form_cd,
+                                          nca.unit_value,
+                                          nca.question_identifier,
+                                          nca.data_location,
+                                          nca.answer_group_seq_nbr,
+                                          nca.question_label,
+                                          nca.other_value_ind_cd,
+                                          nca.unit_type_cd,
+                                          nca.mask,
+                                          nca.block_nm,
+                                          nca.question_group_seq_nbr,
+                                          nca.data_type,
+                                          nca.last_chg_time
+                                      from #temp_page_case_answer_table nca WITH (NOLOCK)
+                                      WHERE
+                                          nca.act_uid = phc.public_health_case_uid
+                                      --AND nca.last_chg_time = phc.last_chg_time
+                                      FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS investigation_case_answer
+                          ) AS investigation_case_answer
+
+                          -- investigation notification columns
+                              ,(
+                              SELECT
+                                  (
+                                      SELECT
+                                          act.source_act_uid ,
+                                          act.target_act_uid as public_health_case_uid,
+                                          act.source_class_cd,
+                                          act.target_class_cd,
+                                          act.type_cd as act_type_cd,
+                                          act.status_cd,
+                                          notif.notification_uid,
+                                          notif.prog_area_cd,
+                                          notif.program_jurisdiction_oid,
+                                          notif.jurisdiction_cd,
+                                          notif.record_status_time,
+                                          notif.status_time,
+                                          notif.rpt_sent_time,
+                                          notif.record_status_cd as 'notif_status',
+                                          notif.local_id as 'notif_local_id',
+                                          notif.txt as 'notif_comments',
+                                          notif.add_time as 'notif_add_time',
+                                          notif.add_user_id as 'notif_add_user_id',
+                                          case when notif.add_user_id > 0 then (select * from dbo.fn_get_user_name(notif.add_user_id))
+                                              end as 'notif_add_user_name',
+                                          notif.last_chg_user_id as 'notif_last_chg_user_id',
+                                          case when notif.last_chg_user_id > 0 then (select * from dbo.fn_get_user_name(notif.last_chg_user_id))
+                                              end as 'notif_last_chg_user_name',
+                                          notif.last_chg_time as 'notif_last_chg_time',
+                                          per.local_id as 'local_patient_id',
+                                          per.person_uid as 'local_patient_uid',
+                                          phc.cd as 'condition_cd',
+                                          phc.cd_desc_txt as 'condition_desc'
+                                      FROM
+                                          act_relationship act WITH (NOLOCK)
+                                              join notification notif WITH (NOLOCK) on  act.source_act_uid = notif.notification_uid
+                                              join nbs_odse.dbo.participation part with (nolock) ON part.type_cd='SubjOfPHC' AND part.act_uid=act.target_act_uid
+                                              join nbs_odse.dbo.person per with (nolock) ON per.cd='PAT' AND per.person_uid = part.subject_entity_uid
+                                      WHERE
+                                          act.target_act_uid = phc.public_health_case_uid
+                                        AND notif.cd not in ('EXP_NOTF', 'SHARE_NOTF', 'EXP_NOTF_PHDC','SHARE_NOTF_PHDC')
+                                        AND act.source_class_cd = 'NOTF'
+                                        AND act.target_class_cd = 'CASE' FOR json path,INCLUDE_NULL_VALUES
+                                  ) AS investigation_notifications
+                          ) AS investigation_notifications
+
+                      /*
+                       -- ldf_phc associated with phc
+                      ,(
+                        SELECT
+                          (
+                           select * from nbs_odse..v_ldf_phc ldf
+                             WHERE ldf.public_health_case_uid = phc.public_health_case_uid
+                           Order By ldf.public_health_case_uid, ldf.display_order_nbr
+                                     FOR json path,INCLUDE_NULL_VALUES
+                          ) AS ldf_public_health_case
+                      ) AS ldf_public_health_case
+                      */
+
+                  ) as nestedData
+              WHERE
+                  phc.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_id_list
+                      , ','))) AS results
+                 LEFT JOIN notification WITH (NOLOCK) ON results.public_health_case_uid = notification.notification_uid
+                 LEFT JOIN nbs_srte.dbo.jurisdiction_code jc WITH (NOLOCK) ON results.jurisdiction_cd = jc.code
+                 LEFT JOIN act WITH (NOLOCK) ON act.act_uid = results.public_health_case_uid
+                 LEFT JOIN nbs_srte.dbo.program_area_code pac WITH (NOLOCK) on results.prog_area_cd = pac.prog_area_cd
+                 LEFT JOIN nbs_srte.dbo.state_code sc WITH (NOLOCK) ON results.imported_state_cd = sc.state_cd
+                 LEFT JOIN nbs_srte.dbo.state_county_code_value sccv WITH (NOLOCK) ON results.imported_county_cd = sccv.code
+                 LEFT JOIN nbs_srte.dbo.code_value_general cvg WITH (NOLOCK)
+                           ON results.detection_method_cd = cvg.code and cvg.code_set_nm = 'PHC_DET_MT'
+                 LEFT JOIN nbs_srte.dbo.code_value_general cvg1 WITH (NOLOCK)
+                           on results.priority_cd = cvg1.code and cvg1.code_set_nm = 'NBS_PRIORITY'
+                 LEFT JOIN nbs_srte.dbo.code_value_general cvg2 WITH (NOLOCK)
+                           on results.contact_inv_status_cd = cvg2.code and cvg2.code_set_nm = 'PHC_IN_STS'
+                 LEFT OUTER JOIN nbs_odse.dbo.case_management cm WITH (NOLOCK) on results.public_health_case_uid = cm.public_health_case_uid
+                 LEFT JOIN
+             (SELECT DISTINCT act_uid       AS                                                  nac_page_case_uid,
+                              last_chg_time AS                                                  nac_last_chg_time,
+                              add_time      as                                                  nac_add_time,
+                              MAX(CASE WHEN type_cd = 'PerAsReporterOfPHC' THEN entity_uid END) person_as_reporter_uid,
+                              MAX(CASE WHEN type_cd = 'HospOfADT' THEN entity_uid END)          hospital_uid,
+                              MAX(CASE WHEN type_cd = 'OrgAsClinicOfPHC' THEN entity_uid END)   ordering_facility_uid
+              FROM nbs_act_entity nac WITH (NOLOCK)
+              GROUP BY act_uid, last_chg_time, add_time) AS investigation_act_entity
+             ON investigation_act_entity.nac_page_case_uid = results.public_health_case_uid
+        --LEFT JOIN nbs_srte.dbo.condition_code con on results.cd = con.condition_cd
+        ;
+
+        -- select * from dbo.Investigation_Dim_Event;
+
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log]
+        (      batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES (
+                 @batch_id
+               , 'Investigation PRE-Processing Event'
+               , 'NBS_ODSE.sp_investigation_event'
+               , 'COMPLETE'
+               , 0
+               , LEFT ('Pre ID-' + @phc_id_list, 199)
+               , 0
+               , LEFT (@phc_id_list, 199)
+               );
+
+    END TRY
+
+    BEGIN CATCH
+
+
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+
+        DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+        INSERT INTO [rdb_modern].[dbo].[job_flow_log]
+        (      batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES (
+                 @batch_id
+               , 'Investigation PRE-Processing Event'
+               , 'NBS_ODSE.sp_investigation_event'
+               , 'ERROR: ' + @ErrorMessage
+               , 0
+               , LEFT ('Pre ID-' + @phc_id_list, 199)
+               , 0
+               , LEFT (@phc_id_list, 199)
+               );
+        return @ErrorMessage;
+
+    END CATCH
 
-
-		--EXEC @return_value = [rdb_modern].[dbo].[sp_nbs_batch_start] @type_code 	,@type_description;
-
-		-- SELECT 'Return Value TEST ' = @return_value;
-SELECT @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
-
--- SET @batch_end_time = getdate();
-
-
-PRINT CAST(@batch_id AS VARCHAR(max));
-
-
-BEGIN TRANSACTION;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'Start Process'
-        ,0
-        ,@phc_id_list
-        ,0
-    );
-
-
-SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_INV_FORM_CODE_DATA' ;
-
-		IF OBJECT_ID('#TEMP_INV_FORM_CODE_DATA') IS NOT NULL
-DROP TABLE #TEMP_INV_FORM_CODE_DATA;
-
--- The below SQL is now a view - nbs_odse.dbo.v_inv_form_code_data
-/*SELECT DISTINCT DATA_LOCATION
-    ,CODESET.CODE_SET_GROUP_ID
-    ,CODESET.CODE_SET_NM
-    ,NBS_UI_METADATA.INVESTIGATION_FORM_CD
-    ,CODE_VALUE_GENERAL.CODE
-    ,CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-INTO #TEMP_INV_FORM_CODE_DATA
-FROM NBS_ODSE.DBO.NBS_UI_METADATA WITH (NOLOCK)
-INNER JOIN NBS_SRTE.DBO.CODESET WITH (NOLOCK) ON NBS_UI_METADATA.CODE_SET_GROUP_ID = CODESET.CODE_SET_GROUP_ID
-INNER JOIN NBS_SRTE.DBO.CONDITION_CODE WITH (NOLOCK) ON CONDITION_CODE.INVESTIGATION_FORM_CD = NBS_UI_METADATA.INVESTIGATION_FORM_CD
-INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON CODE_VALUE_GENERAL.CODE_SET_NM = CODESET.CODE_SET_NM
-WHERE  question_identifier in (
-        'DEM218', 'DEM114', 'INV163',  'INV161',  'DEM126',  'DEM113', 'DEM127', 'INV159', 'INV152', 'DEM155', 'NOT112', 'INV109',  'INV107', 'DEM140',  'DEM116_B', 'DEM139', 'INV145', 'INV150', 'INV151', 'NPP063', 'INV144', 'DEM142', 'INV108',  'DEM152', 'DEM238', 'INV187', 'INV112', 'INV174', 'INV107', 'INV2002')
-        AND CODESET.CODE_SET_GROUP_ID IS NOT NULL
-ORDER BY NBS_UI_METADATA.DATA_LOCATION */
-
--- use the view and order by data_location
-Select DATA_LOCATION
-     ,CODE_SET_GROUP_ID
-     ,CODE_SET_NM
-     ,INVESTIGATION_FORM_CD
-     ,CODE
-     ,CODE_SHORT_DESC_TXT
-INTO #TEMP_INV_FORM_CODE_DATA
-from nbs_odse.dbo.v_inv_form_code_data
-ORDER BY DATA_LOCATION;
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-BEGIN TRANSACTION;
-				SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating DBO.TEMP_UPDATE_NEW_PATIENT';
-
-
-	IF OBJECT_ID('#TEMP_UPDATE_NEW_PATIENT') IS NOT NULL
-DROP TABLE #TEMP_UPDATE_NEW_PATIENT;
-
-SELECT  Public_health_case.PUBLIC_HEALTH_CASE_UID
-     ,PER.PERSON_UID
-     ,PER.PERSON_PARENT_UID
-     ,PER.LOCAL_ID AS PERSON_LOCAL_ID
-     ,PER.AGE_CATEGORY_CD
-     ,PER.AGE_REPORTED
-     ,PER.AGE_REPORTED_TIME
-     ,PER.AGE_REPORTED_UNIT_CD
-     ,PER.BIRTH_TIME
-     ,PER.BIRTH_TIME_CALC
-     ,PER.CD AS PERSON_CD
-     ,PER.CD_DESC_TXT AS PERSON_CODE_DESC
-     ,PER.CURR_SEX_CD
-     ,PER.DECEASED_IND_CD
-     ,PER.DECEASED_TIME
-     ,PER.ETHNIC_GROUP_IND
-     ,PER.MARITAL_STATUS_CD
-     ,MPR.MULTIPLE_BIRTH_IND
-     ,MPR.OCCUPATION_CD
-     ,MPR.PRIM_LANG_CD
-     ,MPR.ADULTS_IN_HOUSE_NBR
-     ,MPR.BIRTH_GENDER_CD
-     ,MPR.BIRTH_ORDER_NBR
-     ,MPR.CHILDREN_IN_HOUSE_NBR
-     ,MPR.EDUCATION_LEVEL_CD
-     ,MPR.LAST_CHG_TIME AS MPR_LAST_CHG_TIME
-     ,NOTIFICATION.LAST_CHG_TIME AS NOTIF_LAST_CHG_TIME
-INTO #TEMP_UPDATE_NEW_PATIENT
-FROM NBS_ODSE.DBO.PERSON PER WITH (NOLOCK)
-		INNER JOIN NBS_ODSE.DBO.PARTICIPATION PAR WITH (NOLOCK) ON PER.PERSON_UID = PAR.SUBJECT_ENTITY_UID
-    INNER JOIN NBS_ODSE.DBO.Public_health_case Public_health_case WITH (NOLOCK) ON PAR.act_uid = Public_health_case.public_health_case_uid
-    INNER JOIN NBS_ODSE.DBO.PERSON MPR WITH (NOLOCK) ON PER.PERSON_PARENT_UID = MPR.PERSON_UID
-    LEFT JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP  WITH (NOLOCK) ON ACT_RELATIONSHIP.TARGET_ACT_UID=PUBLIC_HEALTH_CASE.PUBLIC_HEALTH_CASE_UID
-    LEFT JOIN NBS_ODSE.DBO.NOTIFICATION   WITH (NOLOCK) ON NOTIFICATION.NOTIFICATION_UID=ACT_RELATIONSHIP.SOURCE_ACT_UID
-    AND NOTIFICATION.CD='NOTF'
-WHERE PAR.TYPE_CD = 'SUBJOFPHC'
-  and  Public_health_case.public_health_case_uid in (select value from string_split(@phc_id_list, ','))
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-COMMIT TRANSACTION;
--------------------PHCSUBJECT
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCPATIENTINFO';
-
-		IF OBJECT_ID('#TEMP_PHCPATIENTINFO') IS NOT NULL
-DROP TABLE #TEMP_PHCPATIENTINFO;
-
-SELECT
-    PER.*
-     ,(COALESCE(LTRIM(RTRIM(PNM.LAST_NM)), '') + ', ' + COALESCE(LTRIM(RTRIM(PNM.FIRST_NM)), '')) AS PATIENTNAME
-     ,case when LTRIM(RTRIM(PST.STATE_CD)) = '' then null else LTRIM(RTRIM(PST.STATE_CD)) end STATE_CD
-     ,SRT1.code_short_desc_txt AS STATE
-     ,case when LTRIM(RTRIM(PST.CNTY_CD)) = '' then null else LTRIM(RTRIM(PST.CNTY_CD)) end CNTY_CD
-     ,SRT3.code_desc_txt AS COUNTY
-     ,PAR.AWARENESS_CD
-     ,PAR.AWARENESS_DESC_TXT
-     ,PAR.TYPE_CD AS PAR_TYPE_CD
-     ,CVG.CODE_SHORT_DESC_TXT AS EDUCATION_LEVEL_DESC_TXT
-     ,RTRIM(LTRIM(A.CODE_SHORT_DESC_TXT)) AS ETHNIC_GROUP_IND_DESC
-     ,CVG2.CODE_SHORT_DESC_TXT AS MARITAL_STATUS_DESC_TXT
-     ,LNG.CODE_SHORT_DESC_TXT AS PRIM_LANG_DESC_TXT
-     ,ELP.FROM_TIME AS ELP_FROM_TIME
-     ,ELP.TO_TIME AS ELP_TO_TIME
-     ,ELP.CLASS_CD AS ELP_CLASS_CD
-     ,ELP.USE_CD AS ELP_USE_CD
-     ,ELP.AS_OF_DATE AS SUB_ADDR_AS_OF_DATE
-     ,PST.POSTAL_LOCATOR_UID
-     ,PST.CENSUS_BLOCK_CD
-     ,PST.CENSUS_MINOR_CIVIL_DIVISION_CD
-     ,PST.CENSUS_TRACK_CD
-     ,PST.CITY_CD
-     ,case when LTRIM(RTRIM(PST.CITY_DESC_TXT)) = '' then null else LTRIM(RTRIM(PST.CITY_DESC_TXT)) end CITY_DESC_TXT
-     ,case when LTRIM(RTRIM(PST.CNTRY_CD)) = '' then null else LTRIM(RTRIM(PST.CNTRY_CD)) end CNTRY_CD
-     ,CNTRY_DESC.CODE_SHORT_DESC_TXT AS CNTRY_DESC_TXT
-     ,PST.REGION_DISTRICT_CD
-     ,PST.MSA_CONGRESS_DISTRICT_CD
-     ,case when LTRIM(RTRIM(PST.ZIP_CD)) = '' then null else LTRIM(RTRIM(PST.ZIP_CD)) end ZIP_CD
-     ,PST.RECORD_STATUS_TIME AS PST_RECORD_STATUS_TIME
-     ,PST.RECORD_STATUS_CD AS PST_RECORD_STATUS_CD
-     ,case when LTRIM(RTRIM(PST.STREET_ADDR1)) = '' then null else LTRIM(RTRIM(PST.STREET_ADDR1)) end STREET_ADDR1
-     ,case when LTRIM(RTRIM(PST.STREET_ADDR2)) = '' then null else LTRIM(RTRIM(PST.STREET_ADDR2)) end STREET_ADDR2
-     ,PAR.ACT_UID
-     ,CONDITION_CODE.INVESTIGATION_FORM_CD
-     ,AGE_UNIT.CODE_SHORT_DESC_TXT AS AGE_REPORTED_UNIT_DESC_TXT
-     ,BIRTH_GENDER.CODE_SHORT_DESC_TXT AS BIRTH_GENDER_DESC_TXT
-     ,CURR_SEX.CODE_SHORT_DESC_TXT AS CURR_SEX_DESC_TXT
-     ,OCCUPATION.CODE_SHORT_DESC_TXT AS OCCUPATION_DESC_TXT
-     ,RN = ROW_NUMBER() OVER (
-				PARTITION BY PER.PERSON_UID ORDER BY PER.PERSON_UID
-				)
-			, CASE WHEN (CONDITION_CODE.investigation_form_cd NOT LIKE 'PG_%' or CONDITION_CODE.investigation_form_cd  is null) then 1 else 0 end as FLAG1 ---added this as part of optimization (very imp)
-INTO #TEMP_PHCPATIENTINFO
-FROM #TEMP_UPDATE_NEW_PATIENT PER WITH (NOLOCK)
-		INNER JOIN NBS_ODSE.DBO.PARTICIPATION PAR WITH (NOLOCK) ON PER.PERSON_UID = PAR.SUBJECT_ENTITY_UID
-    INNER JOIN NBS_ODSE.DBO.Public_health_case Public_health_case WITH (NOLOCK) ON PAR.act_uid = Public_health_case.public_health_case_uid
-    INNER JOIN NBS_srte.DBO.Condition_code Condition_code WITH (NOLOCK) ON Condition_code.condition_cd = Public_health_case.cd
-    LEFT OUTER JOIN NBS_ODSE.DBO.ENTITY_LOCATOR_PARTICIPATION ELP WITH (NOLOCK) ON ELP.ENTITY_UID = PER.PERSON_UID
-    AND ELP.USE_CD = 'H'
-    AND ELP.CLASS_CD = 'PST'
-    AND ELP.RECORD_STATUS_CD = 'ACTIVE'
-    LEFT OUTER JOIN NBS_ODSE.DBO.POSTAL_LOCATOR PST WITH (NOLOCK) ON ELP.LOCATOR_UID = PST.POSTAL_LOCATOR_UID
-    AND PST.RECORD_STATUS_CD = 'ACTIVE'
-    LEFT OUTER JOIN NBS_SRTE.DBO.Code_value_general CNTRY_DESC ON CNTRY_DESC.code=PST.cntry_cd
-    AND CNTRY_DESC.CODE=PST.CNTRY_CD
-    AND CNTRY_DESC.CODE_SET_NM='PSL_CNTRY'
-    LEFT OUTER JOIN NBS_SRTE.DBO.V_state_code SRT1 WITH (NOLOCK) ON PST.STATE_CD = SRT1.CODE
-    LEFT OUTER JOIN NBS_SRTE.DBO.state_county_code_value SRT3 WITH (NOLOCK) ON PST.CNTY_CD = SRT3.CODE
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA A ON A.CODE=PER.ETHNIC_GROUP_IND
-    AND  A.investigation_form_cd = Condition_code.investigation_form_cd
-    AND A.DATA_LOCATION LIKE '%.ETHNIC_GROUP_IND'
-    LEFT OUTER JOIN NBS_ODSE.DBO.PERSON_NAME PNM WITH (NOLOCK) ON PER.PERSON_UID = PNM.PERSON_UID
-    AND PNM.NM_USE_CD = 'L'
-    AND PNM.RECORD_STATUS_CD = 'ACTIVE'
-
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA AGE_UNIT WITH (NOLOCK) ON PER.age_reported_unit_cd = AGE_UNIT.CODE
-    AND  AGE_UNIT.investigation_form_cd = Condition_code.investigation_form_cd
-    AND AGE_UNIT.DATA_LOCATION LIKE 'Person.age_reported_unit_cd'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA BIRTH_GENDER WITH (NOLOCK) ON PER.birth_gender_cd = BIRTH_GENDER.CODE
-    AND  BIRTH_GENDER.investigation_form_cd = Condition_code.investigation_form_cd
-    AND BIRTH_GENDER.DATA_LOCATION LIKE 'Person.birth_gender_cd'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA CURR_SEX WITH (NOLOCK) ON PER.curr_sex_cd = CURR_SEX.CODE
-    AND  CURR_SEX.investigation_form_cd = Condition_code.investigation_form_cd
-    AND CURR_SEX.DATA_LOCATION LIKE 'Person.curr_sex_cd'
-    LEFT OUTER JOIN NBS_SRTE.DBO.NAICS_INDUSTRY_CODE OCCUPATION WITH (NOLOCK) ON PER.occupation_cd = OCCUPATION.CODE
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL CVG WITH (NOLOCK) ON PER.education_level_cd = CVG.CODE
-    AND CVG.CODE_SET_NM = 'P_EDUC_LVL'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA CVG2 WITH (NOLOCK) ON PER.MARITAL_STATUS_CD = CVG2.CODE
-    AND  CVG2.investigation_form_cd = Condition_code.investigation_form_cd
-    AND CVG2.DATA_LOCATION = 'PERSON.MARITAL_STATUS_CD'
-    LEFT OUTER JOIN NBS_SRTE.DBO.LANGUAGE_CODE LNG WITH (NOLOCK) ON PER.PRIM_LANG_CD = LNG.CODE
-where Public_health_case.public_health_case_uid in (select value from string_split(@phc_id_list, ','))
-ORDER BY PAR.ACT_UID
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-DELETE
-FROM #TEMP_PHCPATIENTINFO
-WHERE RN > 1
-
-
-    PRINT '1. starttime' + LEFT(CONVERT(VARCHAR, @batch_start_time, 120), 10)
-		PRINT '1. endtime' + LEFT(CONVERT(VARCHAR, @batch_end_time, 120), 10)
-
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-UPDATE #TEMP_PHCPATIENTINFO
-SET ETHNIC_GROUP_IND_DESC = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCPATIENTINFO
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON #TEMP_PHCPATIENTINFO.ETHNIC_GROUP_IND = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'P_ETHN_GRP'
-    AND #TEMP_PHCPATIENTINFO.FLAG1 =1; ---added this optimization
-
-
-UPDATE #TEMP_PHCPATIENTINFO
-SET MARITAL_STATUS_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCPATIENTINFO
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON #TEMP_PHCPATIENTINFO.MARITAL_STATUS_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'P_MARITAL'
-    AND #TEMP_PHCPATIENTINFO.FLAG1 =1; ---added this optimization
-
-
-UPDATE #TEMP_PHCPATIENTINFO
-SET BIRTH_GENDER_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCPATIENTINFO
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON #TEMP_PHCPATIENTINFO.birth_gender_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'SEX'
-    AND BIRTH_GENDER_DESC_TXT IS NULL
-    AND birth_gender_cd IS NOT NULL
-
-
-UPDATE #TEMP_PHCPATIENTINFO
-SET AGE_REPORTED_UNIT_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCPATIENTINFO
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON #TEMP_PHCPATIENTINFO.age_reported_unit_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'AGE_UNIT'
-    AND #TEMP_PHCPATIENTINFO.FLAG1 =1; ---added this optimization
-
-
-UPDATE #TEMP_PHCPATIENTINFO
-SET CURR_SEX_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCPATIENTINFO
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON #TEMP_PHCPATIENTINFO.curr_sex_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'SEX'
-    AND #TEMP_PHCPATIENTINFO.FLAG1 =1; ---added this optimization
-
-
-COMMIT TRANSACTION;
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO_INIT';
-		IF OBJECT_ID('#TEMP_PHCINFO_INIT') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO_INIT;
-
-SELECT OBSERVATION2.CD, t.PUBLIC_HEALTH_CASE_UID,OBS_VALUE_DATE.FROM_TIME
-INTO #TEMP_PHCINFO_INIT
-FROM #TEMP_PHCPATIENTINFO t WITH (NOLOCK)
-			INNER JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP WITH (NOLOCK) ON ACT_RELATIONSHIP.TARGET_ACT_UID=t.PUBLIC_HEALTH_CASE_UID
-    INNER JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP ACT_RELATIONSHIP2 WITH (NOLOCK) ON ACT_RELATIONSHIP2.TARGET_ACT_UID=ACT_RELATIONSHIP.SOURCE_ACT_UID
-    LEFT JOIN NBS_ODSE.DBO.OBSERVATION OBSERVATION2 WITH (NOLOCK) ON OBSERVATION2.OBSERVATION_UID =ACT_RELATIONSHIP2.SOURCE_ACT_UID
-    LEFT JOIN NBS_ODSE.DBO.OBS_VALUE_DATE  WITH (NOLOCK) ON OBSERVATION2.OBSERVATION_UID =OBS_VALUE_DATE.OBSERVATION_UID
-WHERE OBSERVATION2.CD IN ('INV132', 'INV133') AND ACT_RELATIONSHIP.TYPE_CD ='PHCInvForm';
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO_LEGACY_HOSP';
-		IF OBJECT_ID('#TEMP_PHCINFO_LEGACY_HOSP') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO_LEGACY_HOSP;
-
-SELECT OBSERVATION2.CD, t.PUBLIC_HEALTH_CASE_UID,OBS_VALUE_CODED.CODE
-INTO #TEMP_PHCINFO_LEGACY_HOSP
-FROM #TEMP_PHCPATIENTINFO t WITH (NOLOCK)
-			INNER JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP WITH (NOLOCK) ON ACT_RELATIONSHIP.TARGET_ACT_UID=t.PUBLIC_HEALTH_CASE_UID
-    INNER JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP ACT_RELATIONSHIP2 WITH (NOLOCK) ON ACT_RELATIONSHIP2.TARGET_ACT_UID=ACT_RELATIONSHIP.SOURCE_ACT_UID
-    INNER JOIN NBS_ODSE.DBO.OBSERVATION AS OBSERVATION2  WITH (NOLOCK) ON ACT_RELATIONSHIP2.SOURCE_ACT_UID =OBSERVATION2.OBSERVATION_UID
-    INNER JOIN NBS_ODSE.DBO.OBS_VALUE_CODED  WITH (NOLOCK) ON ACT_RELATIONSHIP2.SOURCE_ACT_UID =OBS_VALUE_CODED.OBSERVATION_UID
-WHERE OBSERVATION2.CD IN ('INV128') AND ACT_RELATIONSHIP.TYPE_CD ='PHCInvForm';
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO1';
-
-		IF OBJECT_ID('#TEMP_PHCINFO1') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO1;
-
-SELECT PHC.PUBLIC_HEALTH_CASE_UID
-     ,PHC.CASE_TYPE_CD
-     ,PHC.DIAGNOSIS_TIME AS DIAGNOSIS_DATE
-     ,PHC.CD AS PHC_CODE
-     ,PHC.CD_DESC_TXT AS PHC_CODE_DESC
-     ,ISNULL(PHC.CASE_CLASS_CD, '') CASE_CLASS_CD
-     ,PHC.CD_SYSTEM_CD
-     ,PHC.CD_SYSTEM_DESC_TXT
-     ,PHC.CONFIDENTIALITY_CD
-     ,PHC.CONFIDENTIALITY_DESC_TXT
-     ,case when ltrim(rtrim(PHC.DETECTION_METHOD_CD)) = '' then null else ltrim(rtrim(PHC.DETECTION_METHOD_CD)) end detection_method_cd
-     ,
-    /*PHC.DETECTION_METHOD_DESC_TXT,*/
-    case when ltrim(rtrim(PHC.DISEASE_IMPORTED_CD)) = '' then null else ltrim(rtrim(PHC.DISEASE_IMPORTED_CD)) end DISEASE_IMPORTED_CD
-     ,
-    /*PHC.DISEASE_IMPORTED_DESC_TXT,*/
-    PHC.GROUP_CASE_CNT
-     ,PHC.INVESTIGATION_STATUS_CD
-     ,PHC.JURISDICTION_CD
-     ,JURISDICTION_CODE.CODE_DESC_TXT AS JURISDICTION
-     ,case when SUBSTRING(ltrim(rtrim(PHC.MMWR_WEEK)), 1, 4) = '' then null else SUBSTRING(ltrim(rtrim(PHC.MMWR_WEEK)), 1, 4) end MMWR_WEEK
-     ,case when SUBSTRING(ltrim(rtrim(PHC.MMWR_YEAR)), 1, 4) = '' then null else SUBSTRING(ltrim(rtrim(PHC.MMWR_YEAR)), 1, 4) end MMWR_YEAR
-     ,case when ltrim(rtrim(PHC.OUTBREAK_IND)) = '' then null else ltrim(rtrim(PHC.OUTBREAK_IND)) end OUTBREAK_IND
-     ,case when ltrim(rtrim(PHC.OUTBREAK_FROM_TIME)) = '' then null else ltrim(rtrim(PHC.OUTBREAK_FROM_TIME)) end OUTBREAK_FROM_TIME
-     ,case when ltrim(rtrim(PHC.OUTBREAK_TO_TIME)) = '' then null else ltrim(rtrim(PHC.OUTBREAK_TO_TIME)) end OUTBREAK_TO_TIME
-     ,case when ltrim(rtrim(PHC.OUTBREAK_NAME)) = '' then null else ltrim(rtrim(PHC.OUTBREAK_NAME)) end OUTBREAK_NAME
-     ,case when ltrim(rtrim(PHC.OUTCOME_CD)) = '' then null else ltrim(rtrim(PHC.OUTCOME_CD)) end OUTCOME_CD
-     ,case when SUBSTRING(ltrim(rtrim(PHC.PAT_AGE_AT_ONSET)), 1, 4) = '' then null else SUBSTRING(ltrim(rtrim(PHC.PAT_AGE_AT_ONSET)), 1, 4) end PAT_AGE_AT_ONSET
-     ,case when ltrim(rtrim(PHC.PAT_AGE_AT_ONSET_UNIT_CD)) = '' then null else ltrim(rtrim(PHC.PAT_AGE_AT_ONSET_UNIT_CD)) end PAT_AGE_AT_ONSET_UNIT_CD
-     ,PHC.PROG_AREA_CD
-     ,PHC.RECORD_STATUS_CD
-     ,PHC.RPT_CNTY_CD
-     ,PHC.RPT_FORM_CMPLT_TIME
-     ,case when ltrim(rtrim(PHC.RPT_SOURCE_CD)) = '' then null else ltrim(rtrim(PHC.RPT_SOURCE_CD)) end RPT_SOURCE_CD
-     ,
-    /*PHC.RPT_SOURCE_CD_DESC_TXT*/
-    PHC.RPT_TO_COUNTY_TIME
-     ,PHC.RPT_TO_STATE_TIME
-     ,PHC.STATUS_CD
-     ,PHC.EFFECTIVE_FROM_TIME AS ONSETDATE
-     ,PHC.ACTIVITY_FROM_TIME AS INVESTIGATIONSTARTDATE
-     ,PHC.ADD_TIME AS PHC_ADD_TIME
-     ,PHC.PROGRAM_JURISDICTION_OID
-     ,PHC.SHARED_IND
-     ,PHC.IMPORTED_COUNTRY_CD AS IMPORTED_COUNTRY_CODE
-     ,PHC.IMPORTED_STATE_CD AS IMPORTED_STATE_CODE
-     ,PHC.IMPORTED_COUNTY_CD AS IMPORTED_COUNTY_CODE
-     ,PHC.INVESTIGATOR_ASSIGNED_TIME AS INVESTIGATOR_ASSIGN_DATE
-     ,PHC.HOSPITALIZED_ADMIN_TIME AS HSPTL_ADMISSION_DT
-     ,PHC.HOSPITALIZED_DISCHARGE_TIME AS HSPTL_DISCHARGE_DT
-     ,PHC.HOSPITALIZED_DURATION_AMT
-     ,PHC.IMPORTED_CITY_DESC_TXT
-     ,PHC.DECEASED_TIME AS INVESTIGATION_DEATH_DATE
-     ,PHC.LOCAL_ID AS LOCAL_ID
-     ,PHC.LAST_CHG_TIME AS LASTUPDATE
-     ,case when ltrim(rtrim(PHC.TXT)) = '' then null else ltrim(rtrim(PHC.TXT)) end PHCTXT
-     ,FOOD_HANDLER_IND_CD
-     ,case when ltrim(rtrim(hospitalized_ind_cd)) = '' then null else ltrim(rtrim(hospitalized_ind_cd)) end HOSPITALIZED_IND
-     ,DAY_CARE_IND_CD
-     ,PREGNANT_IND_CD
-     ,CONDITION_CODE.INVESTIGATION_FORM_CD
-     ,TEMP_PHCINFO_INITA.FROM_TIME AS LEGACY_HSPTL_ADMISSION_DT
-     ,TEMP_PHCINFO_INITb.FROM_TIME AS LEGACY_HSPTL_DISCHARGE_DT
-     ,NOTIF_LAST_CHG_TIME
-     ,t.CODE AS LEGACY_HOSP_IND
-INTO #TEMP_PHCINFO1
-FROM NBS_ODSE.DBO.PUBLIC_HEALTH_CASE PHC WITH (NOLOCK)
-		INNER JOIN #TEMP_PHCPATIENTINFO t1 ON PHC.PUBLIC_HEALTH_CASE_UID = t1.ACT_UID
-    LEFT OUTER JOIN NBS_SRTE.DBO.JURISDICTION_CODE WITH (NOLOCK) ON JURISDICTION_CODE.CODE = PHC.jurisdiction_cd
-    INNER JOIN NBS_SRTE.DBO.Condition_code ON PHC.CD=Condition_code.condition_cd
-    LEFT OUTER JOIN #TEMP_PHCINFO_INIT TEMP_PHCINFO_INITA ON  PHC.PUBLIC_HEALTH_CASE_UID = TEMP_PHCINFO_INITA.PUBLIC_HEALTH_CASE_UID
-    AND TEMP_PHCINFO_INITA.CD='INV132'
-    LEFT OUTER JOIN #TEMP_PHCINFO_INIT TEMP_PHCINFO_INITB ON  PHC.PUBLIC_HEALTH_CASE_UID = TEMP_PHCINFO_INITB.PUBLIC_HEALTH_CASE_UID
-    AND TEMP_PHCINFO_INITB.CD='INV133'
-    LEFT OUTER JOIN #TEMP_PHCINFO_LEGACY_HOSP t  ON  PHC.PUBLIC_HEALTH_CASE_UID = t.PUBLIC_HEALTH_CASE_UID
-    AND t.CD='INV128'
-where PHC.public_health_case_uid in (select value from string_split(@phc_id_list, ','))
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-PRINT @ROWCOUNT_NO;
-
-UPDATE #TEMP_PHCINFO1
-SET HSPTL_ADMISSION_DT = LEGACY_HSPTL_ADMISSION_DT
-WHERE LEGACY_HSPTL_ADMISSION_DT IS NOT NULL;
-
-UPDATE #TEMP_PHCINFO1
-SET HOSPITALIZED_IND = LEGACY_HOSP_IND
-WHERE LEGACY_HOSP_IND IS NOT NULL;
-
-UPDATE #TEMP_PHCINFO1
-SET HSPTL_DISCHARGE_DT = LEGACY_HSPTL_DISCHARGE_DT
-WHERE LEGACY_HSPTL_DISCHARGE_DT IS NOT NULL;
-
-
-ALTER TABLE #TEMP_PHCINFO1 DROP column LEGACY_HSPTL_DISCHARGE_DT, LEGACY_HSPTL_ADMISSION_DT;
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Remove Updated records';
-
-DELETE
-FROM NBS_ODSE.DBO.SubjectRaceInfo
-WHERE public_health_case_uid IN (
-    SELECT public_health_case_uid
-    FROM #TEMP_PHCINFO1
-);
-
-DELETE
-FROM NBS_ODSE.DBO.PublicHealthCaseFact
-WHERE public_health_case_uid IN (
-    SELECT public_health_case_uid
-    FROM #TEMP_PHCINFO1
-);
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO2';
-
-		IF OBJECT_ID('#TEMP_PHCINFO2') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO2;
-
-SELECT A.*
-     ,NBS_CASE_ANSWER.ANSWER_TXT AS THERAPY_DATE
-INTO #TEMP_PHCINFO2
-FROM #TEMP_PHCINFO1 A WITH (NOLOCK)
-		LEFT OUTER JOIN NBS_ODSE.DBO.NBS_CASE_ANSWER WITH (NOLOCK) ON A.PUBLIC_HEALTH_CASE_UID = NBS_CASE_ANSWER.ACT_UID
-    AND NBS_CASE_ANSWER.NBS_QUESTION_UID IN (
-    SELECT NBS_QUESTION_UID
-    FROM NBS_ODSE.DBO.NBS_QUESTION WITH (NOLOCK)
-    WHERE QUESTION_IDENTIFIER = 'TUB170'
-    );
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO3';
-
-		IF OBJECT_ID('#TEMP_PHCINFO3') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO3;
-
-SELECT A.*
-     ,case when ltrim(rtrim(AID.ROOT_EXTENSION_TXT)) = '' then null else ltrim(rtrim(AID.ROOT_EXTENSION_TXT)) end  AS STATE_CASE_ID
-INTO #TEMP_PHCINFO3
-FROM #TEMP_PHCINFO2 A WITH (NOLOCK)
-		LEFT OUTER JOIN NBS_ODSE.DBO.ACT_ID AID WITH (NOLOCK) ON A.PUBLIC_HEALTH_CASE_UID = AID.ACT_UID
-    AND ACT_ID_SEQ = 1
-WHERE A.RECORD_STATUS_CD <> 'LOG_DEL'
-ORDER BY A.PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Update TEMP_PHCINFO3';
-
-		/*UPDATE #TEMP_PHCINFO3
-		SET STATE_CASE_ID = NULL
-		WHERE STATE_CASE_ID = LTRIM(RTRIM(''));*/
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCINFO';
-
-		IF OBJECT_ID('#TEMP_PHCINFO') IS NOT NULL
-DROP TABLE #TEMP_PHCINFO;
-
-SELECT PUBLIC_HEALTH_CASE_UID
-     ,CASE_TYPE_CD
-     ,DIAGNOSIS_DATE
-     ,PHC_CODE
-     ,case when PHC_CODE_DESC = null then A.condition_short_nm  else PHC_CODE_DESC end as PHC_CODE_DESC
-     ,CASE_CLASS_CD
-     ,CD_SYSTEM_CD
-     ,THERAPY_DATE
-     ,STATE_CASE_ID
-     ,CD_SYSTEM_DESC_TXT
-     ,CONFIDENTIALITY_CD
-     ,CONFIDENTIALITY_DESC_TXT
-     ,DETECTION_METHOD_CD
-     ,DISEASE_IMPORTED_CD
-     ,GROUP_CASE_CNT
-     ,INVESTIGATION_STATUS_CD
-     ,JURISDICTION
-     ,JURISDICTION_CD
-     ,MMWR_WEEK
-     ,MMWR_YEAR
-     ,OUTBREAK_IND
-     ,OUTBREAK_FROM_TIME
-     ,OUTBREAK_TO_TIME
-     ,OUTBREAK_NAME
-     ,OUTCOME_CD
-     ,PAT_AGE_AT_ONSET
-     ,PAT_AGE_AT_ONSET_UNIT_CD
-     ,t3.PROG_AREA_CD
-     ,RECORD_STATUS_CD
-     ,RPT_CNTY_CD
-     ,RPT_FORM_CMPLT_TIME
-     ,RPT_SOURCE_CD
-     ,RPT_TO_COUNTY_TIME
-     ,RPT_TO_STATE_TIME
-     ,t3.STATUS_CD
-     ,ONSETDATE
-     ,INVESTIGATIONSTARTDATE
-     ,PHC_ADD_TIME
-     ,PROGRAM_JURISDICTION_OID
-     ,SHARED_IND
-     ,IMPORTED_COUNTRY_CODE
-     ,IMPORTED_STATE_CODE
-     ,IMPORTED_COUNTY_CODE
-     ,INVESTIGATOR_ASSIGN_DATE
-     ,HSPTL_ADMISSION_DT
-     ,HSPTL_DISCHARGE_DT
-     ,HOSPITALIZED_DURATION_AMT
-     ,IMPORTED_CITY_DESC_TXT
-     ,INVESTIGATION_DEATH_DATE
-     ,LOCAL_ID
-     ,HOSPITALIZED_IND
-     ,DAY_CARE_IND_CD AS CASE_DAY_CARE_IND_CD
-     ,PREGNANT_IND_CD
-     ,LASTUPDATE
-     ,case when ltrim(rtrim(PHCTXT))='' then null else ltrim(rtrim(PHCTXT)) end as PHCTXT
-     ,A.CONDITION_CD
-     ,A.investigation_form_cd
-     ,A.condition_short_nm AS PHC_CODE_SHORT_DESC
-     ,B.CODE_SHORT_DESC_TXT AS DISEASE_IMPORTED_DESC_TXT
-     ,C.CODE_SHORT_DESC_TXT AS DETECTION_METHOD_DESC_TXT
-     ,D.CODE_SHORT_DESC_TXT AS RPT_SOURCE_DESC_TXT
-     ,E.CODE_SHORT_DESC_TXT AS HOSPITALIZED
-     ,F.CODE_SHORT_DESC_TXT AS PREGNANT
-     ,G.CODE_SHORT_DESC_TXT AS DAY_CARE_IND_CD
-     ,H.CODE_SHORT_DESC_TXT AS FOOD_HANDLER_IND_CD
-     ,I.CODE_SHORT_DESC_TXT AS IMPORTED_COUNTRY_CD
-     ,J.CODE_SHORT_DESC_TXT AS IMPORTED_COUNTY_CD
-     ,K.CODE_SHORT_DESC_TXT AS IMPORTED_STATE_CD
-     ,L.CODE_SHORT_DESC_TXT AS CASE_CLASS_DESC_TXT
-     ,M.CODE_SHORT_DESC_TXT AS investigation_status_desc_txt
-     ,N.CODE_SHORT_DESC_TXT AS outcome_desc_txt
-     ,O.CODE_SHORT_DESC_TXT AS pat_age_at_onset_unit_desc_txt
-     ,P.prog_area_desc_txt AS prog_area_desc_txt
-     ,Q.CODE_SHORT_DESC_TXT AS rpt_cnty_desc_txt
-     ,R.CODE_SHORT_DESC_TXT AS outbreak_name_desc
-     ,NOTIF_LAST_CHG_TIME
-     , CASE WHEN (A.investigation_form_cd NOT LIKE 'PG_%' or A.investigation_form_cd is null) then 1 else 0 end as FLAG2  /* Optimization (very imp) */
-INTO #TEMP_PHCINFO
-FROM #TEMP_PHCINFO3 t3
-         LEFT OUTER JOIN NBS_SRTE.DBO.CONDITION_CODE A WITH (NOLOCK) ON A.CONDITION_CD = t3.PHC_CODE
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA B WITH (NOLOCK) ON t3.DISEASE_IMPORTED_CD = B.CODE
-    AND t3.investigation_form_cd = B.investigation_form_cd
-    AND B.DATA_LOCATION LIKE '%.DISEASE_IMPORTED_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA C WITH (NOLOCK) ON t3.DETECTION_METHOD_CD = C.CODE
-    AND t3.investigation_form_cd = C.investigation_form_cd
-    AND C.DATA_LOCATION LIKE '%.DETECTION_METHOD_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA D WITH (NOLOCK) ON t3.RPT_SOURCE_CD = D.CODE
-    AND t3.investigation_form_cd = D.investigation_form_cd
-    AND D.DATA_LOCATION LIKE '%.RPT_SOURCE_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA E WITH (NOLOCK) ON t3.HOSPITALIZED_IND = E.CODE
-    AND t3.investigation_form_cd = E.investigation_form_cd
-    AND E.DATA_LOCATION LIKE '%.HOSPITALIZED_IND_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA F WITH (NOLOCK) ON t3.PREGNANT_IND_CD = F.CODE
-    AND t3.investigation_form_cd = F.investigation_form_cd
-    AND F.DATA_LOCATION LIKE '%.PREGNANT_IND_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA G WITH (NOLOCK) ON t3.DAY_CARE_IND_CD = G.CODE
-    AND t3.investigation_form_cd = G.investigation_form_cd
-    AND G.DATA_LOCATION LIKE '%.DAY_CARE_IND_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA H WITH (NOLOCK) ON t3.FOOD_HANDLER_IND_CD = H.CODE
-    AND t3.investigation_form_cd = H.investigation_form_cd
-    AND H.DATA_LOCATION LIKE '%.FOOD_HANDLER_IND_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA I WITH (NOLOCK) ON t3.IMPORTED_COUNTRY_CODE = I.CODE
-    AND t3.investigation_form_cd = I.investigation_form_cd
-    AND I.DATA_LOCATION LIKE '%.IMPORTED_COUNTRY_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA J WITH (NOLOCK) ON t3.IMPORTED_COUNTY_CODE = J.CODE
-    AND t3.investigation_form_cd = J.investigation_form_cd
-    AND J.DATA_LOCATION LIKE '%.IMPORTED_COUNTY_CD'
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA K WITH (NOLOCK) ON t3.IMPORTED_STATE_CODE = K.CODE
-    AND t3.INVESTIGATION_FORM_CD = K.INVESTIGATION_FORM_CD
-    AND K.DATA_LOCATION LIKE '%.IMPORTED_STATE_CD'
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL L WITH (NOLOCK) ON t3.CASE_CLASS_CD = L.CODE
-    AND L.CODE_SET_NM = 'PHC_CLASS'
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL M WITH (NOLOCK) ON t3.INVESTIGATION_STATUS_CD = M.CODE
-    AND M.CODE_SET_NM = 'PHC_IN_STS'
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL N WITH (NOLOCK) ON t3.OUTCOME_CD = N.CODE
-    AND N.CODE_SET_NM = 'YNU'
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL O WITH (NOLOCK) ON t3.PAT_AGE_AT_ONSET_UNIT_CD = O.CODE
-    AND O.CODE_SET_NM = 'AGE_UNIT'
-    LEFT OUTER JOIN NBS_SRTE.DBO.PROGRAM_AREA_CODE P WITH (NOLOCK) ON t3.PROG_AREA_CD = P.PROG_AREA_CD
-    AND P.CODE_SET_NM = 'S_PROGRA_C'
-    LEFT OUTER JOIN NBS_SRTE.DBO.V_STATE_COUNTY_CODE_VALUE Q WITH (NOLOCK) ON t3.RPT_CNTY_CD = Q.CODE
-    AND Q.CODE_SET_NM = 'COUNTY_CCD'
-    LEFT OUTER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL R WITH (NOLOCK) ON t3.OUTBREAK_NAME = R.CODE
-    AND R.CODE_SET_NM = 'OUTBREAK_NM'
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-
-UPDATE t
-SET DISEASE_IMPORTED_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.DISEASE_IMPORTED_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'PHC_IMPRT'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET DETECTION_METHOD_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.detection_method_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'PHC_DET_MT'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET RPT_SOURCE_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.rpt_source_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'PHC_RPT_SRC_T'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET HOSPITALIZED = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.HOSPITALIZED_IND = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'YNU'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET PREGNANT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.pregnant_ind_cd = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'YNU'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET DAY_CARE_IND_CD = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.CASE_DAY_CARE_IND_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'YNU'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET FOOD_HANDLER_IND_CD = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.FOOD_HANDLER_IND_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'YNU'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET DISEASE_IMPORTED_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.DISEASE_IMPORTED_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'PHC_IMPRT'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET IMPORTED_COUNTRY_CD = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.IMPORTED_COUNTRY_CODE = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'PSL_CNTRY'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET IMPORTED_STATE_CD = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.IMPORTED_STATE_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'STATE_CCD'
-    AND FLAG2=1; /* Optimization */
-
-UPDATE t
-SET IMPORTED_STATE_CD = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_PHCINFO t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.IMPORTED_STATE_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM = 'YNU'
-    AND FLAG2=1; /* Optimization */
-
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Cleanup process';
-
-
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,0
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCSUBJECT';
-
-		IF OBJECT_ID('#TEMP_PHCSUBJECT') IS NOT NULL
-DROP TABLE #TEMP_PHCSUBJECT;
-
-SELECT --PUBLIC_HEALTH_CASE_UID,
-    CASE_TYPE_CD
-     ,DIAGNOSIS_DATE
-     ,PHC_CODE
-     ,PHC_CODE_DESC
-     ,CASE_CLASS_CD
-     ,CD_SYSTEM_CD
-     ,THERAPY_DATE
-     ,STATE_CASE_ID
-     ,CD_SYSTEM_DESC_TXT
-     ,CONFIDENTIALITY_CD
-     ,CONFIDENTIALITY_DESC_TXT
-     ,DETECTION_METHOD_CD
-     ,HSPTL_ADMISSION_DT
-     ,HSPTL_DISCHARGE_DT
-     ,DISEASE_IMPORTED_CD
-     ,GROUP_CASE_CNT
-     ,INVESTIGATION_STATUS_CD
-     ,JURISDICTION
-     ,JURISDICTION_CD
-     ,MMWR_WEEK
-     ,MMWR_YEAR
-     ,OUTBREAK_IND
-     ,OUTBREAK_FROM_TIME
-     ,OUTBREAK_TO_TIME
-     ,OUTBREAK_NAME
-     ,OUTCOME_CD
-     ,PAT_AGE_AT_ONSET
-     ,PAT_AGE_AT_ONSET_UNIT_CD
-     ,PROG_AREA_CD
-     ,RECORD_STATUS_CD
-     ,RPT_CNTY_CD
-     ,RPT_FORM_CMPLT_TIME
-     ,RPT_SOURCE_CD
-     ,RPT_TO_COUNTY_TIME
-     ,RPT_TO_STATE_TIME
-     ,STATUS_CD
-     ,ONSETDATE
-     ,INVESTIGATIONSTARTDATE
-     ,PHC_ADD_TIME
-     ,PROGRAM_JURISDICTION_OID
-     ,SHARED_IND
-     ,IMPORTED_COUNTRY_CODE
-     ,IMPORTED_STATE_CODE
-     ,IMPORTED_COUNTY_CODE
-     ,INVESTIGATOR_ASSIGN_DATE
-     ,HOSPITALIZED_DURATION_AMT
-     ,IMPORTED_CITY_DESC_TXT
-     ,INVESTIGATION_DEATH_DATE
-     ,LOCAL_ID
-     ,HOSPITALIZED_IND
-     ,PREGNANT_IND_CD
-     ,PHC_CODE_SHORT_DESC
-     ,DISEASE_IMPORTED_DESC_TXT
-     ,DETECTION_METHOD_DESC_TXT
-     ,RPT_SOURCE_DESC_TXT
-     ,HOSPITALIZED
-     ,PREGNANT
-     ,RPT_CNTY_DESC_TXT
-     ,DAY_CARE_IND_CD
-     ,FOOD_HANDLER_IND_CD
-     ,IMPORTED_COUNTRY_CD
-     ,IMPORTED_COUNTY_CD
-     ,IMPORTED_STATE_CD
-     ,CASE_CLASS_DESC_TXT
-     ,INVESTIGATION_STATUS_DESC_TXT
-     ,OUTCOME_DESC_TXT
-     ,PAT_AGE_AT_ONSET_UNIT_DESC_TXT
-     ,OUTBREAK_NAME_DESC
-     ,LASTUPDATE
-     ,PHCTXT
-     ,PROG_AREA_DESC_TXT
-     ,t.*
-INTO #TEMP_PHCSUBJECT
-FROM #TEMP_PHCINFO t1 WITH (NOLOCK)
-		INNER JOIN #TEMP_PHCPATIENTINFO t WITH (NOLOCK) ON t1.PUBLIC_HEALTH_CASE_UID = t.PUBLIC_HEALTH_CASE_UID
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
------------------------------------------SMMARY
-----TODO NEEDS TO CHECK MERGE LOGIC
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_SUMMARYUID';
-
-		IF OBJECT_ID('#TEMP_SUMMARYUID') IS NOT NULL
-DROP TABLE #TEMP_SUMMARYUID;
-
-SELECT PHC.PUBLIC_HEALTH_CASE_UID
-     ,SRT1.PARENT_IS_CD AS STATE_CD
-     ,SRT2.CODE_DESC_TXT AS STATE
-     ,PHC.RPT_CNTY_CD AS CNTY_CD
-     ,SRT1.CODE_DESC_TXT AS COUNTY
-INTO #TEMP_SUMMARYUID
-FROM NBS_ODSE.DBO.PUBLIC_HEALTH_CASE PHC WITH (NOLOCK)
-		LEFT OUTER JOIN NBS_SRTE.DBO.STATE_COUNTY_CODE_VALUE SRT1 WITH (NOLOCK) ON PHC.RPT_CNTY_CD = SRT1.CODE
-    LEFT OUTER JOIN NBS_SRTE.DBO.STATE_CODE SRT2 WITH (NOLOCK) ON SRT1.PARENT_IS_CD = SRT2.STATE_CD
-    LEFT JOIN NBS_ODSE.DBO.ACT_RELATIONSHIP ARN WITH (NOLOCK) ON ARN.TARGET_ACT_UID=PHC.PUBLIC_HEALTH_CASE_UID
-    LEFT JOIN NBS_ODSE.DBO.NOTIFICATION WITH (NOLOCK) ON NOTIFICATION.NOTIFICATION_UID=ARN.SOURCE_ACT_UID
-    AND NOTIFICATION.CD='NOTF'
-WHERE CASE_TYPE_CD IS NOT NULL
-  AND CASE_TYPE_CD = 'S'
-  and  PHC.public_health_case_uid in (select value from string_split(@phc_id_list, ','))
-
-
-ORDER BY PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_CASECNT';
-
-		IF OBJECT_ID('#TEMP_CASECNT') IS NOT NULL
-DROP TABLE #TEMP_CASECNT;
-
-SELECT AR2.TARGET_ACT_UID AS PUBLIC_HEALTH_CASE_UID
-     ,AR2.SOURCE_ACT_UID AS SUM_REPORT_FORM_UID
-     ,AR1.TARGET_ACT_UID AS AR1_SUM_REPORT_FORM_UID
-     ,
-    /*--SUMMARY_REPORT_FORM OBS_UID*/
-    AR1.SOURCE_ACT_UID AS AR1_SUM107_UID
-     ,
-    /*--SUM107 OBS_UID*/
-    OB1.OBSERVATION_UID AS OB1_SUM107_UID
-     ,OB1.CD AS OB1_CD
-     ,OB2.OBSERVATION_UID AS OB2_SUM_REPORT_FORM_UID
-     ,OB2.CD AS OB2_CD
-     ,OVN.NUMERIC_VALUE_1 AS GROUP_CASE_CNT
-     ,AR1.TYPE_CD AS AR1_TYPE_CD
-     ,AR1.SOURCE_CLASS_CD AS AR1_SOURCE_CLASS_CD
-     ,AR1.TARGET_CLASS_CD AS AR1_TARGET_CLASS_CD
-     ,AR2.TYPE_CD AS AR2_TYPE_CD
-     ,AR2.SOURCE_CLASS_CD AS AR2_SOURCE_CLASS_CD
-     ,AR2.TARGET_CLASS_CD AS AR2_TARGET_CLASS_CD
-INTO #TEMP_CASECNT
-FROM NBS_ODSE.DBO.ACT_RELATIONSHIP AS AR1 WITH (NOLOCK)
-			,NBS_ODSE.DBO.OBSERVATION AS OB1 WITH (NOLOCK)
-        ,NBS_ODSE.DBO.OBSERVATION AS OB2 WITH (NOLOCK)
-        ,NBS_ODSE.DBO.OBS_VALUE_NUMERIC AS OVN WITH (NOLOCK)
-        ,NBS_ODSE.DBO.ACT_RELATIONSHIP AS AR2 WITH (NOLOCK)
-WHERE AR1.SOURCE_ACT_UID = OB1.OBSERVATION_UID
-  AND AR1.TARGET_ACT_UID = OB2.OBSERVATION_UID
-  AND AR1.TYPE_CD = 'SUMMARYFRMQ'
-  AND OB1.CD = 'SUM107'
-  AND OB2.CD = 'SUMMARY_REPORT_FORM'
-  AND OB1.OBSERVATION_UID = OVN.OBSERVATION_UID
-  AND OB2.OBSERVATION_UID = AR2.SOURCE_ACT_UID
-  AND AR2.TYPE_CD = 'SUMMARYFORM'
-  and  AR2.TARGET_ACT_UID in (select value from string_split(@phc_id_list, ','))
-
-
-
-ORDER BY PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
----TODO PENDING CODE LOGIC
------------------------NOTIFICATION
-BEGIN TRANSACTION;
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_SAS_LATEST_NOT';
-
-		IF OBJECT_ID('#TEMP_SAS_LATEST_NOT') IS NOT NULL
-DROP TABLE #TEMP_SAS_LATEST_NOT;
-
-SELECT TARGET_ACT_UID AS PUBLIC_HEALTH_CASE_UID
-     ,ar.SOURCE_ACT_UID
-     ,SOURCE_CLASS_CD
-     ,NF.RECORD_STATUS_CD AS NOTIFCURRENTSTATE
-     , NF.txt
-     ,NF.local_id AS NOTIFICATION_LOCAL_ID
-INTO #TEMP_SAS_LATEST_NOT
-FROM NBS_ODSE.DBO.ACT_RELATIONSHIP AR WITH (NOLOCK)
-			,NBS_ODSE.DBO.NOTIFICATION NF WITH (NOLOCK)
-WHERE AR.SOURCE_ACT_UID = NF.NOTIFICATION_UID
-  AND SOURCE_CLASS_CD = 'NOTF'
-  AND TARGET_CLASS_CD = 'CASE'
-  AND (
-    NF.RECORD_STATUS_CD = 'COMPLETED'
-   OR NF.RECORD_STATUS_CD = 'PEND_APPR'
-   OR NF.RECORD_STATUS_CD = 'APPROVED'
-    )
-  AND  AR.TARGET_ACT_UID IN (SELECT PUBLIC_HEALTH_CASE_UID  FROM #TEMP_PHCSUBJECT WITH (NOLOCK))
-
-
-    COMMIT TRANSACTION;
-BEGIN TRANSACTION;
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_SAS_NOTIFICATION';
-
-		IF OBJECT_ID('#TEMP_SAS_NOTIFICATION') IS NOT NULL
-DROP TABLE #TEMP_SAS_NOTIFICATION;
-
-SELECT DISTINCT TARGET_ACT_UID AS PUBLIC_HEALTH_CASE_UID
-              ,TARGET_CLASS_CD
-              ,SOURCE_ACT_UID
-              ,SOURCE_CLASS_CD
-              ,NF.VERSION_CTRL_NBR
-              ,NF.ADD_TIME
-              ,NF.ADD_USER_ID
-              ,NF.RPT_SENT_TIME
-              ,NF.RECORD_STATUS_CD
-              ,NF.RECORD_STATUS_TIME
-              ,NF.LAST_CHG_TIME
-              ,NF.LAST_CHG_USER_ID
-              ,'Y' AS HIST_IND
-              , NF.txt
-              ,CAST(NULL AS INT) AS NOTIFSENTCOUNT
-              ,CAST(NULL AS INT) AS NOTIFREJECTEDCOUNT
-              ,CAST(NULL AS INT) AS NOTIFCREATEDCOUNT
-              ,CAST(NULL AS INT) AS X1
-              ,CAST(NULL AS INT) AS X2
-              ,CAST(NULL AS DATETIME) AS FIRSTNOTIFICATIONSENDDATE
-              ,CAST(NULL AS DATETIME) AS NOTIFICATIONDATE
-INTO #TEMP_SAS_NOTIFICATION
-FROM NBS_ODSE.DBO.ACT_RELATIONSHIP AR WITH (NOLOCK)
-			 INNER JOIN NBS_ODSE.DBO.NOTIFICATION_HIST NF WITH (NOLOCK) ON AR.SOURCE_ACT_UID = NF.NOTIFICATION_UID
-WHERE
-    SOURCE_CLASS_CD = 'NOTF'
-  AND TARGET_CLASS_CD = 'CASE'
-  AND NF.CD='NOTF'
-  AND (
-    NF.RECORD_STATUS_CD = 'COMPLETED'
-   OR NF.RECORD_STATUS_CD = 'MSG_FAIL'
-   OR NF.RECORD_STATUS_CD = 'REJECTED'
-   OR NF.RECORD_STATUS_CD = 'PEND_APPR'
-   OR NF.RECORD_STATUS_CD = 'APPROVED'
-    )
-  and AR.TARGET_ACT_UID IN (SELECT PUBLIC_HEALTH_CASE_UID FROM #TEMP_PHCSUBJECT WITH (NOLOCK))
-
-
-UNION
-
-SELECT TARGET_ACT_UID
-     ,TARGET_CLASS_CD
-     ,SOURCE_ACT_UID
-     ,SOURCE_CLASS_CD
-     ,NF.VERSION_CTRL_NBR
-     ,NF.ADD_TIME
-     ,NF.ADD_USER_ID
-     ,NF.RPT_SENT_TIME
-     ,NF.RECORD_STATUS_CD
-     ,NF.RECORD_STATUS_TIME
-     ,NF.LAST_CHG_TIME
-     ,NF.LAST_CHG_USER_ID
-     ,'N' AS HIST_IND
-     , NULL AS TXT
-     ,CAST(NULL AS INT) AS NOTIFSENTCOUNT
-     ,CAST(NULL AS INT) AS NOTIFREJECTEDCOUNT
-     ,CAST(NULL AS INT) AS NOTIFCREATEDCOUNT
-     ,CAST(NULL AS INT) AS X1
-     ,CAST(NULL AS INT) AS X2
-     ,CAST(NULL AS DATETIME) AS FIRSTNOTIFICATIONSENDDATE
-     ,CAST(NULL AS DATETIME) AS NOTIFICATIONDATE
-FROM NBS_ODSE.DBO.ACT_RELATIONSHIP AR WITH (NOLOCK)
-			,NBS_ODSE.DBO.NOTIFICATION NF WITH (NOLOCK)
-WHERE AR.SOURCE_ACT_UID = NF.NOTIFICATION_UID
-  AND SOURCE_CLASS_CD = 'NOTF'
-  AND TARGET_CLASS_CD = 'CASE'
-  AND NF.CD='NOTF'
-  AND (
-    NF.RECORD_STATUS_CD = 'COMPLETED'
-   OR NF.RECORD_STATUS_CD = 'MSG_FAIL'
-   OR NF.RECORD_STATUS_CD = 'REJECTED'
-   OR NF.RECORD_STATUS_CD = 'PEND_APPR'
-   OR NF.RECORD_STATUS_CD = 'APPROVED'
-    )
-  and AR.TARGET_ACT_UID IN (SELECT PUBLIC_HEALTH_CASE_UID FROM #TEMP_PHCSUBJECT WITH (NOLOCK))
-
-ORDER BY TARGET_ACT_UID
-        ,LAST_CHG_TIME;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCFACT';
-
-		IF OBJECT_ID('#TEMP_PHCFACT') IS NOT NULL
-DROP TABLE #TEMP_PHCFACT;
-
-SELECT t.*
-     ,TARGET_CLASS_CD
-     ,tn.SOURCE_ACT_UID
-     ,tn.SOURCE_CLASS_CD
-     ,VERSION_CTRL_NBR
-     ,ADD_TIME
-     ,ADD_USER_ID
-     ,RPT_SENT_TIME
-     ,RECORD_STATUS_CD
-     ,RECORD_STATUS_TIME
-     ,LAST_CHG_TIME
-     ,LAST_CHG_USER_ID
-     ,HIST_IND
-     ,NOTIFSENTCOUNT
-     ,NOTIFCREATEDCOUNT
-     ,FIRSTNOTIFICATIONSENDDATE
-     ,NOTIFICATIONDATE
-INTO #TEMP_PHCFACT
-FROM #TEMP_CASECNT t WITH (NOLOCK)
-		LEFT JOIN #TEMP_SAS_NOTIFICATION tn WITH (NOLOCK) ON tn.PUBLIC_HEALTH_CASE_UID = t.PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_MIN_MAX_NOTIFICATION';
-
-IF OBJECT_ID('#TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL
-DROP TABLE #TEMP_MIN_MAX_NOTIFICATION;
-
-SELECT DISTINCT MIN(CASE
-    WHEN VERSION_CTRL_NBR = 1
-        THEN RECORD_STATUS_CD
-    END) AS FIRSTNOTIFICATIONSTATUS
-              ,
-
-    SUM(CASE
-        WHEN RECORD_STATUS_CD = 'REJECTED'
-            THEN 1
-        ELSE 0
-        END) NOTIFREJECTEDCOUNT
-              ,SUM(CASE
-    WHEN RECORD_STATUS_CD = 'APPROVED'
-        OR RECORD_STATUS_CD = 'PEND_APPR'
-        THEN 1
-    WHEN RECORD_STATUS_CD = 'REJECTED'
-        THEN -1
-    ELSE 0
-    END) NOTIFCREATEDCOUNT
-              ,SUM(CASE
-    WHEN RECORD_STATUS_CD = 'COMPLETED'
-        THEN 1
-    ELSE 0
-    END) NOTIFSENTCOUNT
-              ,MIN(CASE
-    WHEN RECORD_STATUS_CD = 'COMPLETED'
-        THEN RPT_SENT_TIME
-    END) AS FIRSTNOTIFICATIONSENDDATE
-              ,
-    SUM(CASE
-        WHEN RECORD_STATUS_CD = 'PEND_APPR'
-            THEN 1
-        ELSE 0
-        END) NOTIFCREATEDPENDINGSCOUNT
-              ,MAX(CASE
-    WHEN RECORD_STATUS_CD = 'APPROVED'
-        OR RECORD_STATUS_CD = 'PEND_APPR'
-        THEN LAST_CHG_TIME
-    END) AS LASTNOTIFICATIONDATE
-              ,
-              --DONE?
-    MAX(CASE
-        WHEN RECORD_STATUS_CD = 'COMPLETED'
-            THEN RPT_SENT_TIME
-        END) AS LASTNOTIFICATIONSENDDATE
-              ,
-              --DONE?
-    MIN(ADD_TIME) AS FIRSTNOTIFICATIONDATE
-              ,
-              --DONE
-    MIN(ADD_USER_ID) AS FIRSTNOTIFICATIONSUBMITTEDBY
-              ,
-              --DONE
-    MIN(ADD_USER_ID) AS LASTNOTIFICATIONSUBMITTEDBY
-              --DONE
-              --MIN(CASE WHEN RECORD_STATUS_CD='COMPLETED' THEN  LAST_CHG_USER_ID END) AS FIRSTNOTIFICATIONSUBMITTEDBY,
-              ,MIN(CASE
-    WHEN RECORD_STATUS_CD = 'COMPLETED'
-        AND RPT_SENT_TIME IS NOT NULL
-        THEN RPT_SENT_TIME
-    END) AS NOTIFICATIONDATE
-              ,PUBLIC_HEALTH_CASE_UID
-INTO #TEMP_MIN_MAX_NOTIFICATION
-FROM #TEMP_SAS_NOTIFICATION WITH (NOLOCK)
-GROUP BY PUBLIC_HEALTH_CASE_UID;
-
-UPDATE #TEMP_MIN_MAX_NOTIFICATION set NOTIFCREATEDCOUNT = NOTIFCREATEDCOUNT-1 where NOTIFCREATEDPENDINGSCOUNT>0 and NOTIFCREATEDCOUNT>0;
-UPDATE #TEMP_MIN_MAX_NOTIFICATION set NOTIFCREATEDCOUNT = 1 where NOTIFCREATEDPENDINGSCOUNT>0 and NOTIFCREATEDCOUNT=0 and NOTIFREJECTEDCOUNT=0;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,0
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_SUB_CASE_NOTIF';
-
-		IF OBJECT_ID('#TEMP_SUB_CASE_NOTIF') IS NOT NULL
-DROP TABLE #TEMP_SUB_CASE_NOTIF;
-
-SELECT DISTINCT ts.*
-              ,NOTIFCREATEDCOUNT
-              ,NOTIFSENTCOUNT
-              ,NOTIFICATIONDATE
-              ,FIRSTNOTIFICATIONSTATUS
-              ,FIRSTNOTIFICATIONSENDDATE
-              ,LASTNOTIFICATIONDATE
-              ,LASTNOTIFICATIONSENDDATE
-              ,FIRSTNOTIFICATIONDATE
-              ,FIRSTNOTIFICATIONSUBMITTEDBY
-              ,LASTNOTIFICATIONSUBMITTEDBY
-              ,t.TXT AS NOTITXT
-              ,t.NOTIFICATION_LOCAL_ID
-              ,t.NOTIFCURRENTSTATE
-              ,ROWN = ROW_NUMBER() OVER (
-				PARTITION BY ts.PUBLIC_HEALTH_CASE_UID ORDER BY ts.PUBLIC_HEALTH_CASE_UID
-				)
-INTO #TEMP_SUB_CASE_NOTIF
-FROM #TEMP_PHCSUBJECT ts WITH (NOLOCK)
-		LEFT JOIN #TEMP_MIN_MAX_NOTIFICATION tn WITH (NOLOCK) ON tn.PUBLIC_HEALTH_CASE_UID = ts.PUBLIC_HEALTH_CASE_UID
-    LEFT JOIN #TEMP_SAS_LATEST_NOT  t WITH (NOLOCK) ON t.PUBLIC_HEALTH_CASE_UID = ts.PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-DELETE
-FROM #TEMP_SUB_CASE_NOTIF
-WHERE ROWN > 1
-      --IF OBJECT_ID ('TEMP_PHCFACT') IS NOT NULL DROP TABLE TEMP_PHCFACT;
-      --IF OBJECT_ID ('TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL DROP TABLE TEMP_MIN_MAX_NOTIFICATION;
-    INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                    batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_CONFIRM';
-
-		IF OBJECT_ID('#TEMP_CONFIRM') IS NOT NULL
-DROP TABLE #TEMP_CONFIRM;
-
-SELECT CONFIRMATION_METHOD.PUBLIC_HEALTH_CASE_UID
-     ,A.CONFIRMATION_METHOD_TIME
-     ,CONFIRMATION_METHOD_CD
-     ,tc.CODE_SHORT_DESC_TXT AS CONFIRMATION_METHOD_DESC_TXT
-     ,tc.investigation_form_cd
-INTO #TEMP_CONFIRM
-FROM (
-         SELECT CONFIRMATION_METHOD.PUBLIC_HEALTH_CASE_UID
-              ,MAX(CONFIRMATION_METHOD_TIME) AS CONFIRMATION_METHOD_TIME
-         FROM NBS_ODSE.DBO.CONFIRMATION_METHOD WITH (NOLOCK)
-         GROUP BY CONFIRMATION_METHOD.PUBLIC_HEALTH_CASE_UID
-     ) A
-         INNER JOIN #TEMP_PHCINFO t WITH (NOLOCK) ON t.PUBLIC_HEALTH_CASE_UID = A.PUBLIC_HEALTH_CASE_UID
-    INNER JOIN NBS_ODSE.DBO.CONFIRMATION_METHOD WITH (NOLOCK) ON A.PUBLIC_HEALTH_CASE_UID = CONFIRMATION_METHOD.PUBLIC_HEALTH_CASE_UID
-    LEFT OUTER JOIN #TEMP_INV_FORM_CODE_DATA  tc WITH (NOLOCK) ON CONFIRMATION_METHOD.CONFIRMATION_METHOD_CD = tc.CODE
-    AND  tc.investigation_form_cd = t.investigation_form_cd
-    AND tc.CODE_SET_NM= 'PHC_CONF_M'
-GROUP BY CONFIRMATION_METHOD.PUBLIC_HEALTH_CASE_UID
-        ,CONFIRMATION_METHOD_CD
-        ,A.CONFIRMATION_METHOD_TIME
-        ,CONFIRMATION_METHOD_DESC_TXT
-        ,tc.CODE_SHORT_DESC_TXT
-        ,tc.investigation_form_cd;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-
-UPDATE t
-SET CONFIRMATION_METHOD_DESC_TXT = CODE_VALUE_GENERAL.CODE_SHORT_DESC_TXT
-    FROM #TEMP_CONFIRM t
-		INNER JOIN NBS_SRTE.DBO.CODE_VALUE_GENERAL WITH (NOLOCK) ON t.CONFIRMATION_METHOD_CD = CODE_VALUE_GENERAL.CODE
-    AND CODE_SET_NM= 'PHC_CONF_M'
-where t.INVESTIGATION_FORM_CD NOT LIKE 'PG_%' or INVESTIGATION_FORM_CD is null
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_CONFIRM_CONCAT';
-
-		IF OBJECT_ID('#TEMP_CONFIRM_CONCAT') IS NOT NULL
-DROP TABLE #TEMP_CONFIRM_CONCAT;
-
-SELECT DISTINCT PUBLIC_HEALTH_CASE_UID
-              ,CONFIRMATION_METHOD_TIME = (
-    SELECT TOP 1 CONFIRMATION_METHOD_TIME
-    FROM #TEMP_CONFIRM WITH (NOLOCK)
-WHERE PUBLIC_HEALTH_CASE_UID = T.PUBLIC_HEALTH_CASE_UID
-    )
-    ,CONFIRMATION_METHOD_DESC_TXT = STUFF((
-    SELECT ', ' + CONFIRMATION_METHOD_DESC_TXT
-    FROM #TEMP_CONFIRM WITH (NOLOCK)
-    WHERE PUBLIC_HEALTH_CASE_UID = T.PUBLIC_HEALTH_CASE_UID
-    FOR XML PATH('')
-    ), 1, 1, '')
-    ,CONFIRMATION_METHOD_CD = STUFF((
-    SELECT ', ' + CONFIRMATION_METHOD_CD
-    FROM #TEMP_CONFIRM WITH (NOLOCK)
-    WHERE PUBLIC_HEALTH_CASE_UID = T.PUBLIC_HEALTH_CASE_UID
-    FOR XML PATH('')
-    ), 1, 1, '')
-INTO #TEMP_CONFIRM_CONCAT
-FROM #TEMP_CONFIRM AS T;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_SUB_CASE_CONF_NOTIF';
-
-		IF OBJECT_ID('#TEMP_SUB_CASE_CONF_NOTIF') IS NOT NULL
-DROP TABLE #TEMP_SUB_CASE_CONF_NOTIF;
-
-SELECT t.*
-     ,CONFIRMATION_METHOD_TIME
-     ,CONFIRMATION_METHOD_CD
-     ,CONFIRMATION_METHOD_DESC_TXT
-INTO #TEMP_SUB_CASE_CONF_NOTIF
-FROM #TEMP_SUB_CASE_NOTIF t WITH (NOLOCK)
-		LEFT OUTER JOIN #TEMP_CONFIRM_CONCAT tc WITH (NOLOCK) ON t.PUBLIC_HEALTH_CASE_UID = tc.PUBLIC_HEALTH_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-----------------------PHCREPORTER
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCREPORTER';
-
-		IF OBJECT_ID('#TEMP_PHCREPORTER') IS NOT NULL
-DROP TABLE #TEMP_PHCREPORTER;
-
-SELECT PAR.ACT_UID
-     ,PNM.PERSON_UID AS ENTITY_UID
-     ,TYPE_CD
-     ,TEL.PHONE_NBR_TXT
-     ,PAR.FROM_TIME
-     ,isnull(RTRIM(LTRIM(PNM.LAST_NM)), '') + ', ' + isnull(PNM.FIRST_NM, '') AS NAME
-INTO #TEMP_PHCREPORTER
-FROM NBS_ODSE.DBO.PARTICIPATION AS PAR WITH (NOLOCK)
-		INNER JOIN #TEMP_PHCINFO t on t.public_health_CASE_UID  =PAR.ACT_UID
-    INNER JOIN NBS_ODSE.DBO.PERSON  AS P WITH (NOLOCK) ON P.PERSON_UID = PAR.SUBJECT_ENTITY_UID
-    LEFT JOIN NBS_ODSE.DBO.PERSON_NAME AS PNM WITH (NOLOCK) ON PNM.PERSON_UID = PAR.SUBJECT_ENTITY_UID
-    AND PNM.NM_USE_CD = 'L'
-    AND PNM.RECORD_STATUS_CD = 'ACTIVE'
-    LEFT JOIN NBS_ODSE.DBO.ENTITY_LOCATOR_PARTICIPATION AS ELP WITH (NOLOCK) ON ELP.ENTITY_UID = PAR.SUBJECT_ENTITY_UID
-    AND ELP.CLASS_CD = 'TELE'
-    AND ELP.USE_CD = 'WP' /*WORK PLACE*/
-    AND ELP.CD = 'PH' /*PHONE*/
-    AND ELP.RECORD_STATUS_CD = 'ACTIVE'
-    LEFT JOIN NBS_ODSE.DBO.TELE_LOCATOR AS TEL WITH (NOLOCK) ON ELP.LOCATOR_UID = TEL.TELE_LOCATOR_UID
-/*AND (TEL.RECORD_STATUS_CD IS NOT NULL AND TEL.RECORD_STATUS_CD ='ACTIVE')*/
-WHERE (
-    PAR.TYPE_CD IN (
-    'OrgAsReporterOfPHC'
-    ,'InvestgrOfPHC'
-    ,'PerAsReporterOfPHC'
-    ,'PhysicianOfPHC'
-    )
-    )
-UNION
-
-SELECT PAR2.ACT_UID
-     ,ORG.ORGANIZATION_UID AS ENTITY_UID
-     ,TYPE_CD
-     ,' ' AS PHONE_NBR_TXT
-     ,PAR2.FROM_TIME
-     ,ORG.NM_TXT AS NAME
-FROM NBS_ODSE.DBO.PARTICIPATION AS PAR2 WITH (NOLOCK)
-			INNER JOIN #TEMP_PHCINFO t on t.public_health_CASE_UID  =PAR2.ACT_UID
-    INNER JOIN NBS_ODSE.DBO.ORGANIZATION_NAME AS ORG WITH (NOLOCK) ON ORG.ORGANIZATION_UID =  PAR2.SUBJECT_ENTITY_UID
-    INNER JOIN NBS_ODSE.DBO.ORGANIZATION WITH (NOLOCK) ON ORGANIZATION.ORGANIZATION_UID = ORG.ORGANIZATION_UID
-WHERE  PAR2.RECORD_STATUS_CD = 'ACTIVE'
-  AND PAR2.TYPE_CD = 'OrgAsReporterOfPHC'
-  AND LTRIM(RTRIM(NM_TXT)) <> ''
-ORDER BY ACT_UID
-        ,TYPE_CD;
-
-IF OBJECT_ID('#TEMP_ENTITY') IS NOT NULL
-DROP TABLE #TEMP_ENTITY;
-
-SELECT ACT_UID
-     ,PROVIDERNAME = MAX(CASE
-    WHEN TYPE_CD = 'PhysicianOfPHC'
-        THEN NAME
-    END)
-     ,PROVIDERPHONE = MAX(CASE
-    WHEN TYPE_CD = 'PhysicianOfPHC'
-        THEN PHONE_NBR_TXT
-    END)
-     ,REPORTERNAME = MAX(CASE
-    WHEN TYPE_CD = 'PerAsReporterOfPHC'
-        THEN NAME
-    END)
-     ,REPORTERPHONE = MAX(CASE
-    WHEN TYPE_CD = 'PerAsReporterOfPHC'
-        THEN PHONE_NBR_TXT
-    END)
-     ,INVESTIGATORNAME = MAX(CASE
-    WHEN TYPE_CD = 'InvestgrOfPHC'
-        THEN NAME
-    END)
-     ,INVESTIGATORPHONE = MAX(CASE
-    WHEN TYPE_CD = 'InvestgrOfPHC'
-        THEN PHONE_NBR_TXT
-    END)
-     ,INVESTIGATORASSIGNEDDATE = MAX(CASE
-    WHEN TYPE_CD = 'InvestgrOfPHC'
-        THEN FROM_TIME
-    END)
-     ,ORGANIZATIONNAME = MAX(CASE
-    WHEN TYPE_CD = 'OrgAsReporterOfPHC'
-        THEN NAME
-    END)
-INTO #TEMP_ENTITY
-FROM #TEMP_PHCREPORTER WITH (NOLOCK)
-GROUP BY ACT_UID
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_CASE_ENTITY';
-
-		IF OBJECT_ID('#TEMP_CASE_ENTITY') IS NOT NULL
-DROP TABLE #TEMP_CASE_ENTITY;
-
-SELECT tn.*
-     ,te.PROVIDERNAME
-     ,te.PROVIDERPHONE
-     ,te.REPORTERNAME
-     ,te.REPORTERPHONE
-     ,te.INVESTIGATORNAME
-     ,te.INVESTIGATORPHONE
-     ,te.INVESTIGATORASSIGNEDDATE
-     ,te.ORGANIZATIONNAME
-INTO #TEMP_CASE_ENTITY
-FROM #TEMP_SUB_CASE_CONF_NOTIF tn WITH (NOLOCK)
-		LEFT OUTER JOIN #TEMP_ENTITY te WITH (NOLOCK) ON tn.PUBLIC_HEALTH_CASE_UID = te.ACT_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
--------------------------PHCPERSONRACE
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHCPERSONRACE';
-
-		IF OBJECT_ID('#TEMP_PHCPERSONRACE') IS NOT NULL
-DROP TABLE #TEMP_PHCPERSONRACE;
-
-SELECT DISTINCT PER.PERSON_UID
-              ,PER.RACE_CATEGORY_CD
-              ,CODE_SHORT_DESC_TXT AS RACE_DESC_TXT
-INTO #TEMP_PHCPERSONRACE
-FROM NBS_ODSE.DBO.PERSON_RACE AS PER WITH (NOLOCK)
-			,NBS_SRTE.DBO.RACE_CODE AS RAC WITH (NOLOCK)
-        ,#TEMP_UPDATE_NEW_PATIENT t WITH (NOLOCK)
-WHERE PER.RACE_CD = PER.RACE_CATEGORY_CD /*CONCATENATE ONLY CATEGORY CD AND DESC*/
-  AND t.PERSON_UID=PER.PERSON_UID
-  AND PER.RACE_CD = RAC.CODE
-  AND RAC.PARENT_IS_CD = 'ROOT'
-  AND RAC.CODE_SET_NM = 'P_RACE_CAT'
-UNION
-
-SELECT DISTINCT PER.PERSON_UID
-              ,PER.RACE_CATEGORY_CD
-              ,CODE_SHORT_DESC_TXT AS RACE_DESC_TXT
---INTO TEMP_RACE1
-FROM NBS_ODSE.DBO.PERSON_RACE AS PER WITH (NOLOCK)
-			,NBS_SRTE.DBO.RACE_CODE AS RAC WITH (NOLOCK)
-        ,#TEMP_UPDATE_NEW_PATIENT t WITH (NOLOCK)
-WHERE PER.RACE_CD = 'ROOT'
-  AND t.PERSON_UID=PER.PERSON_UID
-  AND PER.RACE_CATEGORY_CD = RAC.CODE
-
-    IF OBJECT_ID('#TEMP_PHCPERSONRACE_CONCAT') IS NOT NULL
-DROP TABLE #TEMP_PHCPERSONRACE_CONCAT;
-
-SELECT DISTINCT PERSON_UID
-              ,RACE_CONCATENATED_DESC_TXT = STUFF((
-    SELECT ', ' + RACE_DESC_TXT
-    FROM #TEMP_PHCPERSONRACE WITH (NOLOCK)
-    WHERE PERSON_UID = T.PERSON_UID
-    FOR XML PATH('')
-    ), 1, 1, '')
-              ,RACE_CONCATENATED_TXT = STUFF((
-    SELECT ', ' + RACE_CATEGORY_CD
-    FROM #TEMP_PHCPERSONRACE WITH (NOLOCK)
-    WHERE PERSON_UID = T.PERSON_UID
-    FOR XML PATH('')
-    ), 1, 1, '')
-INTO #TEMP_PHCPERSONRACE_CONCAT
-FROM #TEMP_PHCPERSONRACE AS T;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Generating TEMP_PHC_FACT';
-
-		IF OBJECT_ID('#TEMP_PHC_FACT') IS NOT NULL
-DROP TABLE #TEMP_PHC_FACT;
-
-SELECT te.*
-     ,RACE_CONCATENATED_DESC_TXT
-     ,RACE_CONCATENATED_TXT
-     ,cast(null  as varchar(20)) EVENT_TYPE
-     ,cast(null as datetime)  EVENT_DATE
-     ,cast(null as datetime)  REPORT_DATE
-     ,cast(null as datetime)  MART_RECORD_CREATION_TIME
-INTO #TEMP_PHC_FACT
-FROM #TEMP_CASE_ENTITY te
-         LEFT OUTER JOIN #TEMP_PHCPERSONRACE_CONCAT tc WITH (NOLOCK) ON te.PERSON_UID = tc.PERSON_UID;
-
-----------------------
--- Moved this column above SQL
--- ALTER TABLE #TEMP_PHC_FACT ADD EVENT_TYPE VARCHAR(20);
-
--- ALTER TABLE #TEMP_PHC_FACT ADD EVENT_DATE DATETIME;
-
--- ALTER TABLE #TEMP_PHC_FACT ADD REPORT_DATE DATETIME;
-
--- ALTER TABLE #TEMP_PHC_FACT ADD MART_RECORD_CREATION_TIME DATETIME;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,0
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Updating TEMP_PHC_FACT';
-
-UPDATE #TEMP_PHC_FACT
-SET EVENT_TYPE = (
-    CASE
-        WHEN ONSETDATE IS NOT NULL
-            THEN 'O'
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NOT NULL
-            THEN 'D'
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NULL
-            AND RPT_TO_COUNTY_TIME IS NOT NULL
-            THEN 'C'
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NULL
-            AND RPT_TO_COUNTY_TIME IS NULL
-            AND RPT_TO_STATE_TIME IS NOT NULL
-            THEN 'S'
-        WHEN PHC_CODE IN ('10220')
-            AND THERAPY_DATE IS NOT NULL
-            THEN 'RVCT_DTS'
-        WHEN PHC_CODE IN ('10220')
-            AND THERAPY_DATE IS NULL
-            AND RPT_FORM_CMPLT_TIME IS NOT NULL
-            THEN 'RVCT_DR'
-        ELSE 'P'
-        END
-    )
-  ,EVENT_DATE = (
-    CASE
-        WHEN ONSETDATE IS NOT NULL
-            THEN ONSETDATE
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NOT NULL
-            THEN DIAGNOSIS_DATE
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NULL
-            AND RPT_TO_COUNTY_TIME IS NOT NULL
-            THEN RPT_TO_COUNTY_TIME
-        WHEN ONSETDATE IS NULL
-            AND DIAGNOSIS_DATE IS NULL
-            AND RPT_TO_COUNTY_TIME IS NULL
-            AND RPT_TO_STATE_TIME IS NOT NULL
-            THEN RPT_TO_STATE_TIME
-        WHEN PHC_CODE IN ('10220')
-            AND THERAPY_DATE IS NOT NULL
-            THEN THERAPY_DATE
-        WHEN PHC_CODE IN ('10220')
-            AND THERAPY_DATE IS NULL
-            AND RPT_FORM_CMPLT_TIME IS NOT NULL
-            THEN RPT_FORM_CMPLT_TIME
-        ELSE PHC_ADD_TIME
-        END
-    )
-  ,REPORT_DATE = (
-    CASE
-        WHEN RPT_TO_COUNTY_TIME is not null
-            THEN RPT_TO_COUNTY_TIME
-        WHEN RPT_TO_STATE_TIME IS NOT NULL AND RPT_TO_COUNTY_TIME IS NULL
-            THEN RPT_TO_STATE_TIME
-        ELSE PHC_ADD_TIME
-        END
-    )
-  ,DECEASED_TIME = (
-    CASE
-        WHEN PHC_CODE IN (
-                          '10220'
-            ,'10030'
-            )
-            THEN INVESTIGATION_DEATH_DATE
-        ELSE DECEASED_TIME
-        END
-    )
-  ,INVESTIGATORASSIGNEDDATE = (
-    CASE
-        WHEN PHC_CODE IN (
-                          '10220'
-            ,'10030'
-            )
-            THEN INVESTIGATOR_ASSIGN_DATE
-        ELSE INVESTIGATORASSIGNEDDATE
-        END
-    )
-  ,MART_RECORD_CREATION_TIME = getDate();;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
--- the below 4 update's are already covered in the above sql
--- so commenting the below 4 sql
--- UPDATE #TEMP_PHC_FACT SET EVENT_DATE = THERAPY_DATE WHERE PHC_CODE ='10220' and THERAPY_DATE is not null ;
--- UPDATE #TEMP_PHC_FACT SET EVENT_DATE = rpt_form_cmplt_time WHERE PHC_CODE ='10220' and THERAPY_DATE is null and rpt_form_cmplt_time is not null;
--- UPDATE #TEMP_PHC_FACT SET EVENT_TYPE = 'RVCT_DTS' WHERE PHC_CODE ='10220' and THERAPY_DATE is not null ;
--- UPDATE #TEMP_PHC_FACT SET EVENT_TYPE = 'RVCT_DR' WHERE PHC_CODE ='10220' and THERAPY_DATE is null and rpt_form_cmplt_time is not null;
-
--- below sql are now in the corresponding select clause
--- UPDATE #TEMP_PHC_FACT SET State_cd = NULL WHERE State_cd = LTRIM(RTRIM(''));
--- UPDATE #TEMP_PHC_FACT SET phctxt = NULL WHERE phctxt = LTRIM(RTRIM(''));
--- UPDATE #TEMP_PHC_FACT SET cntry_cd = NULL WHERE cntry_cd = LTRIM(RTRIM(''));
-
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Cleanup temp tables';
-/*
-		IF OBJECT_ID('#TEMP_UPDATE_NEW_PATIENT') IS NOT NULL
-			DROP TABLE #TEMP_UPDATE_NEW_PATIENT;
-
-		IF OBJECT_ID('#TEMP_PHCINFO1') IS NOT NULL
-			DROP TABLE #TEMP_PHCINFO1;
-
-		IF OBJECT_ID('#TEMP_PHCINFO2') IS NOT NULL
-			DROP TABLE #TEMP_PHCINFO2;
-
-		IF OBJECT_ID('#TEMP_PHCINFO3') IS NOT NULL
-			DROP TABLE #TEMP_PHCINFO3;
-
-		IF OBJECT_ID('#TEMP_INV_FORM_CODE_DATA') IS NOT NULL
-			DROP TABLE #TEMP_INV_FORM_CODE_DATA;
-
-		IF OBJECT_ID('#TEMP_PHCPATIENTINFO') IS NOT NULL
-			DROP TABLE #TEMP_PHCPATIENTINFO;
-
-		IF OBJECT_ID('#TEMP_PHCSUBJECT') IS NOT NULL
-			DROP TABLE #TEMP_PHCSUBJECT;
-
-		IF OBJECT_ID('#TEMP_PHCINFO') IS NOT NULL
-			DROP TABLE #TEMP_PHCINFO;
-
-		IF OBJECT_ID('#TEMP_SUMMARYUID') IS NOT NULL
-			DROP TABLE #TEMP_SUMMARYUID;
-
-		IF OBJECT_ID('#TEMP_CASECNT') IS NOT NULL
-			DROP TABLE #TEMP_CASECNT;
-		IF OBJECT_ID('#TEMP_SAS_LATEST_NOT') IS NOT NULL
-			DROP TABLE #TEMP_SAS_LATEST_NOT;
-
-		IF OBJECT_ID('#TEMP_SAS_NOTIFICATION') IS NOT NULL
-			DROP TABLE #TEMP_SAS_NOTIFICATION;
-
-		IF OBJECT_ID('#TEMP_CASECNT') IS NOT NULL
-			DROP TABLE #TEMP_CASECNT;
-
-		IF OBJECT_ID('#TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL
-			DROP TABLE #TEMP_MIN_MAX_NOTIFICATION;
-
-		IF OBJECT_ID('#TEMP_PHCFACT') IS NOT NULL
-			DROP TABLE #TEMP_PHCFACT;
-
-		IF OBJECT_ID('#TEMP_SUB_CASE_NOTIF') IS NOT NULL
-			DROP TABLE #TEMP_SUB_CASE_NOTIF;
-
-		IF OBJECT_ID('#TEMP_CONFIRM') IS NOT NULL
-			DROP TABLE #TEMP_CONFIRM;
-
-		IF OBJECT_ID('#TEMP_PHCREPORTER') IS NOT NULL
-			DROP TABLE #TEMP_PHCREPORTER;
-
-		IF OBJECT_ID('#TEMP_ENTITY') IS NOT NULL
-			DROP TABLE #TEMP_ENTITY;
-
-		IF OBJECT_ID('#TEMP_CASE_ENTITY') IS NOT NULL
-			DROP TABLE #TEMP_CASE_ENTITY;
-
-		IF OBJECT_ID('#TEMP_PHCPERSONRACE') IS NOT NULL
-			DROP TABLE #TEMP_PHCPERSONRACE;
-
-		IF OBJECT_ID('#TEMP_PHCPERSONRACE_CONCAT') IS NOT NULL
-			DROP TABLE #TEMP_PHCPERSONRACE_CONCAT;
-*/
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'STEP-AVOIDED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,0
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Updating PublicHealthCaseFact';
-
-INSERT INTO NBS_ODSE.DBO.PUBLICHEALTHCASEFACT (
-                                                PUBLIC_HEALTH_CASE_UID
-                                              ,ADULTS_IN_HOUSE_NBR
-                                              ,HSPTL_ADMISSION_DT
-                                              ,HSPTL_DISCHARGE_DT
-                                              ,AGE_CATEGORY_CD
-                                              ,AGE_REPORTED_TIME
-                                              ,AGE_REPORTED_UNIT_CD
-                                              ,AGE_REPORTED
-                                              ,AWARENESS_CD
-                                              ,AWARENESS_DESC_TXT
-                                              ,BIRTH_GENDER_CD
-                                              ,BIRTH_ORDER_NBR
-                                              ,BIRTH_TIME
-                                              ,BIRTH_TIME_CALC
-                                              ,
-    --,BIRTH_TIME_STD
-                                                CASE_CLASS_CD
-                                              ,CASE_TYPE_CD
-                                              ,CD_SYSTEM_CD
-                                              ,CD_SYSTEM_DESC_TXT
-                                              ,CENSUS_BLOCK_CD
-                                              ,CENSUS_MINOR_CIVIL_DIVISION_CD
-                                              ,CENSUS_TRACK_CD
-                                              ,
-    --,CNTY_CODE_DESC_TXT
-                                                CHILDREN_IN_HOUSE_NBR
-                                              ,CITY_CD
-                                              ,CITY_DESC_TXT
-                                              ,CONFIDENTIALITY_CD
-                                              ,CONFIDENTIALITY_DESC_TXT
-                                              ,CONFIRMATION_METHOD_CD
-                                              ,CONFIRMATION_METHOD_TIME
-                                              ,COUNTY
-                                              ,CNTRY_CD
-                                              ,CNTY_CD
-                                              ,CURR_SEX_CD
-                                              ,DECEASED_IND_CD
-                                              ,DECEASED_TIME
-                                              ,DETECTION_METHOD_CD
-                                              ,DETECTION_METHOD_DESC_TXT
-                                              ,DIAGNOSIS_DATE
-                                              ,DISEASE_IMPORTED_CD
-                                              ,DISEASE_IMPORTED_DESC_TXT
-                                              ,EDUCATION_LEVEL_CD
-                                              ,ELP_CLASS_CD
-                                              ,ELP_FROM_TIME
-                                              ,ELP_TO_TIME
-                                              ,ETHNIC_GROUP_IND
-                                              ,ETHNIC_GROUP_IND_DESC
-                                              ,EVENT_DATE
-                                              ,EVENT_TYPE
-                                              ,EDUCATION_LEVEL_DESC_TXT
-                                              ,FIRSTNOTIFICATIONSENDDATE
-                                              ,FIRSTNOTIFICATIONDATE
-                                              ,FIRSTNOTIFICATIONSTATUS
-                                              ,FIRSTNOTIFICATIONSUBMITTEDBY
-                                              ,
-    --,GEOLATITUDE
-    --,GEOLONGITUDE
-                                                GROUP_CASE_CNT
-                                              ,INVESTIGATION_STATUS_CD
-                                              ,INVESTIGATORASSIGNEDDATE
-                                              ,INVESTIGATORNAME
-                                              ,INVESTIGATORPHONE
-                                              ,JURISDICTION_CD
-                                              ,LASTNOTIFICATIONDATE
-                                              ,LASTNOTIFICATIONSENDDATE
-                                              ,LASTNOTIFICATIONSUBMITTEDBY
-                                              ,MARITAL_STATUS_CD
-                                              ,MARITAL_STATUS_DESC_TXT
-                                              ,
-    --,MART_RECORD_CREATION_DATE
-                                                MART_RECORD_CREATION_TIME
-                                              ,MMWR_WEEK
-                                              ,MMWR_YEAR
-                                              ,MSA_CONGRESS_DISTRICT_CD
-                                              ,MULTIPLE_BIRTH_IND
-                                              ,NOTIFCREATEDCOUNT
-                                              ,NOTIFICATIONDATE
-                                              ,NOTIFSENTCOUNT
-                                              ,OCCUPATION_CD
-                                              ,ONSETDATE
-                                              ,ORGANIZATIONNAME
-                                              ,OUTCOME_CD
-                                              ,OUTBREAK_FROM_TIME
-                                              ,OUTBREAK_IND
-                                              ,OUTBREAK_NAME
-                                              ,OUTBREAK_TO_TIME
-                                              ,PAR_TYPE_CD
-                                              ,PAT_AGE_AT_ONSET
-                                              ,PAT_AGE_AT_ONSET_UNIT_CD
-                                              ,POSTAL_LOCATOR_UID
-                                              ,PERSON_CD
-                                              ,PERSON_CODE_DESC
-                                              ,PERSON_UID
-                                              ,PHC_ADD_TIME
-                                              ,PHC_CODE
-                                              ,PHC_CODE_DESC
-                                              ,PHC_CODE_SHORT_DESC
-                                              ,PRIM_LANG_CD
-                                              ,PRIM_LANG_DESC_TXT
-                                              ,PROG_AREA_CD
-                                              ,PROVIDERPHONE
-                                              ,PROVIDERNAME
-                                              ,PST_RECORD_STATUS_TIME
-                                              ,PST_RECORD_STATUS_CD
-                                              ,RACE_CONCATENATED_TXT
-                                              ,RACE_CONCATENATED_DESC_TXT
-                                              ,REGION_DISTRICT_CD
-                                              ,RECORD_STATUS_CD
-                                              ,REPORTERNAME
-                                              ,REPORTERPHONE
-                                              ,RPT_CNTY_CD
-                                              ,RPT_FORM_CMPLT_TIME
-                                              ,RPT_SOURCE_CD
-                                              ,RPT_SOURCE_DESC_TXT
-                                              ,RPT_TO_COUNTY_TIME
-                                              ,RPT_TO_STATE_TIME
-                                              ,SHARED_IND
-                                              ,STATE
-                                              ,STATE_CD
-                                              ,
-    --,STATE_CODE_SHORT_DESC_TXT
-                                                STATUS_CD
-                                              ,STREET_ADDR1
-                                              ,STREET_ADDR2
-                                              ,ELP_USE_CD
-                                              ,ZIP_CD
-                                              ,PATIENTNAME
-                                              ,JURISDICTION
-                                              ,INVESTIGATIONSTARTDATE
-                                              ,PROGRAM_JURISDICTION_OID
-                                              ,REPORT_DATE
-                                              ,PERSON_PARENT_UID
-                                              ,PERSON_LOCAL_ID
-                                              ,SUB_ADDR_AS_OF_DATE
-                                              ,STATE_CASE_ID
-                                              ,LOCAL_ID
-                                              ,AGE_REPORTED_UNIT_DESC_TXT
-                                              ,BIRTH_GENDER_DESC_TXT
-                                              ,CASE_CLASS_DESC_TXT
-                                              ,CNTRY_DESC_TXT
-                                              ,CURR_SEX_DESC_TXT
-                                              ,INVESTIGATION_STATUS_DESC_TXT
-                                              ,OCCUPATION_DESC_TXT
-                                              ,OUTCOME_DESC_TXT
-                                              ,PAT_AGE_AT_ONSET_UNIT_DESC_TXT
-                                              ,PROG_AREA_DESC_TXT
-                                              ,RPT_CNTY_DESC_TXT
-                                              ,OUTBREAK_NAME_DESC
-                                              ,CONFIRMATION_METHOD_DESC_TXT
-                                              ,LASTUPDATE
-                                              ,PHCTXT
-                                              ,NOTITXT
-                                              ,NOTIFICATION_LOCAL_ID
-                                              ,NOTIFCURRENTSTATE
-                                              ,HOSPITALIZED_IND
-) (
-    SELECT PUBLIC_HEALTH_CASE_UID
-         ,ADULTS_IN_HOUSE_NBR
-         ,HSPTL_ADMISSION_DT
-         ,HSPTL_DISCHARGE_DT
-         ,AGE_CATEGORY_CD
-         ,AGE_REPORTED_TIME
-         ,AGE_REPORTED_UNIT_CD
-         ,CONVERT(NUMERIC, substring(RTRIM(LTRIM(AGE_REPORTED)), 1, 3))
-         ,AWARENESS_CD
-         ,AWARENESS_DESC_TXT
-         ,BIRTH_GENDER_CD
-         ,BIRTH_ORDER_NBR
-         ,BIRTH_TIME
-         ,BIRTH_TIME_CALC
-         ,
-         --,BIRTH_TIME_STD
-        CASE_CLASS_CD
-         ,CASE_TYPE_CD
-         ,CD_SYSTEM_CD
-         ,CD_SYSTEM_DESC_TXT
-         ,CENSUS_BLOCK_CD
-         ,CENSUS_MINOR_CIVIL_DIVISION_CD
-         ,CENSUS_TRACK_CD
-         ,
-         --,CNTY_CODE_DESC_TXT
-        CHILDREN_IN_HOUSE_NBR
-         ,CITY_CD
-         ,CITY_DESC_TXT
-         ,CONFIDENTIALITY_CD
-         ,CONFIDENTIALITY_DESC_TXT
-         ,substring(RTRIM(LTRIM(CONFIRMATION_METHOD_CD)), 1, 300)
-         ,CONFIRMATION_METHOD_TIME
-         ,COUNTY
-         ,CNTRY_CD
-         ,CNTY_CD
-         ,CURR_SEX_CD
-         ,DECEASED_IND_CD
-         ,DECEASED_TIME
-         ,DETECTION_METHOD_CD
-         ,DETECTION_METHOD_DESC_TXT
-         ,DIAGNOSIS_DATE
-         ,DISEASE_IMPORTED_CD
-         ,DISEASE_IMPORTED_DESC_TXT
-         ,EDUCATION_LEVEL_CD
-         ,ELP_CLASS_CD
-         ,ELP_FROM_TIME
-         ,ELP_TO_TIME
-         ,ETHNIC_GROUP_IND
-         ,RTRIM(LTRIM(substring(ETHNIC_GROUP_IND_DESC, 1, 50)))
-         ,EVENT_DATE
-         ,substring(EVENT_TYPE, 1, 10)
-         ,EDUCATION_LEVEL_DESC_TXT
-         ,FIRSTNOTIFICATIONSENDDATE
-         ,FIRSTNOTIFICATIONDATE
-         ,FIRSTNOTIFICATIONSTATUS
-         ,FIRSTNOTIFICATIONSUBMITTEDBY
-         ,
-         --,GEOLATITUDE
-         --,GEOLONGITUDE
-        GROUP_CASE_CNT
-         ,INVESTIGATION_STATUS_CD
-         ,INVESTIGATORASSIGNEDDATE
-         ,INVESTIGATORNAME
-         ,INVESTIGATORPHONE
-         ,JURISDICTION_CD
-         ,LASTNOTIFICATIONDATE
-         ,LASTNOTIFICATIONSENDDATE
-         ,LASTNOTIFICATIONSUBMITTEDBY
-         ,MARITAL_STATUS_CD
-         ,MARITAL_STATUS_DESC_TXT
-         ,
-         --,MART_RECORD_CREATION_DATE
-        MART_RECORD_CREATION_TIME
-         ,MMWR_WEEK
-         ,MMWR_YEAR
-         ,MSA_CONGRESS_DISTRICT_CD
-         ,MULTIPLE_BIRTH_IND
-         ,NOTIFCREATEDCOUNT
-         ,NOTIFICATIONDATE
-         ,NOTIFSENTCOUNT
-         ,OCCUPATION_CD
-         ,ONSETDATE
-         ,ORGANIZATIONNAME
-         ,OUTCOME_CD
-         ,OUTBREAK_FROM_TIME
-         ,OUTBREAK_IND
-         ,OUTBREAK_NAME
-         ,OUTBREAK_TO_TIME
-         ,PAR_TYPE_CD
-         ,PAT_AGE_AT_ONSET
-         ,PAT_AGE_AT_ONSET_UNIT_CD
-         ,POSTAL_LOCATOR_UID
-         ,PERSON_CD
-         ,PERSON_CODE_DESC
-         ,PERSON_UID
-         ,PHC_ADD_TIME
-         ,PHC_CODE
-         ,PHC_CODE_DESC
-         ,substring(PHC_CODE_SHORT_DESC, 1, 50)
-         ,PRIM_LANG_CD
-         ,PRIM_LANG_DESC_TXT
-         ,PROG_AREA_CD
-         ,PROVIDERPHONE
-         ,PROVIDERNAME
-         ,PST_RECORD_STATUS_TIME
-         ,PST_RECORD_STATUS_CD
-         ,substring(RTRIM(LTRIM(RACE_CONCATENATED_TXT)), 1, 100)
-         ,substring(RTRIM(LTRIM(RACE_CONCATENATED_DESC_TXT)), 1, 500)
-         ,REGION_DISTRICT_CD
-         ,RECORD_STATUS_CD
-         ,REPORTERNAME
-         ,REPORTERPHONE
-         ,RPT_CNTY_CD
-         ,RPT_FORM_CMPLT_TIME
-         ,RPT_SOURCE_CD
-         ,RPT_SOURCE_DESC_TXT
-         ,RPT_TO_COUNTY_TIME
-         ,RPT_TO_STATE_TIME
-         ,SHARED_IND
-         ,STATE
-         ,STATE_CD
-         ,
-         --,STATE_CODE_SHORT_DESC_TXT
-        STATUS_CD
-         ,STREET_ADDR1
-         ,STREET_ADDR2
-         ,ELP_USE_CD
-         ,ZIP_CD
-         ,RTRIM(LTRIM(PATIENTNAME))
-         ,substring(JURISDICTION, 1, 50)
-         ,INVESTIGATIONSTARTDATE
-         ,PROGRAM_JURISDICTION_OID
-         ,REPORT_DATE
-         ,PERSON_PARENT_UID
-         ,PERSON_LOCAL_ID
-         ,SUB_ADDR_AS_OF_DATE
-         ,STATE_CASE_ID
-         ,LOCAL_ID
-         ,AGE_REPORTED_UNIT_DESC_TXT
-         ,BIRTH_GENDER_DESC_TXT
-         ,CASE_CLASS_DESC_TXT
-         ,CNTRY_DESC_TXT
-         ,CURR_SEX_DESC_TXT
-         ,INVESTIGATION_STATUS_DESC_TXT
-         ,OCCUPATION_DESC_TXT
-         ,OUTCOME_DESC_TXT
-         ,PAT_AGE_AT_ONSET_UNIT_DESC_TXT
-         ,PROG_AREA_DESC_TXT
-         ,RPT_CNTY_DESC_TXT
-         ,OUTBREAK_NAME_DESC
-         ,CONFIRMATION_METHOD_DESC_TXT
-         ,LASTUPDATE
-         ,PHCTXT
-         ,NOTITXT
-         ,NOTIFICATION_LOCAL_ID
-         ,NOTIFCURRENTSTATE
-         ,HOSPITALIZED_IND
-    FROM #TEMP_PHC_FACT WITH (NOLOCK)
-);
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@PROC_STEP_NO
-        ,@PROC_STEP_NAME
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = @Proc_Step_no + 1;
-		SET @Proc_Step_Name = 'Updating SubjectRaceInfo';
-
-INSERT INTO NBS_ODSE.DBO.SUBJECTRACEINFO (
-                                           PUBLIC_HEALTH_CASE_UID
-                                         ,MORBREPORT_UID
-                                         ,RACE_CD
-                                         ,RACE_CATEGORY_CD
-                                         ,RACE_DESC_TXT
-) (
-    SELECT PUBLIC_HEALTH_CASE_UID
-         ,0 AS MORBREPORT_UID
-         ,RACE_CD
-         ,RACE_CATEGORY_CD
-         ,RACE_DESC_TXT FROM NBS_ODSE.DBO.PERSON_RACE AS PR WITH (NOLOCK)
-			,#TEMP_PHC_FACT AS PF WITH (NOLOCK) WHERE PR.PERSON_UID = PF.PERSON_UID
-);
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-IF OBJECT_ID('#TEMP_PHC_FACT') IS NOT NULL
-DROP TABLE #TEMP_PHC_FACT;
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @Batch_id
-        ,'PCHMartETL'
-        ,'NBS_ODSE.PublicHealthCaseFact'
-        ,'COMPLETED'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,@ROWCOUNT_NO
-    );
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-		SET @Proc_Step_no = 999;
-		SET @Proc_Step_Name = 'SP_COMPLETE';
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-)
-VALUES (
-    @batch_id
-        ,'PCHMartETL'
-        ,'PCHMartETL'
-        ,'COMPLETE'
-        ,@Proc_Step_no
-        ,@Proc_Step_name
-        ,@RowCount_no
-    );
-
-COMMIT TRANSACTION;
-
--- EXEC [rdb_modern].[dbo].[sp_nbs_batch_complete] @type_code;
-
-Select 'SUCCESS'
-END TRY
-
-BEGIN CATCH
-IF @@TRANCOUNT > 0
-			ROLLBACK TRANSACTION;
-
-		DECLARE @ErrorNumber INT = ERROR_NUMBER();
-		DECLARE @ErrorLine INT = ERROR_LINE();
-		DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
-		DECLARE @ErrorSeverity INT = ERROR_SEVERITY();
-		DECLARE @ErrorState INT = ERROR_STATE();
-
-INSERT INTO [rdb_modern].[dbo].[job_flow_log] (
-                                                batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[Error_Description]
-    ,[row_count]
-)
-VALUES (
-    @batch_id
-        ,'PCHMartETL'
-        ,'PCHMartETL'
-        ,'ERROR'
-        ,@Proc_Step_no
-        ,'ERROR - ' + @Proc_Step_name
-        ,'Step -' + CAST(@Proc_Step_no AS VARCHAR(3)) + ' -' + CAST(@ErrorMessage AS VARCHAR(500))
-        ,0
-    );
-
-RETURN 'ERROR - ' + @ErrorMessage;
-END CATCH
 END;

--- a/liquibase-service/src/main/resources/db/rdb/020-sp_nrt_organization_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/020-sp_nrt_organization_postprocessing-001.sql
@@ -2,147 +2,149 @@ CREATE OR ALTER PROCEDURE dbo.sp_nrt_organization_postprocessing @id_list nvarch
 AS
 BEGIN
 
-BEGIN TRY
+    BEGIN TRY
 
         /* Logging */
         declare @rowcount bigint;
-		declare @proc_step_no float = 0;
-		declare @proc_step_name varchar(200) = '';
-		declare @batch_id bigint;
-		declare @create_dttm datetime2(7) = current_timestamp ;
-		declare @update_dttm datetime2(7) = current_timestamp ;
-		declare @dataflow_name varchar(200) = 'Organization POST-Processing';
-		declare @package_name varchar(200) = 'sp_nrt_organization_postprocessing';
+        declare @proc_step_no float = 0;
+        declare @proc_step_name varchar(200) = '';
+        declare @batch_id bigint;
+        declare @create_dttm datetime2(7) = current_timestamp ;
+        declare @update_dttm datetime2(7) = current_timestamp ;
+        declare @dataflow_name varchar(200) = 'Organization POST-Processing';
+        declare @package_name varchar(200) = 'sp_nrt_organization_postprocessing';
 
-		set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
+        set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
 
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[msg_description1]
-    ,[row_count]
-)
-VALUES (
-    @batch_id
-        ,@create_dttm
-        ,@update_dttm
-        ,@dataflow_name
-        ,@package_name
-        ,'START'
-        ,0
-        ,'SP_Start'
-        ,LEFT(@id_list,500)
-        ,0
-    );
+        INSERT INTO [dbo].[job_flow_log] (
+           batch_id
+         ,[create_dttm]
+         ,[update_dttm]
+         ,[Dataflow_Name]
+         ,[package_Name]
+         ,[Status_Type]
+         ,[step_number]
+         ,[step_name]
+         ,[msg_description1]
+         ,[row_count]
+        )
+        VALUES (
+                 @batch_id
+               ,@create_dttm
+               ,@update_dttm
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,0
+               ,'SP_Start'
+               ,LEFT(@id_list,500)
+               ,0
+               );
 
-SET @proc_step_name='Create ORGANIZATION Temp table for -'+ LEFT(@id_list,165);
-		SET @proc_step_no = 1;
+        SET @proc_step_name='Create ORGANIZATION Temp table for -'+ LEFT(@id_list,165);
+        SET @proc_step_no = 1;
 
         /* Temp organization table creation*/
-select
-    ORGANIZATION_KEY,
-    nrt.organization_uid as ORGANIZATION_UID,
-    nrt.local_id as ORGANIZATION_LOCAL_ID,
-    nrt.record_status as ORGANIZATION_RECORD_STATUS,
-    nrt.organization_name as ORGANIZATION_NAME,
-    nrt.general_comments as ORGANIZATION_GENERAL_COMMENTS,
-    nrt.quick_code as ORGANIZATION_QUICK_CODE,
-    nrt.stand_ind_class as ORGANIZATION_STAND_IND_CLASS,
-    nrt.facility_id as ORGANIZATION_FACILITY_ID,
-    nrt.facility_id_auth as ORGANIZATION_FACILITY_ID_AUTH,
-    nrt.street_address_1 as ORGANIZATION_STREET_ADDRESS_1,
-    nrt.street_address_2 as ORGANIZATION_STREET_ADDRESS_2,
-    nrt.city as ORGANIZATION_CITY,
-    nrt.state as ORGANIZATION_STATE,
-    nrt.state_code as ORGANIZATION_STATE_CODE,
-    nrt.zip as ORGANIZATION_ZIP,
-    nrt.county as ORGANIZATION_COUNTY,
-    nrt.county_code as ORGANIZATION_COUNTY_CODE,
-    nrt.country as ORGANIZATION_COUNTRY,
-    nrt.address_comments as ORGANIZATION_ADDRESS_COMMENTS,
-    nrt.phone_work as ORGANIZATION_PHONE_WORK,
-    nrt.phone_ext_work as ORGANIZATION_PHONE_EXT_WORK,
-    nrt.email as ORGANIZATION_EMAIL,
-    nrt.phone_comments as ORGANIZATION_PHONE_COMMENTS,
-    nrt.fax as ORGANIZATION_FAX,
-    nrt.entry_method as ORGANIZATION_ENTRY_METHOD,
-    nrt.add_user_name as ORGANIZATION_ADDED_BY,
-    nrt.add_time as ORGANIZATION_ADD_TIME,
-    nrt.last_chg_user_name as ORGANIZATION_LAST_UPDATED_BY,
-    nrt.last_chg_time as ORGANIZATION_LAST_CHANGE_TIME
-into #temp_org_table
-from dbo.nrt_organization nrt
-         left join dbo.d_organization o on o.organization_uid = nrt.organization_uid
-where nrt.organization_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
+        select
+            ORGANIZATION_KEY,
+            nrt.organization_uid as ORGANIZATION_UID,
+            nrt.local_id as ORGANIZATION_LOCAL_ID,
+            nrt.record_status as ORGANIZATION_RECORD_STATUS,
+            nrt.organization_name as ORGANIZATION_NAME,
+            nrt.general_comments as ORGANIZATION_GENERAL_COMMENTS,
+            nrt.quick_code as ORGANIZATION_QUICK_CODE,
+            nrt.stand_ind_class as ORGANIZATION_STAND_IND_CLASS,
+            nrt.facility_id as ORGANIZATION_FACILITY_ID,
+            nrt.facility_id_auth as ORGANIZATION_FACILITY_ID_AUTH,
+            nrt.street_address_1 as ORGANIZATION_STREET_ADDRESS_1,
+            nrt.street_address_2 as ORGANIZATION_STREET_ADDRESS_2,
+            nrt.city as ORGANIZATION_CITY,
+            nrt.state as ORGANIZATION_STATE,
+            nrt.state_code as ORGANIZATION_STATE_CODE,
+            nrt.zip as ORGANIZATION_ZIP,
+            nrt.county as ORGANIZATION_COUNTY,
+            nrt.county_code as ORGANIZATION_COUNTY_CODE,
+            nrt.country as ORGANIZATION_COUNTRY,
+            nrt.address_comments as ORGANIZATION_ADDRESS_COMMENTS,
+            nrt.phone_work as ORGANIZATION_PHONE_WORK,
+            nrt.phone_ext_work as ORGANIZATION_PHONE_EXT_WORK,
+            nrt.email as ORGANIZATION_EMAIL,
+            nrt.phone_comments as ORGANIZATION_PHONE_COMMENTS,
+            nrt.fax as ORGANIZATION_FAX,
+            nrt.entry_method as ORGANIZATION_ENTRY_METHOD,
+            nrt.add_user_name as ORGANIZATION_ADDED_BY,
+            nrt.add_time as ORGANIZATION_ADD_TIME,
+            nrt.last_chg_user_name as ORGANIZATION_LAST_UPDATED_BY,
+            nrt.last_chg_time as ORGANIZATION_LAST_CHANGE_TIME
+        into #temp_org_table
+        from dbo.nrt_organization nrt
+                 left join dbo.d_organization o with (nolock) on o.organization_uid = nrt.organization_uid
+        where nrt.organization_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
 
-/* Logging */
-set @rowcount=@@rowcount
-	   INSERT INTO [dbo].[job_flow_log]
-	   		(
-				batch_id
-				,[Dataflow_Name]
-				,[package_Name]
-				,[Status_Type]
-				,[step_number]
-				,[step_name]
-				,[row_count]
-				,[msg_description1]
-				)
-		VALUES (
-				@batch_id
-				,@dataflow_name
-				,@package_name
-				,'START'
-				,@proc_step_no
-				,@proc_step_name
-				,@rowcount
-				,LEFT(@id_list,500)
-				);
+        if @debug = 'true' select * from #temp_org_table;
+
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
 
         /* D_Organization Update Operation */
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
         SET @proc_step_name='Update D_ORAGANIZATION Dimension';
-		SET @proc_step_no = 2;
-update dbo.d_organization
-set	[ORGANIZATION_KEY]             = org.ORGANIZATION_KEY,
-    [ORGANIZATION_UID]               = org.ORGANIZATION_UID,
-    [ORGANIZATION_LOCAL_ID]          = org.ORGANIZATION_LOCAL_ID,
-    [ORGANIZATION_RECORD_STATUS]     = org.ORGANIZATION_RECORD_STATUS,
-    [ORGANIZATION_NAME]              = CASE WHEN (substring(org.ORGANIZATION_NAME,1,50)) is null then null else substring(org.ORGANIZATION_NAME,1,50) end,
-            [ORGANIZATION_GENERAL_COMMENTS]  = org.ORGANIZATION_GENERAL_COMMENTS,
-            ORGANIZATION_QUICK_CODE          = CASE WHEN (substring(org.ORGANIZATION_QUICK_CODE,1,50)) is null then null else substring(org.ORGANIZATION_QUICK_CODE,1,50) end,
-            [ORGANIZATION_STAND_IND_CLASS]   = org.ORGANIZATION_STAND_IND_CLASS,
-            [ORGANIZATION_FACILITY_ID]	   = CASE when (substring(org.ORGANIZATION_FACILITY_ID,1,50)) is null then null else substring(org.ORGANIZATION_FACILITY_ID,1,50) end,
-            [ORGANIZATION_FACILITY_ID_AUTH]  = CASE WHEN (substring(org.ORGANIZATION_FACILITY_ID_AUTH,1,50)) is null then null else substring(org.ORGANIZATION_FACILITY_ID_AUTH,1,50) end,
-            [ORGANIZATION_STREET_ADDRESS_1]  = substring(org.[ORGANIZATION_STREET_ADDRESS_1] ,1,50),
-            [ORGANIZATION_STREET_ADDRESS_2]  = substring(org.[ORGANIZATION_STREET_ADDRESS_2] ,1,50),
-            [ORGANIZATION_CITY]			   = substring(org.[ORGANIZATION_CITY],1,50),
-            [ORGANIZATION_STATE]             = org.[ORGANIZATION_STATE],
-            [ORGANIZATION_STATE_CODE]        = org.[ORGANIZATION_STATE_CODE],
-            [ORGANIZATION_ZIP]               = org.[ORGANIZATION_ZIP] ,
-            [ORGANIZATION_COUNTY]            = org.[ORGANIZATION_COUNTY] ,
-            [ORGANIZATION_COUNTY_CODE]       = org.[ORGANIZATION_COUNTY_CODE] ,
-            [ORGANIZATION_COUNTRY]           = org.[ORGANIZATION_COUNTRY],
-            [ORGANIZATION_ADDRESS_COMMENTS]  =  org.[ORGANIZATION_ADDRESS_COMMENTS],
-            [ORGANIZATION_PHONE_WORK]        =  org.[ORGANIZATION_PHONE_WORK] ,
-            [ORGANIZATION_PHONE_EXT_WORK]  =  org.[ORGANIZATION_PHONE_EXT_WORK] ,
-            [ORGANIZATION_EMAIL]			   = substring(org.[ORGANIZATION_EMAIL],1,50),
-            [ORGANIZATION_PHONE_COMMENTS]    =  org.[ORGANIZATION_PHONE_COMMENTS] ,
-            [ORGANIZATION_ENTRY_METHOD]       =  org.[ORGANIZATION_ENTRY_METHOD] ,
-            [ORGANIZATION_LAST_CHANGE_TIME]   =  org.[ORGANIZATION_LAST_CHANGE_TIME],
-            [ORGANIZATION_ADD_TIME]           =  org.[ORGANIZATION_ADD_TIME] ,
-            [ORGANIZATION_ADDED_BY]           =  org.[ORGANIZATION_ADDED_BY]  ,
-            [ORGANIZATION_LAST_UPDATED_BY]    =  org.[ORGANIZATION_LAST_UPDATED_BY],
-            [ORGANIZATION_FAX]				   =  org.[ORGANIZATION_FAX]
+        SET @proc_step_no = 2;
+        update dbo.d_organization
+        set	[ORGANIZATION_KEY]             = org.ORGANIZATION_KEY,
+               [ORGANIZATION_UID]               = org.ORGANIZATION_UID,
+               [ORGANIZATION_LOCAL_ID]          = org.ORGANIZATION_LOCAL_ID,
+               [ORGANIZATION_RECORD_STATUS]     = org.ORGANIZATION_RECORD_STATUS,
+               [ORGANIZATION_NAME]              = CASE WHEN (substring(org.ORGANIZATION_NAME,1,50)) is null then null else substring(org.ORGANIZATION_NAME,1,50) end,
+               [ORGANIZATION_GENERAL_COMMENTS]  = org.ORGANIZATION_GENERAL_COMMENTS,
+               ORGANIZATION_QUICK_CODE          = CASE WHEN (substring(org.ORGANIZATION_QUICK_CODE,1,50)) is null then null else substring(org.ORGANIZATION_QUICK_CODE,1,50) end,
+               [ORGANIZATION_STAND_IND_CLASS]   = org.ORGANIZATION_STAND_IND_CLASS,
+               [ORGANIZATION_FACILITY_ID]	   = CASE when (substring(org.ORGANIZATION_FACILITY_ID,1,50)) is null then null else substring(org.ORGANIZATION_FACILITY_ID,1,50) end,
+               [ORGANIZATION_FACILITY_ID_AUTH]  = CASE WHEN (substring(org.ORGANIZATION_FACILITY_ID_AUTH,1,50)) is null then null else substring(org.ORGANIZATION_FACILITY_ID_AUTH,1,50) end,
+               [ORGANIZATION_STREET_ADDRESS_1]  = substring(org.[ORGANIZATION_STREET_ADDRESS_1] ,1,50),
+               [ORGANIZATION_STREET_ADDRESS_2]  = substring(org.[ORGANIZATION_STREET_ADDRESS_2] ,1,50),
+               [ORGANIZATION_CITY]			   = substring(org.[ORGANIZATION_CITY],1,50),
+               [ORGANIZATION_STATE]             = org.[ORGANIZATION_STATE],
+               [ORGANIZATION_STATE_CODE]        = org.[ORGANIZATION_STATE_CODE],
+               [ORGANIZATION_ZIP]               = org.[ORGANIZATION_ZIP] ,
+               [ORGANIZATION_COUNTY]            = org.[ORGANIZATION_COUNTY] ,
+               [ORGANIZATION_COUNTY_CODE]       = org.[ORGANIZATION_COUNTY_CODE] ,
+               [ORGANIZATION_COUNTRY]           = org.[ORGANIZATION_COUNTRY],
+               [ORGANIZATION_ADDRESS_COMMENTS]  =  org.[ORGANIZATION_ADDRESS_COMMENTS],
+               [ORGANIZATION_PHONE_WORK]        =  org.[ORGANIZATION_PHONE_WORK] ,
+               [ORGANIZATION_PHONE_EXT_WORK]  =  org.[ORGANIZATION_PHONE_EXT_WORK] ,
+               [ORGANIZATION_EMAIL]			   = substring(org.[ORGANIZATION_EMAIL],1,50),
+               [ORGANIZATION_PHONE_COMMENTS]    =  org.[ORGANIZATION_PHONE_COMMENTS] ,
+               [ORGANIZATION_ENTRY_METHOD]       =  org.[ORGANIZATION_ENTRY_METHOD] ,
+               [ORGANIZATION_LAST_CHANGE_TIME]   =  org.[ORGANIZATION_LAST_CHANGE_TIME],
+               [ORGANIZATION_ADD_TIME]           =  org.[ORGANIZATION_ADD_TIME] ,
+               [ORGANIZATION_ADDED_BY]           =  org.[ORGANIZATION_ADDED_BY]  ,
+               [ORGANIZATION_LAST_UPDATED_BY]    =  org.[ORGANIZATION_LAST_UPDATED_BY],
+               [ORGANIZATION_FAX]				   =  org.[ORGANIZATION_FAX]
         from #temp_org_table org
-        inner join dbo.d_organization o on org.organization_uid = o.organization_uid
+                 inner join dbo.d_organization o with (nolock) on org.organization_uid = o.organization_uid
             and org.organization_key = o.organization_key
             and o.organization_key is not null;
 
@@ -150,229 +152,229 @@ set	[ORGANIZATION_KEY]             = org.ORGANIZATION_KEY,
         set @rowcount=@@rowcount
         INSERT INTO [dbo].[job_flow_log]
         (
-			batch_id
-			,[Dataflow_Name]
-			,[package_Name]
-			,[Status_Type]
-			,[step_number]
-			,[step_name]
-			,[row_count]
-			,[msg_description1]
-			)
-		VALUES (
-			@batch_id
-			,@dataflow_name
-			,@package_name
-			,'START'
-			,@proc_step_no
-			,@proc_step_name
-			,@rowcount
-			,LEFT(@id_list,500)
-			);
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
-		SET @proc_step_name='Insert into D_ORAGANIZATION Dimension';
-		SET @proc_step_no = 3;
+        SET @proc_step_name='Insert into D_ORAGANIZATION Dimension';
+        SET @proc_step_no = 3;
 
         /* D_Organization Insert Operation */
         -- delete from the key table to generate new keys for the resulting new data to be inserted
-begin try
+        begin try
 
-delete from dbo.nrt_organization_key ;
-insert into dbo.nrt_organization_key(organization_uid)
-select organization_uid from #temp_org_table where organization_key is null order by organization_uid;
+            delete from dbo.nrt_organization_key ;
+            insert into dbo.nrt_organization_key(organization_uid)
+            select organization_uid from #temp_org_table where organization_key is null order by organization_uid;
 
-insert into dbo.d_organization
-([ORGANIZATION_KEY]
- ,[ORGANIZATION_UID]
- ,[ORGANIZATION_LOCAL_ID]
- ,[ORGANIZATION_RECORD_STATUS]
- ,[ORGANIZATION_NAME]
- ,[ORGANIZATION_GENERAL_COMMENTS]
- ,[ORGANIZATION_QUICK_CODE]
- ,[ORGANIZATION_STAND_IND_CLASS]
- ,[ORGANIZATION_FACILITY_ID]
- ,[ORGANIZATION_FACILITY_ID_AUTH]
- ,[ORGANIZATION_STREET_ADDRESS_1]
- ,[ORGANIZATION_STREET_ADDRESS_2]
- ,[ORGANIZATION_CITY]
- ,[ORGANIZATION_STATE]
- ,[ORGANIZATION_STATE_CODE]
- ,[ORGANIZATION_ZIP]
- ,[ORGANIZATION_COUNTY]
- ,[ORGANIZATION_COUNTY_CODE]
- ,[ORGANIZATION_COUNTRY]
- ,[ORGANIZATION_ADDRESS_COMMENTS]
- ,[ORGANIZATION_PHONE_WORK]
- ,[ORGANIZATION_PHONE_EXT_WORK]
- ,[ORGANIZATION_EMAIL]
- ,[ORGANIZATION_PHONE_COMMENTS]
- ,[ORGANIZATION_ENTRY_METHOD]
- ,[ORGANIZATION_LAST_CHANGE_TIME]
- ,[ORGANIZATION_ADD_TIME]
- ,[ORGANIZATION_ADDED_BY]
- ,[ORGANIZATION_LAST_UPDATED_BY]
- ,[ORGANIZATION_FAX])
-SELECT  k.d_organization_key  as ORGANIZATION_KEY
-     ,org.[ORGANIZATION_UID]
-     ,org.[ORGANIZATION_LOCAL_ID]
-     ,org.[ORGANIZATION_RECORD_STATUS]
-     ,cast(org.ORGANIZATION_NAME as varchar(50)) as ORGANIZATION_NAME
-     ,org.[ORGANIZATION_GENERAL_COMMENTS]
-     ,isnull(NULLIF(cast(org.[ORGANIZATION_QUICK_CODE] as varchar(50)),''),NULL) as ORGANIZATION_QUICK_CODE
-     ,org.[ORGANIZATION_STAND_IND_CLASS]
-     ,cast(org.[ORGANIZATION_FACILITY_ID] as varchar(50)) as ORGANIZATION_FACILITY_ID
-     ,cast(org.ORGANIZATION_FACILITY_ID_AUTH as varchar(50)) as ORGANIZATION_FACILITY_ID_AUTH
-     ,case when cast (org.[ORGANIZATION_STREET_ADDRESS_1] as varchar(50)) is null then null else cast(org.[ORGANIZATION_STREET_ADDRESS_1] as varchar(50)) end
-     ,case when cast (org.[ORGANIZATION_STREET_ADDRESS_2] as varchar(50)) is null then null else cast(org.[ORGANIZATION_STREET_ADDRESS_2] as varchar(50)) end
-     ,isnull(NULLIF(cast(org.[ORGANIZATION_CITY] as varchar(50)),''),NULL) as ORGANIZATION_CITY
-     ,isnull(NULLIF(org.[ORGANIZATION_STATE],''),NULL) as ORGANIZATION_STATE
-     ,isnull(NULLIF(org.[ORGANIZATION_STATE_CODE],''),NULL) as ORGANIZATION_STATE_CODE
-     ,isnull(NULLIF(cast(org.[ORGANIZATION_ZIP] as varchar(10)),''),NULL) as ORGANIZATION_ZIP
-     ,isnull(NULLIF(org.[ORGANIZATION_COUNTY],''),NULL) as ORGANIZATION_COUNTY
-     ,isnull(NULLIF(org.[ORGANIZATION_COUNTY_CODE] ,''),NULL) as ORGANIZATION_COUNTY_CODE
-     ,isnull(NULLIF(org.[ORGANIZATION_COUNTRY],''),NULL) as ORGANIZATION_COUNTRY
-     ,case when org.[ORGANIZATION_ADDRESS_COMMENTS] is null then null else RTRIM(LTRIM(org.[ORGANIZATION_ADDRESS_COMMENTS])) end
-     ,case when org.[ORGANIZATION_PHONE_WORK]is  null then null else org.[ORGANIZATION_PHONE_WORK] end
-     ,case when org.[ORGANIZATION_PHONE_EXT_WORK] is null then null else org.[ORGANIZATION_PHONE_EXT_WORK] end
-     ,isnull(NULLIF(cast(org.[ORGANIZATION_EMAIL] as varchar(50)),''),NULL) as  ORGANIZATION_EMAIL
-     ,case when org.[ORGANIZATION_PHONE_COMMENTS] is null then null else RTRIM(LTRIM(org.[ORGANIZATION_PHONE_COMMENTS])) end
-     ,org.[ORGANIZATION_ENTRY_METHOD]
-     ,org.[ORGANIZATION_LAST_CHANGE_TIME]
-     ,org.[ORGANIZATION_ADD_TIME]
-     ,org.[ORGANIZATION_ADDED_BY]
-     ,org.[ORGANIZATION_LAST_UPDATED_BY]
-     ,org.[ORGANIZATION_FAX]
-FROM #temp_org_table org
-         join dbo.nrt_organization_key k on org.organization_uid = k.organization_uid
-where org.organization_key is null;
+            insert into dbo.d_organization
+            ([ORGANIZATION_KEY]
+            ,[ORGANIZATION_UID]
+            ,[ORGANIZATION_LOCAL_ID]
+            ,[ORGANIZATION_RECORD_STATUS]
+            ,[ORGANIZATION_NAME]
+            ,[ORGANIZATION_GENERAL_COMMENTS]
+            ,[ORGANIZATION_QUICK_CODE]
+            ,[ORGANIZATION_STAND_IND_CLASS]
+            ,[ORGANIZATION_FACILITY_ID]
+            ,[ORGANIZATION_FACILITY_ID_AUTH]
+            ,[ORGANIZATION_STREET_ADDRESS_1]
+            ,[ORGANIZATION_STREET_ADDRESS_2]
+            ,[ORGANIZATION_CITY]
+            ,[ORGANIZATION_STATE]
+            ,[ORGANIZATION_STATE_CODE]
+            ,[ORGANIZATION_ZIP]
+            ,[ORGANIZATION_COUNTY]
+            ,[ORGANIZATION_COUNTY_CODE]
+            ,[ORGANIZATION_COUNTRY]
+            ,[ORGANIZATION_ADDRESS_COMMENTS]
+            ,[ORGANIZATION_PHONE_WORK]
+            ,[ORGANIZATION_PHONE_EXT_WORK]
+            ,[ORGANIZATION_EMAIL]
+            ,[ORGANIZATION_PHONE_COMMENTS]
+            ,[ORGANIZATION_ENTRY_METHOD]
+            ,[ORGANIZATION_LAST_CHANGE_TIME]
+            ,[ORGANIZATION_ADD_TIME]
+            ,[ORGANIZATION_ADDED_BY]
+            ,[ORGANIZATION_LAST_UPDATED_BY]
+            ,[ORGANIZATION_FAX])
+            SELECT  k.d_organization_key  as ORGANIZATION_KEY
+                 ,org.[ORGANIZATION_UID]
+                 ,org.[ORGANIZATION_LOCAL_ID]
+                 ,org.[ORGANIZATION_RECORD_STATUS]
+                 ,cast(org.ORGANIZATION_NAME as varchar(50)) as ORGANIZATION_NAME
+                 ,org.[ORGANIZATION_GENERAL_COMMENTS]
+                 ,isnull(NULLIF(cast(org.[ORGANIZATION_QUICK_CODE] as varchar(50)),''),NULL) as ORGANIZATION_QUICK_CODE
+                 ,org.[ORGANIZATION_STAND_IND_CLASS]
+                 ,cast(org.[ORGANIZATION_FACILITY_ID] as varchar(50)) as ORGANIZATION_FACILITY_ID
+                 ,cast(org.ORGANIZATION_FACILITY_ID_AUTH as varchar(50)) as ORGANIZATION_FACILITY_ID_AUTH
+                 ,case when cast (org.[ORGANIZATION_STREET_ADDRESS_1] as varchar(50)) is null then null else cast(org.[ORGANIZATION_STREET_ADDRESS_1] as varchar(50)) end
+                 ,case when cast (org.[ORGANIZATION_STREET_ADDRESS_2] as varchar(50)) is null then null else cast(org.[ORGANIZATION_STREET_ADDRESS_2] as varchar(50)) end
+                 ,isnull(NULLIF(cast(org.[ORGANIZATION_CITY] as varchar(50)),''),NULL) as ORGANIZATION_CITY
+                 ,isnull(NULLIF(org.[ORGANIZATION_STATE],''),NULL) as ORGANIZATION_STATE
+                 ,isnull(NULLIF(org.[ORGANIZATION_STATE_CODE],''),NULL) as ORGANIZATION_STATE_CODE
+                 ,isnull(NULLIF(cast(org.[ORGANIZATION_ZIP] as varchar(10)),''),NULL) as ORGANIZATION_ZIP
+                 ,isnull(NULLIF(org.[ORGANIZATION_COUNTY],''),NULL) as ORGANIZATION_COUNTY
+                 ,isnull(NULLIF(org.[ORGANIZATION_COUNTY_CODE] ,''),NULL) as ORGANIZATION_COUNTY_CODE
+                 ,isnull(NULLIF(org.[ORGANIZATION_COUNTRY],''),NULL) as ORGANIZATION_COUNTRY
+                 ,case when org.[ORGANIZATION_ADDRESS_COMMENTS] is null then null else RTRIM(LTRIM(org.[ORGANIZATION_ADDRESS_COMMENTS])) end
+                 ,case when org.[ORGANIZATION_PHONE_WORK]is  null then null else org.[ORGANIZATION_PHONE_WORK] end
+                 ,case when org.[ORGANIZATION_PHONE_EXT_WORK] is null then null else org.[ORGANIZATION_PHONE_EXT_WORK] end
+                 ,isnull(NULLIF(cast(org.[ORGANIZATION_EMAIL] as varchar(50)),''),NULL) as  ORGANIZATION_EMAIL
+                 ,case when org.[ORGANIZATION_PHONE_COMMENTS] is null then null else RTRIM(LTRIM(org.[ORGANIZATION_PHONE_COMMENTS])) end
+                 ,org.[ORGANIZATION_ENTRY_METHOD]
+                 ,org.[ORGANIZATION_LAST_CHANGE_TIME]
+                 ,org.[ORGANIZATION_ADD_TIME]
+                 ,org.[ORGANIZATION_ADDED_BY]
+                 ,org.[ORGANIZATION_LAST_UPDATED_BY]
+                 ,org.[ORGANIZATION_FAX]
+            FROM #temp_org_table org
+                     join dbo.nrt_organization_key k with (nolock) on org.organization_uid = k.organization_uid
+            where org.organization_key is null;
 
-end try
-begin catch
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+        end try
+        begin catch
+            IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
             /* Logging */
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES
-    (
-    @batch_id
-        ,current_timestamp
-        ,current_timestamp
-        ,@dataflow_name
-        ,@package_name
-        ,'ERROR'
-        ,@Proc_Step_no
-        , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(ERROR_MESSAGE() AS VARCHAR(500))
-        ,0
-        ,LEFT(@id_list,500)
-    );
+            INSERT INTO [dbo].[job_flow_log] (
+               batch_id
+             ,[create_dttm]
+             ,[update_dttm]
+             ,[Dataflow_Name]
+             ,[package_Name]
+             ,[Status_Type]
+             ,[step_number]
+             ,[step_name]
+             ,[row_count]
+             ,[msg_description1]
+            )
+            VALUES
+                (
+                  @batch_id
+                ,current_timestamp
+                ,current_timestamp
+                ,@dataflow_name
+                ,@package_name
+                ,'ERROR'
+                ,@Proc_Step_no
+                , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(ERROR_MESSAGE() AS VARCHAR(500))
+                ,0
+                ,LEFT(@id_list,500)
+                );
 
-return ERROR_MESSAGE();
-end catch
+            return ERROR_MESSAGE();
+        end catch
 
         /* Logging */
-set @rowcount=@@rowcount
-		INSERT INTO [dbo].[job_flow_log] (
-			batch_id
-			,[Dataflow_Name]
-			,[package_Name]
-			,[Status_Type]
-			,[step_number]
-			,[step_name]
-			,[row_count]
-			,[msg_description1]
-			)
-		VALUES (
-			@batch_id
-			,@dataflow_name
-			,@package_name
-			,'START'
-			,@proc_step_no
-			,@proc_step_name
-			,@rowcount
-			,LEFT(@id_list,500)
-			);
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+                                         ,[Dataflow_Name]
+                                         ,[package_Name]
+                                         ,[Status_Type]
+                                         ,[step_number]
+                                         ,[step_name]
+                                         ,[row_count]
+                                         ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
-select 'Success';
+        select 'Success';
 
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
-SET @proc_step_name='SP_COMPLETE';
-		SET @proc_step_no = 4;
+        SET @proc_step_name='SP_COMPLETE';
+        SET @proc_step_no = 4;
 
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES (
-    @batch_id
-        ,current_timestamp
-        ,current_timestamp
-        ,@dataflow_name
-        ,@package_name
-        ,'COMPLETE'
-        ,@proc_step_no
-        ,@proc_step_name
-        ,0
-        ,LEFT(@id_list,500)
-    );
+        INSERT INTO [dbo].[job_flow_log] (
+           batch_id
+         ,[create_dttm]
+         ,[update_dttm]
+         ,[Dataflow_Name]
+         ,[package_Name]
+         ,[Status_Type]
+         ,[step_number]
+         ,[step_name]
+         ,[row_count]
+         ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,current_timestamp
+               ,current_timestamp
+               ,@dataflow_name
+               ,@package_name
+               ,'COMPLETE'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,0
+               ,LEFT(@id_list,500)
+               );
 
-END TRY
+    END TRY
 
-BEGIN CATCH
+    BEGIN CATCH
 
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
         DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
 
         /* Logging */
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES
-    (
-    @batch_id
-        ,current_timestamp
-        ,current_timestamp
-        ,@dataflow_name
-        ,@package_name
-        ,'ERROR'
-        ,@Proc_Step_no
-        , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
-        ,0
-        ,LEFT(@id_list,500)
-    );
+        INSERT INTO [dbo].[job_flow_log] (
+           batch_id
+         ,[create_dttm]
+         ,[update_dttm]
+         ,[Dataflow_Name]
+         ,[package_Name]
+         ,[Status_Type]
+         ,[step_number]
+         ,[step_name]
+         ,[row_count]
+         ,[msg_description1]
+        )
+        VALUES
+            (
+              @batch_id
+            ,current_timestamp
+            ,current_timestamp
+            ,@dataflow_name
+            ,@package_name
+            ,'ERROR'
+            ,@Proc_Step_no
+            , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
+            ,0
+            ,LEFT(@id_list,500)
+            );
 
-return @ErrorMessage;
+        return @ErrorMessage;
 
-END CATCH
+    END CATCH
 
 END;

--- a/liquibase-service/src/main/resources/db/rdb/021-sp_nrt_provider_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/021-sp_nrt_provider_postprocessing-001.sql
@@ -2,109 +2,103 @@ CREATE OR ALTER PROCEDURE dbo.sp_nrt_provider_postprocessing @id_list nvarchar(m
 AS
 BEGIN
 
-BEGIN TRY
+    BEGIN TRY
 
-	/* Logging */
-	declare
-@rowcount bigint;
-	declare
-@proc_step_no float = 0;
-	declare
-@proc_step_name varchar(200) = '';
-	declare
-@batch_id bigint;
-	declare
-@create_dttm datetime2(7) = current_timestamp ;
-	declare
-@update_dttm datetime2(7) = current_timestamp ;
-	declare
-@dataflow_name varchar(200) = 'Provider POST-Processing';
-	declare
-@package_name varchar(200) = 'sp_nrt_provider_postprocessing';
+        /* Logging */
+        declare @rowcount bigint;
+        declare @proc_step_no float = 0;
+        declare @proc_step_name varchar(200) = '';
+        declare @batch_id bigint;
+        declare @create_dttm datetime2(7) = current_timestamp ;
+        declare @update_dttm datetime2(7) = current_timestamp ;
+        declare @dataflow_name varchar(200) = 'Provider POST-Processing';
+        declare @package_name varchar(200) = 'sp_nrt_provider_postprocessing';
 
-	set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
+        set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
 
-INSERT INTO [dbo].[job_flow_log]
-(     batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[msg_description1]
-    ,[row_count])
-VALUES (
-    @batch_id
-        , @create_dttm
-        , @update_dttm
-        , @dataflow_name
-        , @package_name
-        , 'START'
-        , 0
-        , 'SP_Start'
-        , LEFT (@id_list, 500)
-        , 0
-    );
+        INSERT INTO [dbo].[job_flow_log]
+        (     batch_id
+        ,[create_dttm]
+        ,[update_dttm]
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[msg_description1]
+        ,[row_count])
+        VALUES (
+                 @batch_id
+               , @create_dttm
+               , @update_dttm
+               , @dataflow_name
+               , @package_name
+               , 'START'
+               , 0
+               , 'SP_Start'
+               , LEFT (@id_list, 500)
+               , 0
+               );
 
-    SET @proc_step_name='Create PROVIDER Temp tables for -'+ LEFT(@id_list,165);
-	SET @proc_step_no = 1;
+        SET @proc_step_name='Create PROVIDER Temp tables for -'+ LEFT(@id_list,165);
+        SET @proc_step_no = 1;
 
-	/* Temp Provider Table*/
-    select PROVIDER_KEY,
-           nrt.provider_uid                             as PROVIDER_UID,
-           local_id                                     as PROVIDER_LOCAL_ID,
-           record_status                                as PROVIDER_RECORD_STATUS,
-           name_prefix                                  as PROVIDER_NAME_PREFIX,
-           first_name                                   as PROVIDER_FIRST_NAME,
-           middle_name                                  as PROVIDER_MIDDLE_NAME,
-           last_name                                    as PROVIDER_LAST_NAME,
-           name_suffix                                  as PROVIDER_NAME_SUFFIX,
-           name_degree                                  as PROVIDER_NAME_DEGREE,
-           general_comments                             as PROVIDER_GENERAL_COMMENTS,
-           case when rtrim(ltrim(quick_code)) = '' then null
-                else quick_code end                     AS PROVIDER_QUICK_CODE,
-           nrt.provider_registration_num                as PROVIDER_REGISTRATION_NUM,
-           case when rtrim(ltrim(provider_registration_num_auth)) = '' then null
-                else provider_registration_num_auth end AS PROVIDER_REGISRATION_NUM_AUTH,
-           case when rtrim(ltrim(street_address_1)) = '' then null
-                else street_address_1 end               AS PROVIDER_STREET_ADDRESS_1,
-           case when rtrim(ltrim(street_address_2)) = '' then null
-                else street_address_2 end               AS PROVIDER_STREET_ADDRESS_2,
-           city                                         as PROVIDER_CITY,
-           state                                        as PROVIDER_STATE,
-           state_code                                   as PROVIDER_STATE_CODE,
-           zip                                          as PROVIDER_ZIP,
-           county                                       as PROVIDER_COUNTY,
-           case when rtrim(ltrim(county_code)) = '' then null
-                else county_code end                    AS PROVIDER_COUNTY_CODE,
-           country                                      as PROVIDER_COUNTRY,
-           case when rtrim(ltrim(address_comments)) = '' then null
-                else address_comments end               AS PROVIDER_ADDRESS_COMMENTS,
-           case when rtrim(ltrim(phone_work)) = '' then null
-                else phone_work end                     AS PROVIDER_PHONE_WORK,
-           case when rtrim(ltrim(phone_ext_work)) = '' then null
-                else phone_ext_work end                 AS PROVIDER_PHONE_EXT_WORK,
-           email_work                                   as PROVIDER_EMAIL_WORK,
-           case when rtrim(ltrim(phone_comments)) = '' then null
-                else phone_comments end                 AS PROVIDER_PHONE_COMMENTS,
-           phone_cell                                   as PROVIDER_PHONE_CELL,
-           entry_method                                 as PROVIDER_ENTRY_METHOD,
-           add_user_name                                as PROVIDER_ADDED_BY,
-           add_time                                     as PROVIDER_ADD_TIME,
-           last_chg_user_name                           as PROVIDER_LAST_UPDATED_BY,
-           last_chg_time                                as PROVIDER_LAST_CHANGE_TIME
-    into #temp_prv_table
-    from dbo.nrt_provider nrt
-             left join dbo.d_provider p on p.provider_uid = nrt.provider_uid
-    where nrt.provider_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','))
+        /* Temp Provider Table*/
+        select PROVIDER_KEY,
+               nrt.provider_uid                             as PROVIDER_UID,
+               local_id                                     as PROVIDER_LOCAL_ID,
+               record_status                                as PROVIDER_RECORD_STATUS,
+               name_prefix                                  as PROVIDER_NAME_PREFIX,
+               first_name                                   as PROVIDER_FIRST_NAME,
+               middle_name                                  as PROVIDER_MIDDLE_NAME,
+               last_name                                    as PROVIDER_LAST_NAME,
+               name_suffix                                  as PROVIDER_NAME_SUFFIX,
+               name_degree                                  as PROVIDER_NAME_DEGREE,
+               general_comments                             as PROVIDER_GENERAL_COMMENTS,
+               case when rtrim(ltrim(quick_code)) = '' then null
+                    else quick_code end                     AS PROVIDER_QUICK_CODE,
+               nrt.provider_registration_num                as PROVIDER_REGISTRATION_NUM,
+               case when rtrim(ltrim(provider_registration_num_auth)) = '' then null
+                    else provider_registration_num_auth end AS PROVIDER_REGISRATION_NUM_AUTH,
+               case when rtrim(ltrim(street_address_1)) = '' then null
+                    else street_address_1 end               AS PROVIDER_STREET_ADDRESS_1,
+               case when rtrim(ltrim(street_address_2)) = '' then null
+                    else street_address_2 end               AS PROVIDER_STREET_ADDRESS_2,
+               city                                         as PROVIDER_CITY,
+               state                                        as PROVIDER_STATE,
+               state_code                                   as PROVIDER_STATE_CODE,
+               zip                                          as PROVIDER_ZIP,
+               county                                       as PROVIDER_COUNTY,
+               case when rtrim(ltrim(county_code)) = '' then null
+                    else county_code end                    AS PROVIDER_COUNTY_CODE,
+               country                                      as PROVIDER_COUNTRY,
+               case when rtrim(ltrim(address_comments)) = '' then null
+                    else address_comments end               AS PROVIDER_ADDRESS_COMMENTS,
+               case when rtrim(ltrim(phone_work)) = '' then null
+                    else phone_work end                     AS PROVIDER_PHONE_WORK,
+               case when rtrim(ltrim(phone_ext_work)) = '' then null
+                    else phone_ext_work end                 AS PROVIDER_PHONE_EXT_WORK,
+               email_work                                   as PROVIDER_EMAIL_WORK,
+               case when rtrim(ltrim(phone_comments)) = '' then null
+                    else phone_comments end                 AS PROVIDER_PHONE_COMMENTS,
+               phone_cell                                   as PROVIDER_PHONE_CELL,
+               entry_method                                 as PROVIDER_ENTRY_METHOD,
+               add_user_name                                as PROVIDER_ADDED_BY,
+               add_time                                     as PROVIDER_ADD_TIME,
+               last_chg_user_name                           as PROVIDER_LAST_UPDATED_BY,
+               last_chg_time                                as PROVIDER_LAST_CHANGE_TIME
+        into #temp_prv_table
+        from dbo.nrt_provider nrt
+                 left join dbo.d_provider p with (nolock) on p.provider_uid = nrt.provider_uid
+        where nrt.provider_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
 
-    /* Logging */
-    set @rowcount=@@rowcount
-    INSERT
-    INTO [dbo].[job_flow_log]
-    (     batch_id
+        if @debug = 'true' select * from #temp_prv_table;
+
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT
+        INTO [dbo].[job_flow_log]
+        (     batch_id
         ,[Dataflow_Name]
         ,[package_Name]
         ,[Status_Type]
@@ -112,245 +106,240 @@ VALUES (
         ,[step_name]
         ,[row_count]
         ,[msg_description1])
-    VALUES (
-        @batch_id
+        VALUES (
+                 @batch_id
+               , @dataflow_name
+               , @package_name
+               , 'START'
+               , @proc_step_no
+               , @proc_step_name
+               , @rowcount
+               , LEFT (@id_list, 500)
+               );
+
+        SET @proc_step_name='Update D_PROVIDER Dimension';
+        SET @proc_step_no = 2;
+
+        /* D_Provider Update Operation */
+        BEGIN TRANSACTION;
+        update dbo.d_provider
+        set [PROVIDER_UID] = prv.[PROVIDER_UID], [PROVIDER_KEY] = prv.[PROVIDER_KEY], [PROVIDER_LOCAL_ID] = prv.[PROVIDER_LOCAL_ID], [PROVIDER_RECORD_STATUS] = prv.[PROVIDER_RECORD_STATUS], [PROVIDER_NAME_PREFIX] = prv.[PROVIDER_NAME_PREFIX], [PROVIDER_FIRST_NAME] = prv.[PROVIDER_FIRST_NAME], [PROVIDER_MIDDLE_NAME] = prv.[PROVIDER_MIDDLE_NAME], [PROVIDER_LAST_NAME] = prv.[PROVIDER_LAST_NAME], [PROVIDER_NAME_SUFFIX] = prv.[PROVIDER_NAME_SUFFIX], [PROVIDER_NAME_DEGREE] = prv.[PROVIDER_NAME_DEGREE], [PROVIDER_GENERAL_COMMENTS] = prv.[PROVIDER_GENERAL_COMMENTS], [PROVIDER_QUICK_CODE] = substring (prv.[PROVIDER_QUICK_CODE], 1, 50), [PROVIDER_REGISTRATION_NUM] = substring (prv.[PROVIDER_REGISTRATION_NUM], 1, 50), [PROVIDER_REGISRATION_NUM_AUTH] = substring (prv.[PROVIDER_REGISRATION_NUM_AUTH], 1, 50), [PROVIDER_STREET_ADDRESS_1] = substring (prv.[PROVIDER_STREET_ADDRESS_1], 1, 50), [PROVIDER_STREET_ADDRESS_2] = substring (prv.[PROVIDER_STREET_ADDRESS_2], 1, 50), [PROVIDER_CITY] = substring (prv.[PROVIDER_CITY], 1, 50), [PROVIDER_STATE] = prv.[PROVIDER_STATE], [PROVIDER_STATE_CODE] = prv.[PROVIDER_STATE_CODE], [PROVIDER_ZIP] = prv.[PROVIDER_ZIP], [PROVIDER_COUNTY] = prv.[PROVIDER_COUNTY], [PROVIDER_COUNTY_CODE] = prv.[PROVIDER_COUNTY_CODE], [PROVIDER_COUNTRY] = prv.[PROVIDER_COUNTRY], [PROVIDER_ADDRESS_COMMENTS] = prv.[PROVIDER_ADDRESS_COMMENTS], [PROVIDER_PHONE_WORK] = prv.[PROVIDER_PHONE_WORK], [PROVIDER_PHONE_EXT_WORK] = prv.[PROVIDER_PHONE_EXT_WORK], [PROVIDER_EMAIL_WORK] = substring (prv.[PROVIDER_EMAIL_WORK], 1, 50), [PROVIDER_PHONE_COMMENTS] = prv.[PROVIDER_PHONE_COMMENTS], [PROVIDER_PHONE_CELL] = prv.[PROVIDER_PHONE_CELL], [PROVIDER_ENTRY_METHOD] = prv.[PROVIDER_ENTRY_METHOD], [PROVIDER_LAST_CHANGE_TIME] = prv.[PROVIDER_LAST_CHANGE_TIME], [PROVIDER_ADD_TIME] = prv.[PROVIDER_ADD_TIME], [PROVIDER_ADDED_BY] = prv.[PROVIDER_ADDED_BY], [PROVIDER_LAST_UPDATED_BY] = prv.[PROVIDER_LAST_UPDATED_BY]
+        from #temp_prv_table prv
+                 inner join dbo.d_provider p with (nolock)
+                            on prv.provider_uid = p.provider_uid
+                                and prv.provider_key = p.provider_key
+                                and p.provider_key is not null;
+
+
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
+
+        SET @proc_step_name='Insert into D_PROVIDER Dimension';
+        SET @proc_step_no = 3;
+
+        /* D_Provider Insert Operation */
+
+        -- delete from the key table to generate new keys for the resulting new data to be inserted
+        delete from dbo.nrt_provider_key;
+        insert into dbo.nrt_provider_key(provider_uid)
+        select provider_uid
+        from #temp_prv_table
+        where provider_key is null
+        order by provider_uid;
+
+        insert into dbo.d_provider
+        ([PROVIDER_UID]
+        ,[PROVIDER_KEY]
+        ,[PROVIDER_LOCAL_ID]
+        ,[PROVIDER_RECORD_STATUS]
+        ,[PROVIDER_NAME_PREFIX]
+        ,[PROVIDER_FIRST_NAME]
+        ,[PROVIDER_MIDDLE_NAME]
+        ,[PROVIDER_LAST_NAME]
+        ,[PROVIDER_NAME_SUFFIX]
+        ,[PROVIDER_NAME_DEGREE]
+        ,[PROVIDER_GENERAL_COMMENTS]
+        ,[PROVIDER_QUICK_CODE]
+        ,[PROVIDER_REGISTRATION_NUM]
+        ,[PROVIDER_REGISRATION_NUM_AUTH]
+        ,[PROVIDER_STREET_ADDRESS_1]
+        ,[PROVIDER_STREET_ADDRESS_2]
+        ,[PROVIDER_CITY]
+        ,[PROVIDER_STATE]
+        ,[PROVIDER_ZIP]
+        ,[PROVIDER_COUNTY]
+        ,[PROVIDER_COUNTRY]
+        ,[PROVIDER_ADDRESS_COMMENTS]
+        ,[PROVIDER_PHONE_WORK]
+        ,[PROVIDER_PHONE_EXT_WORK]
+        ,[PROVIDER_EMAIL_WORK]
+        ,[PROVIDER_PHONE_COMMENTS]
+        ,[PROVIDER_PHONE_CELL]
+        ,[PROVIDER_ENTRY_METHOD]
+        ,[PROVIDER_LAST_CHANGE_TIME]
+        ,[PROVIDER_ADD_TIME]
+        ,[PROVIDER_ADDED_BY]
+        ,[PROVIDER_LAST_UPDATED_BY]
+        ,[PROVIDER_STATE_CODE]
+        ,[PROVIDER_COUNTY_CODE])
+        SELECT prv.[PROVIDER_UID]
+             , k.[d_PROVIDER_KEY] as PROVIDER_KEY
+             , prv.[PROVIDER_LOCAL_ID]
+             , prv.[PROVIDER_RECORD_STATUS]
+             , prv.[PROVIDER_NAME_PREFIX]
+             , prv.[PROVIDER_FIRST_NAME]
+             , prv.[PROVIDER_MIDDLE_NAME]
+             , prv.[PROVIDER_LAST_NAME]
+             , prv.[PROVIDER_NAME_SUFFIX]
+             , prv.[PROVIDER_NAME_DEGREE]
+             , prv.[PROVIDER_GENERAL_COMMENTS]
+             , case when cast(prv.PROVIDER_QUICK_CODE as varchar(50)) = '' then null
+                    else cast(prv.PROVIDER_QUICK_CODE as varchar(50)) end
+             , case when cast(prv.[PROVIDER_REGISTRATION_NUM] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_REGISTRATION_NUM] as varchar(50)) end
+             , case when cast(prv.[PROVIDER_REGISRATION_NUM_AUTH] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_REGISRATION_NUM_AUTH] as varchar(50)) end
+             , case when cast(prv.[PROVIDER_STREET_ADDRESS_1] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_STREET_ADDRESS_1] as varchar(50)) end
+             , case when cast(prv.[PROVIDER_STREET_ADDRESS_2] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_STREET_ADDRESS_2] as varchar(50)) end
+             , case when cast(prv.[PROVIDER_CITY] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_CITY] as varchar(50)) end
+             , prv.[PROVIDER_STATE]
+             , prv.[PROVIDER_ZIP]
+             , prv.[PROVIDER_COUNTY]
+             , prv.[PROVIDER_COUNTRY]
+             , case when prv.[PROVIDER_ADDRESS_COMMENTS] = '' then null else prv.[PROVIDER_ADDRESS_COMMENTS] end
+             , case when prv.[PROVIDER_PHONE_WORK] = '' then null else prv.[PROVIDER_PHONE_WORK] end
+             , case when prv.[PROVIDER_PHONE_EXT_WORK] = '' then null else prv.[PROVIDER_PHONE_EXT_WORK] end
+             , case when cast(prv.[PROVIDER_EMAIL_WORK] as varchar(50)) = '' then null
+                    else cast(prv.[PROVIDER_EMAIL_WORK] as varchar(50)) end
+             , case when prv.[PROVIDER_PHONE_COMMENTS] = '' then null else prv.[PROVIDER_PHONE_COMMENTS] end
+             , prv.[PROVIDER_PHONE_CELL]
+             , prv.[PROVIDER_ENTRY_METHOD]
+             , prv.[PROVIDER_LAST_CHANGE_TIME]
+             , prv.[PROVIDER_ADD_TIME]
+             , prv.[PROVIDER_ADDED_BY]
+             , prv.[PROVIDER_LAST_UPDATED_BY]
+             , prv.[PROVIDER_STATE_CODE]
+             , case when prv.[PROVIDER_COUNTY_CODE] = '' then null else prv.[PROVIDER_COUNTY_CODE] end
+        FROM #temp_prv_table prv
+                 join dbo.nrt_provider_key k with (nolock) on prv.provider_uid = k.provider_uid
+        where prv.provider_key is null;
+
+        /* Logging */
+        set
+            @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
+
+        select 'Success';
+
+        COMMIT TRANSACTION;
+
+        SET @proc_step_name='SP_COMPLETE';
+        SET @proc_step_no = 4;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (     batch_id
+        ,[create_dttm]
+        ,[update_dttm]
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1])
+        VALUES (
+                 @batch_id
+               , current_timestamp
+               , current_timestamp
+               , @dataflow_name
+               , @package_name
+               , 'COMPLETE'
+               , @proc_step_no
+               , @proc_step_name
+               , 0
+               , LEFT (@id_list, 500)
+               );
+
+    END TRY
+
+    BEGIN CATCH
+
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+
+        DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+
+        /* Logging */
+        INSERT INTO [dbo].[job_flow_log]
+        (     batch_id
+        ,[create_dttm]
+        ,[update_dttm]
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1])
+        VALUES
+            (
+              @batch_id
+            , current_timestamp
+            , current_timestamp
             , @dataflow_name
             , @package_name
-            , 'START'
-            , @proc_step_no
-            , @proc_step_name
-            , @rowcount
+            , 'ERROR'
+            , @Proc_Step_no
+            , 'Step -' + CAST (@Proc_Step_no AS VARCHAR (3))+' -' + CAST (@ErrorMessage AS VARCHAR (500))
+            , 0
             , LEFT (@id_list, 500)
-        );
+            );
 
-    SET @proc_step_name='Update D_PROVIDER Dimension';
-	SET @proc_step_no = 2;
+        return @ErrorMessage;
 
-	/* D_Provider Update Operation */
-    BEGIN TRANSACTION;
-    update dbo.d_provider
-    set [PROVIDER_UID] = prv.[PROVIDER_UID], [PROVIDER_KEY] = prv.[PROVIDER_KEY], [PROVIDER_LOCAL_ID] = prv.[PROVIDER_LOCAL_ID], [PROVIDER_RECORD_STATUS] = prv.[PROVIDER_RECORD_STATUS], [PROVIDER_NAME_PREFIX] = prv.[PROVIDER_NAME_PREFIX], [PROVIDER_FIRST_NAME] = prv.[PROVIDER_FIRST_NAME], [PROVIDER_MIDDLE_NAME] = prv.[PROVIDER_MIDDLE_NAME], [PROVIDER_LAST_NAME] = prv.[PROVIDER_LAST_NAME], [PROVIDER_NAME_SUFFIX] = prv.[PROVIDER_NAME_SUFFIX], [PROVIDER_NAME_DEGREE] = prv.[PROVIDER_NAME_DEGREE], [PROVIDER_GENERAL_COMMENTS] = prv.[PROVIDER_GENERAL_COMMENTS], [PROVIDER_QUICK_CODE] = substring (prv.[PROVIDER_QUICK_CODE], 1, 50), [PROVIDER_REGISTRATION_NUM] = substring (prv.[PROVIDER_REGISTRATION_NUM], 1, 50), [PROVIDER_REGISRATION_NUM_AUTH] = substring (prv.[PROVIDER_REGISRATION_NUM_AUTH], 1, 50), [PROVIDER_STREET_ADDRESS_1] = substring (prv.[PROVIDER_STREET_ADDRESS_1], 1, 50), [PROVIDER_STREET_ADDRESS_2] = substring (prv.[PROVIDER_STREET_ADDRESS_2], 1, 50), [PROVIDER_CITY] = substring (prv.[PROVIDER_CITY], 1, 50), [PROVIDER_STATE] = prv.[PROVIDER_STATE], [PROVIDER_STATE_CODE] = prv.[PROVIDER_STATE_CODE], [PROVIDER_ZIP] = prv.[PROVIDER_ZIP], [PROVIDER_COUNTY] = prv.[PROVIDER_COUNTY], [PROVIDER_COUNTY_CODE] = prv.[PROVIDER_COUNTY_CODE], [PROVIDER_COUNTRY] = prv.[PROVIDER_COUNTRY], [PROVIDER_ADDRESS_COMMENTS] = prv.[PROVIDER_ADDRESS_COMMENTS], [PROVIDER_PHONE_WORK] = prv.[PROVIDER_PHONE_WORK], [PROVIDER_PHONE_EXT_WORK] = prv.[PROVIDER_PHONE_EXT_WORK], [PROVIDER_EMAIL_WORK] = substring (prv.[PROVIDER_EMAIL_WORK], 1, 50), [PROVIDER_PHONE_COMMENTS] = prv.[PROVIDER_PHONE_COMMENTS], [PROVIDER_PHONE_CELL] = prv.[PROVIDER_PHONE_CELL], [PROVIDER_ENTRY_METHOD] = prv.[PROVIDER_ENTRY_METHOD], [PROVIDER_LAST_CHANGE_TIME] = prv.[PROVIDER_LAST_CHANGE_TIME], [PROVIDER_ADD_TIME] = prv.[PROVIDER_ADD_TIME], [PROVIDER_ADDED_BY] = prv.[PROVIDER_ADDED_BY], [PROVIDER_LAST_UPDATED_BY] = prv.[PROVIDER_LAST_UPDATED_BY]
-    from #temp_prv_table prv
-        inner join dbo.d_provider p
-    on prv.provider_uid = p.provider_uid
-        and prv.provider_key = p.provider_key
-        and p.provider_key is not null;
-
-
-    /* Logging */
-    set @rowcount=@@rowcount
-	INSERT INTO [dbo].[job_flow_log]
-			(
-				batch_id
-				,[Dataflow_Name]
-				,[package_Name]
-				,[Status_Type]
-				,[step_number]
-				,[step_name]
-				,[row_count]
-				,[msg_description1]
-				)
-			VALUES (
-				@batch_id
-				,@dataflow_name
-				,@package_name
-				,'START'
-				,@proc_step_no
-				,@proc_step_name
-				,@rowcount
-				,LEFT(@id_list,500)
-				);
-
-	SET
-@proc_step_name='Insert into D_PROVIDER Dimension';
-	SET
-@proc_step_no = 3;
-
-	/* D_Provider Insert Operation */
-
-	-- delete from the key table to generate new keys for the resulting new data to be inserted
-delete from dbo.nrt_provider_key;
-insert into dbo.nrt_provider_key(provider_uid)
-select provider_uid
-from #temp_prv_table
-where provider_key is null
-order by provider_uid;
-
-insert into dbo.d_provider
-([ PROVIDER_UID]
- ,[PROVIDER_KEY]
- ,[PROVIDER_LOCAL_ID]
- ,[PROVIDER_RECORD_STATUS]
- ,[PROVIDER_NAME_PREFIX]
- ,[PROVIDER_FIRST_NAME]
- ,[PROVIDER_MIDDLE_NAME]
- ,[PROVIDER_LAST_NAME]
- ,[PROVIDER_NAME_SUFFIX]
- ,[PROVIDER_NAME_DEGREE]
- ,[PROVIDER_GENERAL_COMMENTS]
- ,[PROVIDER_QUICK_CODE]
- ,[PROVIDER_REGISTRATION_NUM]
- ,[PROVIDER_REGISRATION_NUM_AUTH]
- ,[PROVIDER_STREET_ADDRESS_1]
- ,[PROVIDER_STREET_ADDRESS_2]
- ,[PROVIDER_CITY]
- ,[PROVIDER_STATE]
- ,[PROVIDER_ZIP]
- ,[PROVIDER_COUNTY]
- ,[PROVIDER_COUNTRY]
- ,[PROVIDER_ADDRESS_COMMENTS]
- ,[PROVIDER_PHONE_WORK]
- ,[PROVIDER_PHONE_EXT_WORK]
- ,[PROVIDER_EMAIL_WORK]
- ,[PROVIDER_PHONE_COMMENTS]
- ,[PROVIDER_PHONE_CELL]
- ,[PROVIDER_ENTRY_METHOD]
- ,[PROVIDER_LAST_CHANGE_TIME]
- ,[PROVIDER_ADD_TIME]
- ,[PROVIDER_ADDED_BY]
- ,[PROVIDER_LAST_UPDATED_BY]
- ,[PROVIDER_STATE_CODE]
- ,[PROVIDER_COUNTY_CODE])
-SELECT prv.[PROVIDER_UID]
-     , k.[d_PROVIDER_KEY] as PROVIDER_KEY
-     , prv.[PROVIDER_LOCAL_ID]
-     , prv.[PROVIDER_RECORD_STATUS]
-     , prv.[PROVIDER_NAME_PREFIX]
-     , prv.[PROVIDER_FIRST_NAME]
-     , prv.[PROVIDER_MIDDLE_NAME]
-     , prv.[PROVIDER_LAST_NAME]
-     , prv.[PROVIDER_NAME_SUFFIX]
-     , prv.[PROVIDER_NAME_DEGREE]
-     , prv.[PROVIDER_GENERAL_COMMENTS]
-     , case when cast(prv.PROVIDER_QUICK_CODE as varchar(50)) = '' then null
-            else cast(prv.PROVIDER_QUICK_CODE as varchar(50)) end
-     , case when cast(prv.[PROVIDER_REGISTRATION_NUM] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_REGISTRATION_NUM] as varchar(50)) end
-     , case when cast(prv.[PROVIDER_REGISRATION_NUM_AUTH] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_REGISRATION_NUM_AUTH] as varchar(50)) end
-     , case when cast(prv.[PROVIDER_STREET_ADDRESS_1] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_STREET_ADDRESS_1] as varchar(50)) end
-     , case when cast(prv.[PROVIDER_STREET_ADDRESS_2] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_STREET_ADDRESS_2] as varchar(50)) end
-     , case when cast(prv.[PROVIDER_CITY] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_CITY] as varchar(50)) end
-     , prv.[PROVIDER_STATE]
-     , prv.[PROVIDER_ZIP]
-     , prv.[PROVIDER_COUNTY]
-     , prv.[PROVIDER_COUNTRY]
-     , case when prv.[PROVIDER_ADDRESS_COMMENTS] = '' then null else prv.[PROVIDER_ADDRESS_COMMENTS] end
-     , case when prv.[PROVIDER_PHONE_WORK] = '' then null else prv.[PROVIDER_PHONE_WORK] end
-     , case when prv.[PROVIDER_PHONE_EXT_WORK] = '' then null else prv.[PROVIDER_PHONE_EXT_WORK] end
-     , case when cast(prv.[PROVIDER_EMAIL_WORK] as varchar(50)) = '' then null
-            else cast(prv.[PROVIDER_EMAIL_WORK] as varchar(50)) end
-     , case when prv.[PROVIDER_PHONE_COMMENTS] = '' then null else prv.[PROVIDER_PHONE_COMMENTS] end
-     , prv.[PROVIDER_PHONE_CELL]
-     , prv.[PROVIDER_ENTRY_METHOD]
-     , prv.[PROVIDER_LAST_CHANGE_TIME]
-     , prv.[PROVIDER_ADD_TIME]
-     , prv.[PROVIDER_ADDED_BY]
-     , prv.[PROVIDER_LAST_UPDATED_BY]
-     , prv.[PROVIDER_STATE_CODE]
-     , case when prv.[PROVIDER_COUNTY_CODE] = '' then null else prv.[PROVIDER_COUNTY_CODE] end
-FROM #temp_prv_table prv
-         join dbo.nrt_provider_key k on prv.provider_uid = k.provider_uid
-where prv.provider_key is null;
-
-/* Logging */
-set
-@rowcount=@@rowcount
-		INSERT INTO [dbo].[job_flow_log]
-		(
-			batch_id
-			,[Dataflow_Name]
-			,[package_Name]
-			,[Status_Type]
-			,[step_number]
-			,[step_name]
-			,[row_count]
-			,[msg_description1]
-			)
-		VALUES (
-			@batch_id
-			,@dataflow_name
-			,@package_name
-			,'START'
-			,@proc_step_no
-			,@proc_step_name
-			,@rowcount
-			,LEFT(@id_list,500)
-			);
-
-select 'Success';
-
-COMMIT TRANSACTION;
-
-SET
-@proc_step_name='SP_COMPLETE';
-	SET
-@proc_step_no = 4;
-
-INSERT INTO [dbo].[job_flow_log]
-(     batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1])
-VALUES (
-    @batch_id
-        , current_timestamp
-        , current_timestamp
-        , @dataflow_name
-        , @package_name
-        , 'COMPLETE'
-        , @proc_step_no
-        , @proc_step_name
-        , 0
-        , LEFT (@id_list, 500)
-    );
-
-END TRY
-
-BEGIN CATCH
-
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
-
-    	DECLARE
-@ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
-
-    	/* Logging */
-INSERT INTO [dbo].[job_flow_log]
-(     batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1])
-VALUES
-    (
-    @batch_id
-        , current_timestamp
-        , current_timestamp
-        , @dataflow_name
-        , @package_name
-        , 'ERROR'
-        , @Proc_Step_no
-        , 'Step -' + CAST (@Proc_Step_no AS VARCHAR (3))+' -' + CAST (@ErrorMessage AS VARCHAR (500))
-        , 0
-        , LEFT (@id_list, 500)
-    );
-
-return @ErrorMessage;
-
-END CATCH
+    END CATCH
 
 END;

--- a/liquibase-service/src/main/resources/db/rdb/022-sp_nrt_patient_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/022-sp_nrt_patient_postprocessing-001.sql
@@ -2,561 +2,562 @@ CREATE OR ALTER PROCEDURE dbo.sp_nrt_patient_postprocessing @id_list nvarchar(ma
 AS
 BEGIN
 
-BEGIN TRY
+    BEGIN TRY
 
-	/* Logging */
-	declare @rowcount bigint;
-	declare @proc_step_no float = 0;
-	declare @proc_step_name varchar(200) = '';
-	declare @batch_id bigint;
-	declare @create_dttm datetime2(7) = current_timestamp ;
-	declare @update_dttm datetime2(7) = current_timestamp ;
-	declare @dataflow_name varchar(200) = 'Patient POST-Processing';
-	declare @package_name varchar(200) = 'RDB_MODERN.sp_nrt_patient_postprocessing';
+        /* Logging */
+        declare @rowcount bigint;
+        declare @proc_step_no float = 0;
+        declare @proc_step_name varchar(200) = '';
+        declare @batch_id bigint;
+        declare @create_dttm datetime2(7) = current_timestamp ;
+        declare @update_dttm datetime2(7) = current_timestamp ;
+        declare @dataflow_name varchar(200) = 'Patient POST-Processing';
+        declare @package_name varchar(200) = 'RDB_MODERN.sp_nrt_patient_postprocessing';
 
-	set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
+        set @batch_id = cast((format(getdate(),'yyMMddHHmmss')) as bigint);
 
-INSERT INTO [dbo].[job_flow_log]
-(
-      batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[msg_description1]
-    ,[row_count]
-)
-VALUES (
-    @batch_id
-        ,@create_dttm
-        ,@update_dttm
-        ,@dataflow_name
-        ,@package_name
-        ,'START'
-        ,0
-        ,'SP_Start'
-        ,LEFT(@id_list,500)
-        ,0
-    );
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[create_dttm]
+        ,[update_dttm]
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[msg_description1]
+        ,[row_count]
+        )
+        VALUES (
+                 @batch_id
+               ,@create_dttm
+               ,@update_dttm
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,0
+               ,'SP_Start'
+               ,LEFT(@id_list,500)
+               ,0
+               );
 
-SET @proc_step_name='Create PATIENT Temp tables for -'+ LEFT(@id_list,165);
-	SET @proc_step_no = 1;
+        SET @proc_step_name='Create PATIENT Temp tables for -'+ LEFT(@id_list,165);
+        SET @proc_step_no = 1;
 
-	/* Temp patient table creation*/
-select
-    PATIENT_KEY,
-    nrt.patient_uid AS PATIENT_UID,
-    nrt.patient_mpr_uid AS PATIENT_MPR_UID,
-    record_status AS PATIENT_RECORD_STATUS,
-    local_id AS PATIENT_LOCAL_ID,
-    case when rtrim(ltrim(general_comments)) = '' then null
-         else general_comments end AS PATIENT_GENERAL_COMMENTS,
-    first_name AS PATIENT_FIRST_NAME,
-    case when rtrim(ltrim(middle_name)) = '' then null
-         else middle_name end AS PATIENT_MIDDLE_NAME,
-    last_name AS PATIENT_LAST_NAME,
-    name_suffix AS PATIENT_NAME_SUFFIX,
-    alias_nickname AS PATIENT_ALIAS_NICKNAME,
-    case when rtrim(ltrim(street_address_1)) = '' then null
-         else street_address_1 end AS PATIENT_STREET_ADDRESS_1,
-    case when rtrim(ltrim(street_address_2)) = '' then null
-         else street_address_2 end AS PATIENT_STREET_ADDRESS_2,
-    case when rtrim(ltrim(city)) = '' then null
-         else city end AS PATIENT_CITY,
-    state AS PATIENT_STATE,
-    case when rtrim(ltrim(state_code)) = '' then null
-         else state_code end AS PATIENT_STATE_CODE,
-    case when rtrim(ltrim(zip)) = '' then null
-         else zip end AS PATIENT_ZIP,
-    case when rtrim(ltrim(county_code)) = '' then null
-         else county_code end AS PATIENT_COUNTY_CODE,
-    county AS PATIENT_COUNTY,
-    case when rtrim(ltrim(country)) = '' then null
-         else country end AS PATIENT_COUNTRY,
-    case when rtrim(ltrim(within_city_limits)) = '' then null
-         else within_city_limits end AS PATIENT_WITHIN_CITY_LIMITS,
-    case when rtrim(ltrim(phone_home)) = '' then null
-         else phone_home end AS PATIENT_PHONE_HOME,
-    case when rtrim(ltrim(phone_ext_home)) = '' then null
-         else phone_ext_home end AS PATIENT_PHONE_EXT_HOME,
-    case when rtrim(ltrim(phone_work)) = '' then null
-         else phone_work end AS PATIENT_PHONE_WORK,
-    case when rtrim(ltrim(phone_ext_work)) = '' then null
-         else phone_ext_work end AS PATIENT_PHONE_EXT_WORK,
-    phone_cell AS PATIENT_PHONE_CELL,
-    email AS PATIENT_EMAIL,
-    dob AS PATIENT_DOB,
-    age_reported AS PATIENT_AGE_REPORTED,
-    age_reported_unit AS PATIENT_AGE_REPORTED_UNIT,
-    birth_sex AS PATIENT_BIRTH_SEX,
-    current_sex AS PATIENT_CURRENT_SEX,
-    deceased_indicator AS PATIENT_DECEASED_INDICATOR,
-    deceased_date AS PATIENT_DECEASED_DATE,
-    marital_status AS PATIENT_MARITAL_STATUS,
-    case when rtrim(ltrim(ssn)) = '' then null
-         else ssn end AS PATIENT_SSN,
-    ethnicity AS PATIENT_ETHNICITY,
-    race_calculated AS PATIENT_RACE_CALCULATED,
-    race_calc_details AS PATIENT_RACE_CALC_DETAILS,
-    race_amer_ind_1 AS PATIENT_RACE_AMER_IND_1,
-    race_amer_ind_2 AS PATIENT_RACE_AMER_IND_2,
-    race_amer_ind_3 AS PATIENT_RACE_AMER_IND_3,
-    race_amer_ind_gt3_ind AS PATIENT_RACE_AMER_IND_GT3_IND,
-    race_amer_ind_all AS PATIENT_RACE_AMER_IND_ALL,
-    race_asian_1 AS PATIENT_RACE_ASIAN_1,
-    race_asian_2 AS PATIENT_RACE_ASIAN_2,
-    race_asian_3 AS PATIENT_RACE_ASIAN_3,
-    race_asian_gt3_ind AS PATIENT_RACE_ASIAN_GT3_IND,
-    race_asian_all AS PATIENT_RACE_ASIAN_ALL,
-    race_black_1 AS PATIENT_RACE_BLACK_1,
-    race_black_2 AS PATIENT_RACE_BLACK_2,
-    race_black_3 AS PATIENT_RACE_BLACK_3,
-    race_black_gt3_ind AS PATIENT_RACE_BLACK_GT3_IND,
-    race_black_all AS PATIENT_RACE_BLACK_ALL,
-    race_nat_hi_1 AS PATIENT_RACE_NAT_HI_1,
-    race_nat_hi_2 AS PATIENT_RACE_NAT_HI_2,
-    race_nat_hi_3 AS PATIENT_RACE_NAT_HI_3,
-    race_nat_hi_gt3_ind AS PATIENT_RACE_NAT_HI_GT3_IND,
-    race_nat_hi_all AS PATIENT_RACE_NAT_HI_ALL,
-    race_white_1 AS PATIENT_RACE_WHITE_1,
-    race_white_2 AS PATIENT_RACE_WHITE_2,
-    race_white_3 AS PATIENT_RACE_WHITE_3,
-    race_white_gt3_ind AS PATIENT_RACE_WHITE_GT3_IND,
-    race_white_all AS PATIENT_RACE_WHITE_ALL,
-    nrt.patient_number AS PATIENT_NUMBER,
-    nrt.patient_number_auth AS PATIENT_NUMBER_AUTH,
-    entry_method AS PATIENT_ENTRY_METHOD,
-    speaks_english AS PATIENT_SPEAKS_ENGLISH,
-    unk_ethnic_rsn AS PATIENT_UNK_ETHNIC_RSN,
-    curr_sex_unk_rsn AS PATIENT_CURR_SEX_UNK_RSN,
-    preferred_gender AS PATIENT_PREFERRED_GENDER,
-    addl_gender_info AS PATIENT_ADDL_GENDER_INFO,
-    census_tract AS PATIENT_CENSUS_TRACT,
-    race_all AS PATIENT_RACE_ALL,
-    birth_country AS PATIENT_BIRTH_COUNTRY,
-    primary_occupation AS PATIENT_PRIMARY_OCCUPATION,
-    primary_language AS PATIENT_PRIMARY_LANGUAGE,
-    add_user_name AS PATIENT_ADDED_BY,
-    add_time AS PATIENT_ADD_TIME,
-    last_chg_user_name AS PATIENT_LAST_UPDATED_BY,
-    last_chg_time AS PATIENT_LAST_CHANGE_TIME
-into #temp_patient_table
-from dbo.nrt_patient nrt
-         left join dbo.d_patient p on p.patient_uid = nrt.patient_uid
-where
-    nrt.patient_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
+        /* Temp patient table creation*/
+        select
+            PATIENT_KEY,
+            nrt.patient_uid AS PATIENT_UID,
+            nrt.patient_mpr_uid AS PATIENT_MPR_UID,
+            record_status AS PATIENT_RECORD_STATUS,
+            local_id AS PATIENT_LOCAL_ID,
+            case when rtrim(ltrim(general_comments)) = '' then null
+                 else general_comments end AS PATIENT_GENERAL_COMMENTS,
+            first_name AS PATIENT_FIRST_NAME,
+            case when rtrim(ltrim(middle_name)) = '' then null
+                 else middle_name end AS PATIENT_MIDDLE_NAME,
+            last_name AS PATIENT_LAST_NAME,
+            name_suffix AS PATIENT_NAME_SUFFIX,
+            alias_nickname AS PATIENT_ALIAS_NICKNAME,
+            case when rtrim(ltrim(street_address_1)) = '' then null
+                 else street_address_1 end AS PATIENT_STREET_ADDRESS_1,
+            case when rtrim(ltrim(street_address_2)) = '' then null
+                 else street_address_2 end AS PATIENT_STREET_ADDRESS_2,
+            case when rtrim(ltrim(city)) = '' then null
+                 else city end AS PATIENT_CITY,
+            state AS PATIENT_STATE,
+            case when rtrim(ltrim(state_code)) = '' then null
+                 else state_code end AS PATIENT_STATE_CODE,
+            case when rtrim(ltrim(zip)) = '' then null
+                 else zip end AS PATIENT_ZIP,
+            case when rtrim(ltrim(county_code)) = '' then null
+                 else county_code end AS PATIENT_COUNTY_CODE,
+            county AS PATIENT_COUNTY,
+            case when rtrim(ltrim(country)) = '' then null
+                 else country end AS PATIENT_COUNTRY,
+            case when rtrim(ltrim(within_city_limits)) = '' then null
+                 else within_city_limits end AS PATIENT_WITHIN_CITY_LIMITS,
+            case when rtrim(ltrim(phone_home)) = '' then null
+                 else phone_home end AS PATIENT_PHONE_HOME,
+            case when rtrim(ltrim(phone_ext_home)) = '' then null
+                 else phone_ext_home end AS PATIENT_PHONE_EXT_HOME,
+            case when rtrim(ltrim(phone_work)) = '' then null
+                 else phone_work end AS PATIENT_PHONE_WORK,
+            case when rtrim(ltrim(phone_ext_work)) = '' then null
+                 else phone_ext_work end AS PATIENT_PHONE_EXT_WORK,
+            phone_cell AS PATIENT_PHONE_CELL,
+            email AS PATIENT_EMAIL,
+            dob AS PATIENT_DOB,
+            age_reported AS PATIENT_AGE_REPORTED,
+            age_reported_unit AS PATIENT_AGE_REPORTED_UNIT,
+            birth_sex AS PATIENT_BIRTH_SEX,
+            current_sex AS PATIENT_CURRENT_SEX,
+            deceased_indicator AS PATIENT_DECEASED_INDICATOR,
+            deceased_date AS PATIENT_DECEASED_DATE,
+            marital_status AS PATIENT_MARITAL_STATUS,
+            case when rtrim(ltrim(ssn)) = '' then null
+                 else ssn end AS PATIENT_SSN,
+            ethnicity AS PATIENT_ETHNICITY,
+            race_calculated AS PATIENT_RACE_CALCULATED,
+            race_calc_details AS PATIENT_RACE_CALC_DETAILS,
+            race_amer_ind_1 AS PATIENT_RACE_AMER_IND_1,
+            race_amer_ind_2 AS PATIENT_RACE_AMER_IND_2,
+            race_amer_ind_3 AS PATIENT_RACE_AMER_IND_3,
+            race_amer_ind_gt3_ind AS PATIENT_RACE_AMER_IND_GT3_IND,
+            race_amer_ind_all AS PATIENT_RACE_AMER_IND_ALL,
+            race_asian_1 AS PATIENT_RACE_ASIAN_1,
+            race_asian_2 AS PATIENT_RACE_ASIAN_2,
+            race_asian_3 AS PATIENT_RACE_ASIAN_3,
+            race_asian_gt3_ind AS PATIENT_RACE_ASIAN_GT3_IND,
+            race_asian_all AS PATIENT_RACE_ASIAN_ALL,
+            race_black_1 AS PATIENT_RACE_BLACK_1,
+            race_black_2 AS PATIENT_RACE_BLACK_2,
+            race_black_3 AS PATIENT_RACE_BLACK_3,
+            race_black_gt3_ind AS PATIENT_RACE_BLACK_GT3_IND,
+            race_black_all AS PATIENT_RACE_BLACK_ALL,
+            race_nat_hi_1 AS PATIENT_RACE_NAT_HI_1,
+            race_nat_hi_2 AS PATIENT_RACE_NAT_HI_2,
+            race_nat_hi_3 AS PATIENT_RACE_NAT_HI_3,
+            race_nat_hi_gt3_ind AS PATIENT_RACE_NAT_HI_GT3_IND,
+            race_nat_hi_all AS PATIENT_RACE_NAT_HI_ALL,
+            race_white_1 AS PATIENT_RACE_WHITE_1,
+            race_white_2 AS PATIENT_RACE_WHITE_2,
+            race_white_3 AS PATIENT_RACE_WHITE_3,
+            race_white_gt3_ind AS PATIENT_RACE_WHITE_GT3_IND,
+            race_white_all AS PATIENT_RACE_WHITE_ALL,
+            nrt.patient_number AS PATIENT_NUMBER,
+            nrt.patient_number_auth AS PATIENT_NUMBER_AUTH,
+            entry_method AS PATIENT_ENTRY_METHOD,
+            speaks_english AS PATIENT_SPEAKS_ENGLISH,
+            unk_ethnic_rsn AS PATIENT_UNK_ETHNIC_RSN,
+            curr_sex_unk_rsn AS PATIENT_CURR_SEX_UNK_RSN,
+            preferred_gender AS PATIENT_PREFERRED_GENDER,
+            addl_gender_info AS PATIENT_ADDL_GENDER_INFO,
+            case when rtrim(ltrim(census_tract)) = '' then null
+                 else census_tract end AS PATIENT_CENSUS_TRACT,
+            race_all AS PATIENT_RACE_ALL,
+            birth_country AS PATIENT_BIRTH_COUNTRY,
+            primary_occupation AS PATIENT_PRIMARY_OCCUPATION,
+            primary_language AS PATIENT_PRIMARY_LANGUAGE,
+            add_user_name AS PATIENT_ADDED_BY,
+            add_time AS PATIENT_ADD_TIME,
+            last_chg_user_name AS PATIENT_LAST_UPDATED_BY,
+            last_chg_time AS PATIENT_LAST_CHANGE_TIME
+        into #temp_patient_table
+        from dbo.nrt_patient nrt
+                 left join dbo.d_patient p with (nolock) on p.patient_uid = nrt.patient_uid
+        where
+            nrt.patient_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
 
-/* Logging */
-set @rowcount=@@rowcount
-	INSERT INTO [dbo].[job_flow_log] (
-			batch_id
-			,[Dataflow_Name]
-			,[package_Name]
-			,[Status_Type]
-			,[step_number]
-			,[step_name]
-			,[row_count]
-			,[msg_description1]
-			)
-		VALUES (
-			@batch_id
-			,@dataflow_name
-			,@package_name
-			,'START'
-			,@proc_step_no
-			,@proc_step_name
-			,@rowcount
-			,LEFT(@id_list,500)
-			);
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+                                         ,[Dataflow_Name]
+                                         ,[package_Name]
+                                         ,[Status_Type]
+                                         ,[step_number]
+                                         ,[step_name]
+                                         ,[row_count]
+                                         ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
-   	SET @proc_step_name='Update D_PATIENT Dimension';
-	SET @proc_step_no = 2;
+        SET @proc_step_name='Update D_PATIENT Dimension';
+        SET @proc_step_no = 2;
 
-	/* D_Patient Update Operation */
-BEGIN TRANSACTION;
-update dbo.d_patient
-set	[PATIENT_KEY]	=	tpt.[PATIENT_KEY]	,
-    [PATIENT_MPR_UID]	=	tpt.[PATIENT_MPR_UID]	,
-    [PATIENT_RECORD_STATUS]	=	tpt.[PATIENT_RECORD_STATUS]	,
-    [PATIENT_LOCAL_ID]	=	tpt.[PATIENT_LOCAL_ID]	,
-    [PATIENT_GENERAL_COMMENTS]	=	 substring(tpt.[PATIENT_GENERAL_COMMENTS] ,1,2000)	,
-    [PATIENT_FIRST_NAME]	=	tpt.[PATIENT_FIRST_NAME]	,
-    [PATIENT_MIDDLE_NAME]	=	tpt.[PATIENT_MIDDLE_NAME]	,
-    [PATIENT_LAST_NAME]	=	tpt.[PATIENT_LAST_NAME]	,
-    [PATIENT_NAME_SUFFIX]	=	tpt.[PATIENT_NAME_SUFFIX]	,
-    [PATIENT_ALIAS_NICKNAME]	=	tpt.[PATIENT_ALIAS_NICKNAME]	,
-    [PATIENT_STREET_ADDRESS_1]	=	substring(tpt.[PATIENT_STREET_ADDRESS_1],1,50)	,
-    [PATIENT_STREET_ADDRESS_2]	=	substring(tpt.[PATIENT_STREET_ADDRESS_2],1,50)	,
-    [PATIENT_CITY]	=	 substring(tpt.[PATIENT_CITY] ,1,50)	,
-    [PATIENT_STATE]	=	tpt.[PATIENT_STATE]	,
-    [PATIENT_STATE_CODE]	=	tpt.[PATIENT_STATE_CODE]	,
-    [PATIENT_ZIP]	=	tpt.[PATIENT_ZIP]	,
-    [PATIENT_COUNTY]	=		substring(tpt.[PATIENT_COUNTY] ,1,50),
-    [PATIENT_COUNTY_CODE]	=	tpt.[PATIENT_COUNTY_CODE]	,
-    [PATIENT_COUNTRY]	=	tpt.[PATIENT_COUNTRY]	,
-    [PATIENT_WITHIN_CITY_LIMITS]	=	tpt.[PATIENT_WITHIN_CITY_LIMITS]	,
-    [PATIENT_PHONE_HOME]	=	tpt.[PATIENT_PHONE_HOME]	,
-    [PATIENT_PHONE_EXT_HOME]	=	tpt.[PATIENT_PHONE_EXT_HOME]	,
-    [PATIENT_PHONE_WORK]	=	tpt.[PATIENT_PHONE_WORK]	,
-    [PATIENT_PHONE_EXT_WORK]	=	tpt.[PATIENT_PHONE_EXT_WORK]	,
-    [PATIENT_PHONE_CELL]	=	tpt.[PATIENT_PHONE_CELL]	,
-    [PATIENT_EMAIL]	=	tpt.[PATIENT_EMAIL]	,
-    [PATIENT_DOB]	=	tpt.[PATIENT_DOB]	,
-    [PATIENT_AGE_REPORTED]	=		tpt.[PATIENT_AGE_REPORTED],
-    [PATIENT_AGE_REPORTED_UNIT]	=	 substring(tpt.[PATIENT_AGE_REPORTED_UNIT] ,1,20)	,
-    [PATIENT_BIRTH_SEX]	=	 substring(tpt.[PATIENT_BIRTH_SEX] ,1,50)	,
-    [PATIENT_CURRENT_SEX]	=		substring(tpt.[PATIENT_CURRENT_SEX] ,1,50),
-    [PATIENT_DECEASED_INDICATOR]	=		substring(tpt.[PATIENT_DECEASED_INDICATOR] ,1,50),
-    [PATIENT_DECEASED_DATE]	=	tpt.[PATIENT_DECEASED_DATE]	,
-    [PATIENT_MARITAL_STATUS]	=		substring(tpt.[PATIENT_MARITAL_STATUS] ,1,50),
-    [PATIENT_SSN]	=	substring(tpt.[PATIENT_SSN] ,1,50)	,
-    [PATIENT_ETHNICITY]	=		substring(tpt.[PATIENT_ETHNICITY] ,1,50),
-    [PATIENT_RACE_CALCULATED]	=		substring(tpt.[PATIENT_RACE_CALCULATED] ,1,50),
-    [PATIENT_RACE_CALC_DETAILS]	=	tpt.[PATIENT_RACE_CALC_DETAILS]	,
-    [PATIENT_RACE_AMER_IND_1]	=	tpt.[PATIENT_RACE_AMER_IND_1]	,
-    [PATIENT_RACE_AMER_IND_2]	=	tpt.[PATIENT_RACE_AMER_IND_2]	,
-    [PATIENT_RACE_AMER_IND_3]	=	tpt.[PATIENT_RACE_AMER_IND_3]	,
-    [PATIENT_RACE_AMER_IND_GT3_IND]	=	tpt.[PATIENT_RACE_AMER_IND_GT3_IND]	,
-    [PATIENT_RACE_AMER_IND_ALL]	=	tpt.[PATIENT_RACE_AMER_IND_ALL]	,
-    [PATIENT_RACE_ASIAN_1]	=	tpt.[PATIENT_RACE_ASIAN_1]	,
-    [PATIENT_RACE_ASIAN_2]	=	tpt.[PATIENT_RACE_ASIAN_2]	,
-    [PATIENT_RACE_ASIAN_3]	=	tpt.[PATIENT_RACE_ASIAN_3]	,
-    [PATIENT_RACE_ASIAN_GT3_IND]	=	tpt.[PATIENT_RACE_ASIAN_GT3_IND]	,
-    [PATIENT_RACE_ASIAN_ALL]	=	tpt.[PATIENT_RACE_ASIAN_ALL]	,
-    [PATIENT_RACE_BLACK_1]	=	tpt.[PATIENT_RACE_BLACK_1]	,
-    [PATIENT_RACE_BLACK_2]	=	tpt.[PATIENT_RACE_BLACK_2]	,
-    [PATIENT_RACE_BLACK_3]	=	tpt.[PATIENT_RACE_BLACK_3]	,
-    [PATIENT_RACE_BLACK_GT3_IND]	=	tpt.[PATIENT_RACE_BLACK_GT3_IND]	,
-    [PATIENT_RACE_BLACK_ALL]	=	tpt.[PATIENT_RACE_BLACK_ALL]	,
-    [PATIENT_RACE_NAT_HI_1]	=	tpt.[PATIENT_RACE_NAT_HI_1]	,
-    [PATIENT_RACE_NAT_HI_2]	=	tpt.[PATIENT_RACE_NAT_HI_2]	,
-    [PATIENT_RACE_NAT_HI_3]	=	tpt.[PATIENT_RACE_NAT_HI_3]	,
-    [PATIENT_RACE_NAT_HI_GT3_IND]	=	tpt.[PATIENT_RACE_NAT_HI_GT3_IND]	,
-    [PATIENT_RACE_NAT_HI_ALL]	=	tpt.[PATIENT_RACE_NAT_HI_ALL]	,
-    [PATIENT_RACE_WHITE_1]	=	tpt.[PATIENT_RACE_WHITE_1]	,
-    [PATIENT_RACE_WHITE_2]	=	tpt.[PATIENT_RACE_WHITE_2]	,
-    [PATIENT_RACE_WHITE_3]	=	tpt.[PATIENT_RACE_WHITE_3]	,
-    [PATIENT_RACE_WHITE_GT3_IND]	=	tpt.[PATIENT_RACE_WHITE_GT3_IND]	,
-    [PATIENT_RACE_WHITE_ALL]	=	tpt.[PATIENT_RACE_WHITE_ALL]	,
-    [PATIENT_NUMBER]	=		substring(tpt.[PATIENT_NUMBER] ,1,50),
-    [PATIENT_NUMBER_AUTH]	=	tpt.[PATIENT_NUMBER_AUTH]	,
-    [PATIENT_ENTRY_METHOD]	=	tpt.[PATIENT_ENTRY_METHOD]	,
-    [PATIENT_LAST_CHANGE_TIME]	=	tpt.[PATIENT_LAST_CHANGE_TIME]	,
-    [PATIENT_ADD_TIME]	=	tpt.[PATIENT_ADD_TIME]	,
-    [PATIENT_ADDED_BY]	=	tpt.[PATIENT_ADDED_BY]	,
-    [PATIENT_LAST_UPDATED_BY]	=	tpt.[PATIENT_LAST_UPDATED_BY]	,
-    [PATIENT_SPEAKS_ENGLISH]	=	tpt.[PATIENT_SPEAKS_ENGLISH]	,
-    [PATIENT_UNK_ETHNIC_RSN]	=	tpt.[PATIENT_UNK_ETHNIC_RSN]	,
-    [PATIENT_CURR_SEX_UNK_RSN]	=	tpt.[PATIENT_CURR_SEX_UNK_RSN]	,
-    [PATIENT_PREFERRED_GENDER]	=	tpt.[PATIENT_PREFERRED_GENDER]	,
-    [PATIENT_ADDL_GENDER_INFO]	=	tpt.[PATIENT_ADDL_GENDER_INFO]	,
-    [PATIENT_CENSUS_TRACT]	=	tpt.[PATIENT_CENSUS_TRACT]	,
-    [PATIENT_RACE_ALL]	=	tpt.[PATIENT_RACE_ALL]	,
-    [PATIENT_BIRTH_COUNTRY]	=	 substring(tpt.[PATIENT_BIRTH_COUNTRY] ,1,50)	,
-    [PATIENT_PRIMARY_OCCUPATION]	=		substring(tpt.[PATIENT_PRIMARY_OCCUPATION] ,1,50),
-    [PATIENT_PRIMARY_LANGUAGE]	=		substring(tpt.[PATIENT_PRIMARY_LANGUAGE] ,1,50)
-from #temp_patient_table tpt
-    inner join dbo.d_patient p on tpt.patient_uid = p.patient_uid
-    and tpt.patient_key = p.patient_key
-    and p.patient_key is not null;
+        /* D_Patient Update Operation */
+        BEGIN TRANSACTION;
+        update dbo.d_patient
+        set	[PATIENT_KEY]	=	tpt.[PATIENT_KEY]	,
+               [PATIENT_MPR_UID]	=	tpt.[PATIENT_MPR_UID]	,
+               [PATIENT_RECORD_STATUS]	=	tpt.[PATIENT_RECORD_STATUS]	,
+               [PATIENT_LOCAL_ID]	=	tpt.[PATIENT_LOCAL_ID]	,
+               [PATIENT_GENERAL_COMMENTS]	=	 substring(tpt.[PATIENT_GENERAL_COMMENTS] ,1,2000)	,
+               [PATIENT_FIRST_NAME]	=	tpt.[PATIENT_FIRST_NAME]	,
+               [PATIENT_MIDDLE_NAME]	=	tpt.[PATIENT_MIDDLE_NAME]	,
+               [PATIENT_LAST_NAME]	=	tpt.[PATIENT_LAST_NAME]	,
+               [PATIENT_NAME_SUFFIX]	=	tpt.[PATIENT_NAME_SUFFIX]	,
+               [PATIENT_ALIAS_NICKNAME]	=	tpt.[PATIENT_ALIAS_NICKNAME]	,
+               [PATIENT_STREET_ADDRESS_1]	=	substring(tpt.[PATIENT_STREET_ADDRESS_1],1,50)	,
+               [PATIENT_STREET_ADDRESS_2]	=	substring(tpt.[PATIENT_STREET_ADDRESS_2],1,50)	,
+               [PATIENT_CITY]	=	 substring(tpt.[PATIENT_CITY] ,1,50)	,
+               [PATIENT_STATE]	=	tpt.[PATIENT_STATE]	,
+               [PATIENT_STATE_CODE]	=	tpt.[PATIENT_STATE_CODE]	,
+               [PATIENT_ZIP]	=	tpt.[PATIENT_ZIP]	,
+               [PATIENT_COUNTY]	=		substring(tpt.[PATIENT_COUNTY] ,1,50),
+               [PATIENT_COUNTY_CODE]	=	tpt.[PATIENT_COUNTY_CODE]	,
+               [PATIENT_COUNTRY]	=	tpt.[PATIENT_COUNTRY]	,
+               [PATIENT_WITHIN_CITY_LIMITS]	=	tpt.[PATIENT_WITHIN_CITY_LIMITS]	,
+               [PATIENT_PHONE_HOME]	=	tpt.[PATIENT_PHONE_HOME]	,
+               [PATIENT_PHONE_EXT_HOME]	=	tpt.[PATIENT_PHONE_EXT_HOME]	,
+               [PATIENT_PHONE_WORK]	=	tpt.[PATIENT_PHONE_WORK]	,
+               [PATIENT_PHONE_EXT_WORK]	=	tpt.[PATIENT_PHONE_EXT_WORK]	,
+               [PATIENT_PHONE_CELL]	=	tpt.[PATIENT_PHONE_CELL]	,
+               [PATIENT_EMAIL]	=	tpt.[PATIENT_EMAIL]	,
+               [PATIENT_DOB]	=	tpt.[PATIENT_DOB]	,
+               [PATIENT_AGE_REPORTED]	=		tpt.[PATIENT_AGE_REPORTED],
+               [PATIENT_AGE_REPORTED_UNIT]	=	 substring(tpt.[PATIENT_AGE_REPORTED_UNIT] ,1,20)	,
+               [PATIENT_BIRTH_SEX]	=	 substring(tpt.[PATIENT_BIRTH_SEX] ,1,50)	,
+               [PATIENT_CURRENT_SEX]	=		substring(tpt.[PATIENT_CURRENT_SEX] ,1,50),
+               [PATIENT_DECEASED_INDICATOR]	=		substring(tpt.[PATIENT_DECEASED_INDICATOR] ,1,50),
+               [PATIENT_DECEASED_DATE]	=	tpt.[PATIENT_DECEASED_DATE]	,
+               [PATIENT_MARITAL_STATUS]	=		substring(tpt.[PATIENT_MARITAL_STATUS] ,1,50),
+               [PATIENT_SSN]	=	substring(tpt.[PATIENT_SSN] ,1,50)	,
+               [PATIENT_ETHNICITY]	=		substring(tpt.[PATIENT_ETHNICITY] ,1,50),
+               [PATIENT_RACE_CALCULATED]	=		substring(tpt.[PATIENT_RACE_CALCULATED] ,1,50),
+               [PATIENT_RACE_CALC_DETAILS]	=	tpt.[PATIENT_RACE_CALC_DETAILS]	,
+               [PATIENT_RACE_AMER_IND_1]	=	tpt.[PATIENT_RACE_AMER_IND_1]	,
+               [PATIENT_RACE_AMER_IND_2]	=	tpt.[PATIENT_RACE_AMER_IND_2]	,
+               [PATIENT_RACE_AMER_IND_3]	=	tpt.[PATIENT_RACE_AMER_IND_3]	,
+               [PATIENT_RACE_AMER_IND_GT3_IND]	=	tpt.[PATIENT_RACE_AMER_IND_GT3_IND]	,
+               [PATIENT_RACE_AMER_IND_ALL]	=	tpt.[PATIENT_RACE_AMER_IND_ALL]	,
+               [PATIENT_RACE_ASIAN_1]	=	tpt.[PATIENT_RACE_ASIAN_1]	,
+               [PATIENT_RACE_ASIAN_2]	=	tpt.[PATIENT_RACE_ASIAN_2]	,
+               [PATIENT_RACE_ASIAN_3]	=	tpt.[PATIENT_RACE_ASIAN_3]	,
+               [PATIENT_RACE_ASIAN_GT3_IND]	=	tpt.[PATIENT_RACE_ASIAN_GT3_IND]	,
+               [PATIENT_RACE_ASIAN_ALL]	=	tpt.[PATIENT_RACE_ASIAN_ALL]	,
+               [PATIENT_RACE_BLACK_1]	=	tpt.[PATIENT_RACE_BLACK_1]	,
+               [PATIENT_RACE_BLACK_2]	=	tpt.[PATIENT_RACE_BLACK_2]	,
+               [PATIENT_RACE_BLACK_3]	=	tpt.[PATIENT_RACE_BLACK_3]	,
+               [PATIENT_RACE_BLACK_GT3_IND]	=	tpt.[PATIENT_RACE_BLACK_GT3_IND]	,
+               [PATIENT_RACE_BLACK_ALL]	=	tpt.[PATIENT_RACE_BLACK_ALL]	,
+               [PATIENT_RACE_NAT_HI_1]	=	tpt.[PATIENT_RACE_NAT_HI_1]	,
+               [PATIENT_RACE_NAT_HI_2]	=	tpt.[PATIENT_RACE_NAT_HI_2]	,
+               [PATIENT_RACE_NAT_HI_3]	=	tpt.[PATIENT_RACE_NAT_HI_3]	,
+               [PATIENT_RACE_NAT_HI_GT3_IND]	=	tpt.[PATIENT_RACE_NAT_HI_GT3_IND]	,
+               [PATIENT_RACE_NAT_HI_ALL]	=	tpt.[PATIENT_RACE_NAT_HI_ALL]	,
+               [PATIENT_RACE_WHITE_1]	=	tpt.[PATIENT_RACE_WHITE_1]	,
+               [PATIENT_RACE_WHITE_2]	=	tpt.[PATIENT_RACE_WHITE_2]	,
+               [PATIENT_RACE_WHITE_3]	=	tpt.[PATIENT_RACE_WHITE_3]	,
+               [PATIENT_RACE_WHITE_GT3_IND]	=	tpt.[PATIENT_RACE_WHITE_GT3_IND]	,
+               [PATIENT_RACE_WHITE_ALL]	=	tpt.[PATIENT_RACE_WHITE_ALL]	,
+               [PATIENT_NUMBER]	=		substring(tpt.[PATIENT_NUMBER] ,1,50),
+               [PATIENT_NUMBER_AUTH]	=	tpt.[PATIENT_NUMBER_AUTH]	,
+               [PATIENT_ENTRY_METHOD]	=	tpt.[PATIENT_ENTRY_METHOD]	,
+               [PATIENT_LAST_CHANGE_TIME]	=	tpt.[PATIENT_LAST_CHANGE_TIME]	,
+               [PATIENT_ADD_TIME]	=	tpt.[PATIENT_ADD_TIME]	,
+               [PATIENT_ADDED_BY]	=	tpt.[PATIENT_ADDED_BY]	,
+               [PATIENT_LAST_UPDATED_BY]	=	tpt.[PATIENT_LAST_UPDATED_BY]	,
+               [PATIENT_SPEAKS_ENGLISH]	=	tpt.[PATIENT_SPEAKS_ENGLISH]	,
+               [PATIENT_UNK_ETHNIC_RSN]	=	tpt.[PATIENT_UNK_ETHNIC_RSN]	,
+               [PATIENT_CURR_SEX_UNK_RSN]	=	tpt.[PATIENT_CURR_SEX_UNK_RSN]	,
+               [PATIENT_PREFERRED_GENDER]	=	tpt.[PATIENT_PREFERRED_GENDER]	,
+               [PATIENT_ADDL_GENDER_INFO]	=	tpt.[PATIENT_ADDL_GENDER_INFO]	,
+               [PATIENT_CENSUS_TRACT]	=	tpt.[PATIENT_CENSUS_TRACT]	,
+               [PATIENT_RACE_ALL]	=	tpt.[PATIENT_RACE_ALL]	,
+               [PATIENT_BIRTH_COUNTRY]	=	 substring(tpt.[PATIENT_BIRTH_COUNTRY] ,1,50)	,
+               [PATIENT_PRIMARY_OCCUPATION]	=		substring(tpt.[PATIENT_PRIMARY_OCCUPATION] ,1,50),
+               [PATIENT_PRIMARY_LANGUAGE]	=		substring(tpt.[PATIENT_PRIMARY_LANGUAGE] ,1,50)
+        from #temp_patient_table tpt
+                 inner join dbo.d_patient p with (nolock) on tpt.patient_uid = p.patient_uid
+            and tpt.patient_key = p.patient_key
+            and p.patient_key is not null;
 
-/* Logging */
-set @rowcount=@@rowcount
-	INSERT INTO [dbo].[job_flow_log] (
-				batch_id
-				,[Dataflow_Name]
-				,[package_Name]
-				,[Status_Type]
-				,[step_number]
-				,[step_name]
-				,[row_count]
-				,[msg_description1]
-				)
-			VALUES (
-				@batch_id
-				,@dataflow_name
-				,@package_name
-				,'START'
-				,@proc_step_no
-				,@proc_step_name
-				,@rowcount
-				,LEFT(@id_list,500)
-				);
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log] (
+               batch_id
+             ,[Dataflow_Name]
+             ,[package_Name]
+             ,[Status_Type]
+             ,[step_number]
+             ,[step_name]
+             ,[row_count]
+             ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
-	SET @proc_step_name='Insert into D_PATIENT Dimension';
-	SET @proc_step_no = 3;
+        SET @proc_step_name='Insert into D_PATIENT Dimension';
+        SET @proc_step_no = 3;
 
-	/* D_Patient Insert Operation */
-	-- declare @max_key bigint;
-	-- select  @max_key = max(patient_key) from dbo.d_patient;
+        /* D_Patient Insert Operation */
+        -- declare @max_key bigint;
+        -- select  @max_key = max(patient_key) from dbo.d_patient;
 
-	-- delete from the key table to generate new keys for the resulting new data to be inserted
-delete from dbo.nrt_patient_key ;
-insert into dbo.nrt_patient_key(patient_uid)
-select patient_uid from #temp_patient_table where patient_key is null order by patient_uid;
+        -- delete from the key table to generate new keys for the resulting new data to be inserted
+        delete from dbo.nrt_patient_key ;
+        insert into dbo.nrt_patient_key(patient_uid)
+        select patient_uid from #temp_patient_table where patient_key is null order by patient_uid;
 
-insert into dbo.d_patient
-([PATIENT_KEY]
- ,[PATIENT_MPR_UID]
- ,[PATIENT_RECORD_STATUS]
- ,[PATIENT_LOCAL_ID]
- ,[PATIENT_GENERAL_COMMENTS]
- ,[PATIENT_FIRST_NAME]
- ,[PATIENT_MIDDLE_NAME]
- ,[PATIENT_LAST_NAME]
- ,[PATIENT_NAME_SUFFIX]
- ,[PATIENT_ALIAS_NICKNAME]
- ,[PATIENT_STREET_ADDRESS_1]
- ,[PATIENT_STREET_ADDRESS_2]
- ,[PATIENT_CITY]
- ,[PATIENT_STATE]
- ,[PATIENT_STATE_CODE]
- ,[PATIENT_ZIP]
- ,[PATIENT_COUNTY]
- ,[PATIENT_COUNTY_CODE]
- ,[PATIENT_COUNTRY]
- ,[PATIENT_WITHIN_CITY_LIMITS]
- ,[PATIENT_PHONE_HOME]
- ,[PATIENT_PHONE_EXT_HOME]
- ,[PATIENT_PHONE_WORK]
- ,[PATIENT_PHONE_EXT_WORK]
- ,[PATIENT_PHONE_CELL]
- ,[PATIENT_EMAIL]
- ,[PATIENT_DOB]
- ,[PATIENT_AGE_REPORTED]
- ,[PATIENT_AGE_REPORTED_UNIT]
- ,[PATIENT_BIRTH_SEX]
- ,[PATIENT_CURRENT_SEX]
- ,[PATIENT_DECEASED_INDICATOR]
- ,[PATIENT_DECEASED_DATE]
- ,[PATIENT_MARITAL_STATUS]
- ,[PATIENT_SSN]
- ,[PATIENT_ETHNICITY]
- ,[PATIENT_RACE_CALCULATED]
- ,[PATIENT_RACE_CALC_DETAILS]
- ,[PATIENT_RACE_AMER_IND_1]
- ,[PATIENT_RACE_AMER_IND_2]
- ,[PATIENT_RACE_AMER_IND_3]
- ,[PATIENT_RACE_AMER_IND_GT3_IND]
- ,[PATIENT_RACE_AMER_IND_ALL]
- ,[PATIENT_RACE_ASIAN_1]
- ,[PATIENT_RACE_ASIAN_2]
- ,[PATIENT_RACE_ASIAN_3]
- ,[PATIENT_RACE_ASIAN_GT3_IND]
- ,[PATIENT_RACE_ASIAN_ALL]
- ,[PATIENT_RACE_BLACK_1]
- ,[PATIENT_RACE_BLACK_2]
- ,[PATIENT_RACE_BLACK_3]
- ,[PATIENT_RACE_BLACK_GT3_IND]
- ,[PATIENT_RACE_BLACK_ALL]
- ,[PATIENT_RACE_NAT_HI_1]
- ,[PATIENT_RACE_NAT_HI_2]
- ,[PATIENT_RACE_NAT_HI_3]
- ,[PATIENT_RACE_NAT_HI_GT3_IND]
- ,[PATIENT_RACE_NAT_HI_ALL]
- ,[PATIENT_RACE_WHITE_1]
- ,[PATIENT_RACE_WHITE_2]
- ,[PATIENT_RACE_WHITE_3]
- ,[PATIENT_RACE_WHITE_GT3_IND]
- ,[PATIENT_RACE_WHITE_ALL]
- ,[PATIENT_NUMBER]
- ,[PATIENT_NUMBER_AUTH]
- ,[PATIENT_ENTRY_METHOD]
- ,[PATIENT_LAST_CHANGE_TIME]
- ,[PATIENT_UID]
- ,[PATIENT_ADD_TIME]
- ,[PATIENT_ADDED_BY]
- ,[PATIENT_LAST_UPDATED_BY]
- ,[PATIENT_SPEAKS_ENGLISH]
- ,[PATIENT_UNK_ETHNIC_RSN]
- ,[PATIENT_CURR_SEX_UNK_RSN]
- ,[PATIENT_PREFERRED_GENDER]
- ,[PATIENT_ADDL_GENDER_INFO]
- ,[PATIENT_CENSUS_TRACT]
- ,[PATIENT_RACE_ALL]
- ,[PATIENT_BIRTH_COUNTRY]
- ,[PATIENT_PRIMARY_OCCUPATION]
- ,[PATIENT_PRIMARY_LANGUAGE] )
-SELECT  distinct k.[d_PATIENT_KEY] as PATIENT_KEY
-               ,tpt.[PATIENT_MPR_UID]
-               ,tpt.[PATIENT_RECORD_STATUS]
-               ,tpt.[PATIENT_LOCAL_ID]
-               ,substring(tpt.[PATIENT_GENERAL_COMMENTS] ,1,2000)
-               ,tpt.[PATIENT_FIRST_NAME]
-               ,tpt.[PATIENT_MIDDLE_NAME]
-               ,tpt.[PATIENT_LAST_NAME]
-               ,tpt.[PATIENT_NAME_SUFFIX]
-               ,tpt.[PATIENT_ALIAS_NICKNAME]
-               ,substring(tpt.[PATIENT_STREET_ADDRESS_1],1,50)
-               ,substring(tpt.[PATIENT_STREET_ADDRESS_2],1,50)
-               ,substring(tpt.[PATIENT_CITY],1,50)
-               ,tpt.[PATIENT_STATE]
-               ,tpt.[PATIENT_STATE_CODE]
-               ,tpt.[PATIENT_ZIP]
-               ,substring(tpt.[PATIENT_COUNTY],1,50)
-               ,tpt.[PATIENT_COUNTY_CODE]
-               ,tpt.[PATIENT_COUNTRY]
-               ,tpt.[PATIENT_WITHIN_CITY_LIMITS]
-               ,tpt.[PATIENT_PHONE_HOME]
-               ,tpt.[PATIENT_PHONE_EXT_HOME]
-               ,tpt.[PATIENT_PHONE_WORK]
-               ,tpt.[PATIENT_PHONE_EXT_WORK]
-               ,tpt.[PATIENT_PHONE_CELL]
-               ,tpt.[PATIENT_EMAIL]
-               ,tpt.[PATIENT_DOB]
-               ,tpt.[PATIENT_AGE_REPORTED]
-               ,substring(tpt.[PATIENT_AGE_REPORTED_UNIT] ,1,20)
-               ,substring(tpt.[PATIENT_BIRTH_SEX] ,1,50)
-               ,substring(tpt.[PATIENT_CURRENT_SEX] ,1,50)
-               ,substring(tpt.[PATIENT_DECEASED_INDICATOR] ,1,50)
-               ,tpt.[PATIENT_DECEASED_DATE]
-               ,substring(tpt.[PATIENT_MARITAL_STATUS] ,1,50)
-               ,substring(tpt.[PATIENT_SSN] ,1,50)
-               ,substring(tpt.[PATIENT_ETHNICITY] ,1,50)
-               ,substring(tpt.[PATIENT_RACE_CALCULATED] ,1,50)
-               ,tpt.[PATIENT_RACE_CALC_DETAILS]
-               ,tpt.[PATIENT_RACE_AMER_IND_1]
-               ,tpt.[PATIENT_RACE_AMER_IND_2]
-               ,tpt.[PATIENT_RACE_AMER_IND_3]
-               ,tpt.[PATIENT_RACE_AMER_IND_GT3_IND]
-               ,tpt.[PATIENT_RACE_AMER_IND_ALL]
-               ,tpt.[PATIENT_RACE_ASIAN_1]
-               ,tpt.[PATIENT_RACE_ASIAN_2]
-               ,tpt.[PATIENT_RACE_ASIAN_3]
-               ,tpt.[PATIENT_RACE_ASIAN_GT3_IND]
-               ,tpt.[PATIENT_RACE_ASIAN_ALL]
-               ,tpt.[PATIENT_RACE_BLACK_1]
-               ,tpt.[PATIENT_RACE_BLACK_2]
-               ,tpt.[PATIENT_RACE_BLACK_3]
-               ,tpt.[PATIENT_RACE_BLACK_GT3_IND]
-               ,tpt.[PATIENT_RACE_BLACK_ALL]
-               ,tpt.[PATIENT_RACE_NAT_HI_1]
-               ,tpt.[PATIENT_RACE_NAT_HI_2]
-               ,tpt.[PATIENT_RACE_NAT_HI_3]
-               ,tpt.[PATIENT_RACE_NAT_HI_GT3_IND]
-               ,tpt.[PATIENT_RACE_NAT_HI_ALL]
-               ,tpt.[PATIENT_RACE_WHITE_1]
-               ,tpt.[PATIENT_RACE_WHITE_2]
-               ,tpt.[PATIENT_RACE_WHITE_3]
-               ,tpt.[PATIENT_RACE_WHITE_GT3_IND]
-               ,tpt.[PATIENT_RACE_WHITE_ALL]
-               ,substring(tpt.[PATIENT_NUMBER] ,1,50)
-               ,tpt.[PATIENT_NUMBER_AUTH]
-               ,tpt.[PATIENT_ENTRY_METHOD]
-               ,tpt.[PATIENT_LAST_CHANGE_TIME]
-               ,tpt.[PATIENT_UID]
-               ,tpt.[PATIENT_ADD_TIME]
-               ,tpt.[PATIENT_ADDED_BY]
-               ,tpt.[PATIENT_LAST_UPDATED_BY]
-               ,tpt.[PATIENT_SPEAKS_ENGLISH]
-               ,tpt.[PATIENT_UNK_ETHNIC_RSN]
-               ,tpt.[PATIENT_CURR_SEX_UNK_RSN]
-               ,tpt.[PATIENT_PREFERRED_GENDER]
-               ,tpt.[PATIENT_ADDL_GENDER_INFO]
-               ,tpt.[PATIENT_CENSUS_TRACT]
-               ,tpt.[PATIENT_RACE_ALL]
-               ,substring(tpt.[PATIENT_BIRTH_COUNTRY] ,1,50)
-               ,substring(tpt.[PATIENT_PRIMARY_OCCUPATION] ,1,50)
-               ,substring(tpt.[PATIENT_PRIMARY_LANGUAGE] ,1,50)
-FROM #temp_patient_table tpt
-         join dbo.nrt_patient_key k on tpt.patient_uid = k.patient_uid
-where tpt.patient_key is null;
+        insert into dbo.d_patient
+        ([PATIENT_KEY]
+        ,[PATIENT_MPR_UID]
+        ,[PATIENT_RECORD_STATUS]
+        ,[PATIENT_LOCAL_ID]
+        ,[PATIENT_GENERAL_COMMENTS]
+        ,[PATIENT_FIRST_NAME]
+        ,[PATIENT_MIDDLE_NAME]
+        ,[PATIENT_LAST_NAME]
+        ,[PATIENT_NAME_SUFFIX]
+        ,[PATIENT_ALIAS_NICKNAME]
+        ,[PATIENT_STREET_ADDRESS_1]
+        ,[PATIENT_STREET_ADDRESS_2]
+        ,[PATIENT_CITY]
+        ,[PATIENT_STATE]
+        ,[PATIENT_STATE_CODE]
+        ,[PATIENT_ZIP]
+        ,[PATIENT_COUNTY]
+        ,[PATIENT_COUNTY_CODE]
+        ,[PATIENT_COUNTRY]
+        ,[PATIENT_WITHIN_CITY_LIMITS]
+        ,[PATIENT_PHONE_HOME]
+        ,[PATIENT_PHONE_EXT_HOME]
+        ,[PATIENT_PHONE_WORK]
+        ,[PATIENT_PHONE_EXT_WORK]
+        ,[PATIENT_PHONE_CELL]
+        ,[PATIENT_EMAIL]
+        ,[PATIENT_DOB]
+        ,[PATIENT_AGE_REPORTED]
+        ,[PATIENT_AGE_REPORTED_UNIT]
+        ,[PATIENT_BIRTH_SEX]
+        ,[PATIENT_CURRENT_SEX]
+        ,[PATIENT_DECEASED_INDICATOR]
+        ,[PATIENT_DECEASED_DATE]
+        ,[PATIENT_MARITAL_STATUS]
+        ,[PATIENT_SSN]
+        ,[PATIENT_ETHNICITY]
+        ,[PATIENT_RACE_CALCULATED]
+        ,[PATIENT_RACE_CALC_DETAILS]
+        ,[PATIENT_RACE_AMER_IND_1]
+        ,[PATIENT_RACE_AMER_IND_2]
+        ,[PATIENT_RACE_AMER_IND_3]
+        ,[PATIENT_RACE_AMER_IND_GT3_IND]
+        ,[PATIENT_RACE_AMER_IND_ALL]
+        ,[PATIENT_RACE_ASIAN_1]
+        ,[PATIENT_RACE_ASIAN_2]
+        ,[PATIENT_RACE_ASIAN_3]
+        ,[PATIENT_RACE_ASIAN_GT3_IND]
+        ,[PATIENT_RACE_ASIAN_ALL]
+        ,[PATIENT_RACE_BLACK_1]
+        ,[PATIENT_RACE_BLACK_2]
+        ,[PATIENT_RACE_BLACK_3]
+        ,[PATIENT_RACE_BLACK_GT3_IND]
+        ,[PATIENT_RACE_BLACK_ALL]
+        ,[PATIENT_RACE_NAT_HI_1]
+        ,[PATIENT_RACE_NAT_HI_2]
+        ,[PATIENT_RACE_NAT_HI_3]
+        ,[PATIENT_RACE_NAT_HI_GT3_IND]
+        ,[PATIENT_RACE_NAT_HI_ALL]
+        ,[PATIENT_RACE_WHITE_1]
+        ,[PATIENT_RACE_WHITE_2]
+        ,[PATIENT_RACE_WHITE_3]
+        ,[PATIENT_RACE_WHITE_GT3_IND]
+        ,[PATIENT_RACE_WHITE_ALL]
+        ,[PATIENT_NUMBER]
+        ,[PATIENT_NUMBER_AUTH]
+        ,[PATIENT_ENTRY_METHOD]
+        ,[PATIENT_LAST_CHANGE_TIME]
+        ,[PATIENT_UID]
+        ,[PATIENT_ADD_TIME]
+        ,[PATIENT_ADDED_BY]
+        ,[PATIENT_LAST_UPDATED_BY]
+        ,[PATIENT_SPEAKS_ENGLISH]
+        ,[PATIENT_UNK_ETHNIC_RSN]
+        ,[PATIENT_CURR_SEX_UNK_RSN]
+        ,[PATIENT_PREFERRED_GENDER]
+        ,[PATIENT_ADDL_GENDER_INFO]
+        ,[PATIENT_CENSUS_TRACT]
+        ,[PATIENT_RACE_ALL]
+        ,[PATIENT_BIRTH_COUNTRY]
+        ,[PATIENT_PRIMARY_OCCUPATION]
+        ,[PATIENT_PRIMARY_LANGUAGE] )
+        SELECT  distinct k.[d_PATIENT_KEY] as PATIENT_KEY
+                       ,tpt.[PATIENT_MPR_UID]
+                       ,tpt.[PATIENT_RECORD_STATUS]
+                       ,tpt.[PATIENT_LOCAL_ID]
+                       ,substring(tpt.[PATIENT_GENERAL_COMMENTS] ,1,2000)
+                       ,tpt.[PATIENT_FIRST_NAME]
+                       ,tpt.[PATIENT_MIDDLE_NAME]
+                       ,tpt.[PATIENT_LAST_NAME]
+                       ,tpt.[PATIENT_NAME_SUFFIX]
+                       ,tpt.[PATIENT_ALIAS_NICKNAME]
+                       ,substring(tpt.[PATIENT_STREET_ADDRESS_1],1,50)
+                       ,substring(tpt.[PATIENT_STREET_ADDRESS_2],1,50)
+                       ,substring(tpt.[PATIENT_CITY],1,50)
+                       ,tpt.[PATIENT_STATE]
+                       ,tpt.[PATIENT_STATE_CODE]
+                       ,tpt.[PATIENT_ZIP]
+                       ,substring(tpt.[PATIENT_COUNTY],1,50)
+                       ,tpt.[PATIENT_COUNTY_CODE]
+                       ,tpt.[PATIENT_COUNTRY]
+                       ,tpt.[PATIENT_WITHIN_CITY_LIMITS]
+                       ,tpt.[PATIENT_PHONE_HOME]
+                       ,tpt.[PATIENT_PHONE_EXT_HOME]
+                       ,tpt.[PATIENT_PHONE_WORK]
+                       ,tpt.[PATIENT_PHONE_EXT_WORK]
+                       ,tpt.[PATIENT_PHONE_CELL]
+                       ,tpt.[PATIENT_EMAIL]
+                       ,tpt.[PATIENT_DOB]
+                       ,tpt.[PATIENT_AGE_REPORTED]
+                       ,substring(tpt.[PATIENT_AGE_REPORTED_UNIT] ,1,20)
+                       ,substring(tpt.[PATIENT_BIRTH_SEX] ,1,50)
+                       ,substring(tpt.[PATIENT_CURRENT_SEX] ,1,50)
+                       ,substring(tpt.[PATIENT_DECEASED_INDICATOR] ,1,50)
+                       ,tpt.[PATIENT_DECEASED_DATE]
+                       ,substring(tpt.[PATIENT_MARITAL_STATUS] ,1,50)
+                       ,substring(tpt.[PATIENT_SSN] ,1,50)
+                       ,substring(tpt.[PATIENT_ETHNICITY] ,1,50)
+                       ,substring(tpt.[PATIENT_RACE_CALCULATED] ,1,50)
+                       ,tpt.[PATIENT_RACE_CALC_DETAILS]
+                       ,tpt.[PATIENT_RACE_AMER_IND_1]
+                       ,tpt.[PATIENT_RACE_AMER_IND_2]
+                       ,tpt.[PATIENT_RACE_AMER_IND_3]
+                       ,tpt.[PATIENT_RACE_AMER_IND_GT3_IND]
+                       ,tpt.[PATIENT_RACE_AMER_IND_ALL]
+                       ,tpt.[PATIENT_RACE_ASIAN_1]
+                       ,tpt.[PATIENT_RACE_ASIAN_2]
+                       ,tpt.[PATIENT_RACE_ASIAN_3]
+                       ,tpt.[PATIENT_RACE_ASIAN_GT3_IND]
+                       ,tpt.[PATIENT_RACE_ASIAN_ALL]
+                       ,tpt.[PATIENT_RACE_BLACK_1]
+                       ,tpt.[PATIENT_RACE_BLACK_2]
+                       ,tpt.[PATIENT_RACE_BLACK_3]
+                       ,tpt.[PATIENT_RACE_BLACK_GT3_IND]
+                       ,tpt.[PATIENT_RACE_BLACK_ALL]
+                       ,tpt.[PATIENT_RACE_NAT_HI_1]
+                       ,tpt.[PATIENT_RACE_NAT_HI_2]
+                       ,tpt.[PATIENT_RACE_NAT_HI_3]
+                       ,tpt.[PATIENT_RACE_NAT_HI_GT3_IND]
+                       ,tpt.[PATIENT_RACE_NAT_HI_ALL]
+                       ,tpt.[PATIENT_RACE_WHITE_1]
+                       ,tpt.[PATIENT_RACE_WHITE_2]
+                       ,tpt.[PATIENT_RACE_WHITE_3]
+                       ,tpt.[PATIENT_RACE_WHITE_GT3_IND]
+                       ,tpt.[PATIENT_RACE_WHITE_ALL]
+                       ,substring(tpt.[PATIENT_NUMBER] ,1,50)
+                       ,tpt.[PATIENT_NUMBER_AUTH]
+                       ,tpt.[PATIENT_ENTRY_METHOD]
+                       ,tpt.[PATIENT_LAST_CHANGE_TIME]
+                       ,tpt.[PATIENT_UID]
+                       ,tpt.[PATIENT_ADD_TIME]
+                       ,tpt.[PATIENT_ADDED_BY]
+                       ,tpt.[PATIENT_LAST_UPDATED_BY]
+                       ,tpt.[PATIENT_SPEAKS_ENGLISH]
+                       ,tpt.[PATIENT_UNK_ETHNIC_RSN]
+                       ,tpt.[PATIENT_CURR_SEX_UNK_RSN]
+                       ,tpt.[PATIENT_PREFERRED_GENDER]
+                       ,tpt.[PATIENT_ADDL_GENDER_INFO]
+                       ,tpt.[PATIENT_CENSUS_TRACT]
+                       ,tpt.[PATIENT_RACE_ALL]
+                       ,substring(tpt.[PATIENT_BIRTH_COUNTRY] ,1,50)
+                       ,substring(tpt.[PATIENT_PRIMARY_OCCUPATION] ,1,50)
+                       ,substring(tpt.[PATIENT_PRIMARY_LANGUAGE] ,1,50)
+        FROM #temp_patient_table tpt
+                 join dbo.nrt_patient_key k with (nolock) on tpt.patient_uid = k.patient_uid
+        where tpt.patient_key is null;
 
-/* Logging */
-set @rowcount=@@rowcount
-		INSERT INTO [dbo].[job_flow_log] (
-			batch_id
-			,[Dataflow_Name]
-			,[package_Name]
-			,[Status_Type]
-			,[step_number]
-			,[step_name]
-			,[row_count]
-			,[msg_description1]
-			)
-		VALUES (
-			@batch_id
-			,@dataflow_name
-			,@package_name
-			,'START'
-			,@proc_step_no
-			,@proc_step_name
-			,@rowcount
-			,LEFT(@id_list,500)
-			);
+        /* Logging */
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log] (
+                   batch_id
+                 ,[Dataflow_Name]
+                 ,[package_Name]
+                 ,[Status_Type]
+                 ,[step_number]
+                 ,[step_name]
+                 ,[row_count]
+                 ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list,500)
+               );
 
-select 'Success';
+        SELECT 'Success';
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
-SET @proc_step_name='SP_COMPLETE';
-	SET @proc_step_no = 4;
+        SET @proc_step_name='SP_COMPLETE';
+        SET @proc_step_no = 4;
 
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES (
-    @batch_id
-        ,current_timestamp
-        ,current_timestamp
-        ,@dataflow_name
-        ,@package_name
-        ,'COMPLETE'
-        ,@proc_step_no
-        ,@proc_step_name
-        ,0
-        ,LEFT(@id_list,500)
-    );
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+                                         ,[create_dttm]
+                                         ,[update_dttm]
+                                         ,[Dataflow_Name]
+                                         ,[package_Name]
+                                         ,[Status_Type]
+                                         ,[step_number]
+                                         ,[step_name]
+                                         ,[row_count]
+                                         ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,current_timestamp
+               ,current_timestamp
+               ,@dataflow_name
+               ,@package_name
+               ,'COMPLETE'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,0
+               ,LEFT(@id_list,500)
+               );
 
-END TRY
+    END TRY
 
-BEGIN CATCH
+    BEGIN CATCH
 
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
-    	DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+        DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
 
-    	/* Logging */
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[create_dttm]
-    ,[update_dttm]
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES
-    (
-    @batch_id
-        ,current_timestamp
-        ,current_timestamp
-        ,@dataflow_name
-        ,@package_name
-        ,'ERROR'
-        ,@Proc_Step_no
-        , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
-        ,0
-        ,LEFT(@id_list,500)
-    );
+        /* Logging */
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+                                         ,[create_dttm]
+                                         ,[update_dttm]
+                                         ,[Dataflow_Name]
+                                         ,[package_Name]
+                                         ,[Status_Type]
+                                         ,[step_number]
+                                         ,[step_name]
+                                         ,[row_count]
+                                         ,[msg_description1]
+        )
+        VALUES
+            (
+              @batch_id
+            ,current_timestamp
+            ,current_timestamp
+            ,@dataflow_name
+            ,@package_name
+            ,'ERROR'
+            ,@Proc_Step_no
+            , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
+            ,0
+            ,LEFT(@id_list,500)
+            );
 
-return @ErrorMessage;
+        return @ErrorMessage;
 
-END CATCH
+    END CATCH
 
 END;

--- a/liquibase-service/src/main/resources/db/rdb/023-sp_nrt_investigation_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/023-sp_nrt_investigation_postprocessing-001.sql
@@ -121,7 +121,7 @@ BEGIN
                nrt.outbreak_name               as OUTBREAK_NAME_DESC
         into #temp_inv_table
         from dbo.nrt_investigation nrt
-                 left join dbo.investigation i on i.case_uid = nrt.public_health_case_uid
+                 left join dbo.investigation i with (nolock) on i.case_uid = nrt.public_health_case_uid
         where nrt.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
 
         if @debug = 'true' select * from #temp_inv_table;
@@ -212,7 +212,7 @@ BEGIN
             [CONTACT_INFECTIOUS_TO_DATE]    = inv.CONTACT_INFECTIOUS_TO_DATE,
             [CONTACT_INV_STATUS]            = inv.CONTACT_INV_STATUS,
             [PROGRAM_AREA_DESCRIPTION]      = inv.PROGRAM_AREA_DESCRIPTION,
-            [ADD_TIME]                      = inv.ADD_TIME,
+            [ADD_TIME]          = inv.ADD_TIME,
             [LAST_CHG_TIME]                 = inv.LAST_CHG_TIME,
             [INVESTIGATION_ADDED_BY]        = inv.INVESTIGATION_ADDED_BY,
             [INVESTIGATION_LAST_UPDATED_BY] = inv.INVESTIGATION_LAST_UPDATED_BY,
@@ -223,7 +223,7 @@ BEGIN
             [LEGACY_CASE_ID]                = inv.LEGACY_CASE_ID,
             [OUTBREAK_NAME_DESC]            = inv.OUTBREAK_NAME_DESC
         from #temp_inv_table inv
-                 inner join dbo.investigation i on inv.case_uid = i.case_uid
+                 inner join dbo.investigation i with (nolock) on inv.case_uid = i.case_uid
             and inv.investigation_key = i.investigation_key
             and i.investigation_key is not null;
 
@@ -402,7 +402,7 @@ BEGIN
                inv.LEGACY_CASE_ID,
                inv.OUTBREAK_NAME_DESC
         FROM #temp_inv_table inv
-                 join dbo.nrt_investigation_key k on inv.case_uid = k.case_uid
+                 join dbo.nrt_investigation_key k with (nolock) on inv.case_uid = k.case_uid
         where inv.investigation_key is null;
 
         COMMIT TRANSACTION;
@@ -440,8 +440,8 @@ BEGIN
                         cm.CONFIRMATION_METHOD_KEY
         into #temp_cm_table
         from dbo.nrt_investigation_confirmation nrt
-                 left join dbo.confirmation_method cm on cm.confirmation_method_cd = nrt.confirmation_method_cd
-                 left join dbo.investigation i on i.case_uid = nrt.public_health_case_uid
+                 left join dbo.confirmation_method cm with (nolock) on cm.confirmation_method_cd = nrt.confirmation_method_cd
+                 left join dbo.investigation i with (nolock) on i.case_uid = nrt.public_health_case_uid
         where nrt.public_health_case_uid in (select value FROM STRING_SPLIT(@id_list, ','));
 
         if @debug = 'true' select * from #temp_cm_table;
@@ -452,14 +452,14 @@ BEGIN
         update cm
         set cm.CONFIRMATION_METHOD_DESC = cmt.CONFIRMATION_METHOD_DESC_TXT
         from #temp_cm_table cmt
-                 inner join dbo.confirmation_method cm
+                 inner join dbo.confirmation_method cm with (nolock)
                             on cmt.confirmation_method_key = cm.confirmation_method_key
                                 and cmt.CONFIRMATION_METHOD_KEY is not null;
 
         update cmg
         set cmg.CONFIRMATION_DT = cmt.CONFIRMATION_DT
         from #temp_cm_table cmt
-                 inner join dbo.confirmation_method_group cmg
+                 inner join dbo.confirmation_method_group cmg with (nolock)
                             on cmt.investigation_key = cmg.investigation_key
                                 and cmt.confirmation_method_key = cmg.confirmation_method_key
                                 and cmt.CONFIRMATION_METHOD_KEY is not null;
@@ -503,7 +503,7 @@ BEGIN
         insert into dbo.confirmation_method(CONFIRMATION_METHOD_KEY,CONFIRMATION_METHOD_CD,CONFIRMATION_METHOD_DESC)
         select distinct cmk.D_CONFIRMATION_METHOD_KEY, cmt.confirmation_method_cd, cmt.CONFIRMATION_METHOD_DESC_TXT
         from #temp_cm_table cmt
-                 join dbo.nrt_confirmation_method_key cmk on cmk.confirmation_method_cd = cmt.confirmation_method_cd
+                 join dbo.nrt_confirmation_method_key cmk with (nolock) on cmk.confirmation_method_cd = cmt.confirmation_method_cd
         where cmt.CONFIRMATION_METHOD_KEY is null
           and not exists (select confirmation_method_cd
                           from dbo.confirmation_method cd
@@ -513,8 +513,8 @@ BEGIN
         insert into dbo.CONFIRMATION_METHOD_GROUP ([INVESTIGATION_KEY],[CONFIRMATION_METHOD_KEY],[CONFIRMATION_DT])
         select cmt.INVESTIGATION_KEY, cm.CONFIRMATION_METHOD_KEY, cmt.CONFIRMATION_DT
         from #temp_cm_table cmt
-                 left outer join dbo.confirmation_method cm on cmt.confirmation_method_cd = cm.confirmation_method_cd
-                 left outer join dbo.confirmation_method_group cmg on cmt.investigation_key = cmg.investigation_key
+                 left outer join dbo.confirmation_method cm with (nolock) on cmt.confirmation_method_cd = cm.confirmation_method_cd
+                 left outer join dbo.confirmation_method_group cmg with (nolock) on cmt.investigation_key = cmg.investigation_key
         where cmg.investigation_key is null
           and cmg.confirmation_method_key is null;
 
@@ -575,9 +575,9 @@ BEGIN
                dtm.Datamart                       AS datamart,
                dtm.Stored_Procedure               AS stored_procedure
         FROM dbo.nrt_investigation nrt
-                 LEFT JOIN INVESTIGATION inv ON inv.CASE_UID = nrt.public_health_case_uid
-                 LEFT JOIN D_PATIENT pat ON pat.PATIENT_UID = nrt.patient_id
-                 LEFT JOIN dbo.nrt_datamart_metadata dtm ON dtm.condition_cd = nrt.cd
+                 LEFT JOIN INVESTIGATION inv with (nolock) ON inv.CASE_UID = nrt.public_health_case_uid
+                 LEFT JOIN D_PATIENT pat with (nolock) ON pat.PATIENT_UID = nrt.patient_id
+                 LEFT JOIN dbo.nrt_datamart_metadata dtm with (nolock) ON dtm.condition_cd = nrt.cd
         WHERE nrt.public_health_case_uid in
               (SELECT value FROM STRING_SPLIT(@id_list, ','));
 

--- a/liquibase-service/src/main/resources/db/rdb/030-sp_f_page_case_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/030-sp_f_page_case_postprocessing-001.sql
@@ -1,510 +1,510 @@
 CREATE OR ALTER PROCEDURE dbo.sp_f_page_case_postprocessing
     @phc_ids nvarchar(max),
     @debug bit = 'false'
- as
-
-BEGIN
-    DECLARE @RowCount_no INT ;
-    DECLARE @Proc_Step_no FLOAT = 0 ;
-    DECLARE @Proc_Step_Name VARCHAR(200) = '' ;
-	DECLARE @batch_start_time datetime2(7) = null ;
-	DECLARE @batch_end_time datetime2(7) = null ;
-	DECLARE @batch_id BIGINT;
-	SET @batch_id = cast((format(getdate(),'yyyyMMddHHmmss')) as bigint);
-
-BEGIN TRY
-
-SET @Proc_Step_no = 1;
-	SET @Proc_Step_Name = 'SP_Start';
-
-
-BEGIN TRANSACTION;
-
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[Msg_Description1]
-)
-VALUES
-    (
-    @batch_id
-        ,'F_PAGE_CASE'
-        ,'F_PAGE_CASE'
-        ,'START'
-        ,@Proc_Step_no
-        ,@Proc_Step_Name
-        ,0
-        ,LEFT('ID List-' + @phc_ids,500)
-    );
-
-COMMIT TRANSACTION;
-
-
-select @batch_start_time = batch_start_dttm,@batch_end_time = batch_end_dttm
-from [dbo].[job_batch_log]
-where status_type = 'start' and type_code='MasterETL'
-;
-
-
-BEGIN TRANSACTION;
-
-
-		SET @Proc_Step_no = 2;
-		SET @Proc_Step_Name = ' Generating PHC_UIDS_ALL';
-
-			---> PHC_UIDS
-SELECT inv.public_health_case_uid page_case_uid,
-       CASE_MANAGEMENT_UID,
-       INVESTIGATION_FORM_CD,
-       CD,
-       LAST_CHG_TIME
-INTO #PHC_UIDS
-FROM dbo.nrt_investigation inv
-         --LEFT OUTER JOIN NBS_ODSE..CASE_MANAGEMENT cm ON inv.PUBLIC_HEALTH_CASE_UID= cm.PUBLIC_HEALTH_CASE_UID
-         LEFT OUTER JOIN NBS_SRTE..CONDITION_CODE cc  ON cc.CONDITION_CD= inv.CD
-    AND INVESTIGATION_FORM_CD   NOT IN ( 'INV_FORM_BMDGAS','INV_FORM_BMDGBS','INV_FORM_BMDGEN',
-                                         'INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV',
-                                         'INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
-WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
-
-if @debug  = 'true' select * from #PHC_UIDS;
-
-IF OBJECT_ID('#PHC_UIDS_ALL', 'U') IS NOT NULL
-drop table #PHC_UIDS_ALL
-;
-
-SELECT
-    inv.PUBLIC_HEALTH_CASE_UID  'PAGE_CASE_UID', /* VS LENGTH =8 AS PAGE_CASE_UID 'PAGE_CASE_UID',*/
-        CASE_MANAGEMENT_UID,
-    INVESTIGATION_FORM_CD,
-    CD,
-    LAST_CHG_TIME
-INTO  #PHC_UIDS_ALL
-FROM
-    dbo.nrt_investigation inv
-        --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
-        LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND	INVESTIGATION_FORM_CD
-        NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
-WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
-
-if @debug  = 'true' select * from #PHC_UIDS_ALL;
-
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 3;
-			SET @Proc_Step_Name = ' Generating PHC_CASE_UIDS_ALL';
-
-			IF OBJECT_ID('#PHC_CASE_UIDS_ALL', 'U') IS NOT NULL
-drop table #PHC_CASE_UIDS_ALL
-;
-
-
-SELECT
-    inv.PUBLIC_HEALTH_CASE_UID  'PAGE_CASE_UID', /* VS LENGTH =8 AS PAGE_CASE_UID 'PAGE_CASE_UID',*/
-        CASE_MANAGEMENT_UID,
-    INVESTIGATION_FORM_CD,
-    CD,
-    LAST_CHG_TIME
-INTO  #PHC_CASE_UIDS_ALL
-FROM
-    dbo.nrt_investigation inv
-        --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
-        LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND	INVESTIGATION_FORM_CD
-        NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
-where inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
-  AND CASE_MANAGEMENT_UID is null;
-
-if @debug  = 'true' select * from #PHC_CASE_UIDS_ALL;
-
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 4;
-			SET @Proc_Step_Name = ' Generating ENTITY_KEYSTORE_INC';
-
-			IF OBJECT_ID('#ENTITY_KEYSTORE_INC', 'U') IS NOT NULL
-drop table #ENTITY_KEYSTORE_INC
-;
-
--- drop table dbo.F_S_INV_CASE
-
-IF OBJECT_ID('#F_S_INV_CASE', 'U') IS NOT NULL
-drop table #F_S_INV_CASE;
-
--- Populate dbo.F_S_INV_CASE
-
-
-SELECT public_health_case_uid AS PAGE_CASE_UID,
-       nac_last_chg_time as last_chg_time,
-       nac_add_time as add_time,
-       investigator_id as INVESTIGATOR_uid,
-       person_as_reporter_uid as PERSON_AS_REPORTER_UID,
-       patient_id as patient_uid,
-       physician_id as PHYSICIAN_UID,
-       hospital_uid as HOSPITAL_UID,
-       organization_id as ORG_AS_REPORTER_UID,
-       ordering_facility_uid as ORDERING_FACILTY_UID
-INTO #F_S_INV_CASE
-FROM dbo.nrt_investigation inv WHERE public_health_case_uid
-                                         IN (SELECT PAGE_CASE_UID FROM #PHC_UIDS WHERE CASE_MANAGEMENT_UID IS NULL);
-
-if @debug  = 'true' select * from #F_S_INV_CASE;
-
-
-SELECT
-    FSIV.ADD_TIME,
-    FSIV.LAST_CHG_TIME,
-    FSIV.PATIENT_UID,
-    COALESCE(PATIENT.PATIENT_KEY, 1)  AS PATIENT_KEY,
-    FSIV.PAGE_CASE_UID,
-    FSIV.HOSPITAL_UID,
-    COALESCE(HOSPITAL.ORGANIZATION_KEY, 1)  AS HOSPITAL_KEY,
-    FSIV.ORG_AS_REPORTER_UID,
-    COALESCE(REPORTERORG.ORGANIZATION_KEY, 1)  AS ORG_AS_REPORTER_KEY,
-    FSIV.PERSON_AS_REPORTER_UID,
-    COALESCE(PERSONREPORTER.PROVIDER_KEY, 1)  AS PERSON_AS_REPORTER_KEY,
-    FSIV.PHYSICIAN_UID,
-    COALESCE(PHYSICIAN.PROVIDER_KEY, 1)  AS PHYSICIAN_KEY,
-    FSIV.INVESTIGATOR_UID,
-    COALESCE(PROVIDER.PROVIDER_KEY, 1)  AS INVESTIGATOR_KEY,
-    COALESCE(INVESTIGATION.INVESTIGATION_KEY,1 ) AS INVESTIGATION_KEY,
-    COALESCE(CONDITION.CONDITION_KEY,1)  AS CONDITION_KEY,
-    COALESCE(LOC.GEOCODING_LOCATION_KEY, 1) AS GEOCODING_LOCATION_KEY
---'' as TEMP
-into #ENTITY_KEYSTORE_INC
-FROM #F_S_INV_CASE  FSIV
-         LEFT OUTER JOIN dbo.D_PATIENT PATIENT	 ON	FSIV.PATIENT_UID= PATIENT.PATIENT_UID
-         LEFT OUTER JOIN dbo.D_ORGANIZATION  HOSPITAL ON 	FSIV.HOSPITAL_UID= HOSPITAL.ORGANIZATION_UID
-         LEFT OUTER JOIN dbo.D_ORGANIZATION REPORTERORG ON 	FSIV.ORG_AS_REPORTER_UID= REPORTERORG.ORGANIZATION_UID
-         LEFT OUTER JOIN dbo.D_PROVIDER PERSONREPORTER ON  	FSIV.PERSON_AS_REPORTER_UID= PERSONREPORTER.PROVIDER_UID
-         LEFT OUTER JOIN dbo.D_PROVIDER PROVIDER ON 	FSIV.INVESTIGATOR_UID= PROVIDER.PROVIDER_UID
-         LEFT OUTER JOIN dbo.D_PROVIDER PHYSICIAN ON 	FSIV.PHYSICIAN_UID= PHYSICIAN.PROVIDER_UID
-         LEFT OUTER JOIN dbo.INVESTIGATION  INVESTIGATION ON 	FSIV.PAGE_CASE_UID= INVESTIGATION.CASE_UID
-         LEFT OUTER JOIN #PHC_CASE_UIDS_ALL  CASE_UID ON 	FSIV.PAGE_CASE_UID= CASE_UID.PAGE_CASE_UID
-         LEFT OUTER JOIN dbo.CONDITION CONDITION ON 	CASE_UID.CD= CONDITION.CONDITION_CD
-         LEFT JOIN dbo.GEOCODING_LOCATION AS LOC ON LOC.ENTITY_UID = PATIENT.PATIENT_UID
-;
-
-if @debug  = 'true' select * from #ENTITY_KEYSTORE_INC;
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 5;
-			SET @Proc_Step_Name = ' Generating DIMENSION_KEYS_PAGECASEID';
-
-			IF OBJECT_ID('#DIMENSION_KEYS_PAGECASEID', 'U') IS NOT NULL
-drop table #DIMENSION_KEYS_PAGECASEID
-;
-
-select L_INV_ADMINISTRATIVE_INC.PAGE_CASE_UID as PAGE_CASE_UID
-into #DIMENSION_KEYS_PAGECASEID
-from  dbo.L_INV_ADMINISTRATIVE_INC  union
-select L_INV_CLINICAL_INC.PAGE_CASE_UID 	 from  dbo.L_INV_CLINICAL_INC  union
-select L_INV_COMPLICATION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_COMPLICATION_INC  union
-select L_INV_CONTACT_INC.PAGE_CASE_UID 	 from  dbo.L_INV_CONTACT_INC  union
-select L_INV_DEATH_INC.PAGE_CASE_UID 	 from  dbo.L_INV_DEATH_INC  union
-select L_INV_EPIDEMIOLOGY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_EPIDEMIOLOGY_INC  union
-select L_INV_HIV_INC.PAGE_CASE_UID 	 from  dbo.L_INV_HIV_INC  union
-select L_INV_ISOLATE_TRACKING_INC.PAGE_CASE_UID 	 from  dbo.L_INV_ISOLATE_TRACKING_INC  union
-select L_INV_LAB_FINDING_INC.PAGE_CASE_UID 	 from  dbo.L_INV_LAB_FINDING_INC  union
-select L_INV_MEDICAL_HISTORY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_MEDICAL_HISTORY_INC  union
-select L_INV_MOTHER_INC.PAGE_CASE_UID 	 from  dbo.L_INV_MOTHER_INC  union
-select L_INV_OTHER_INC.PAGE_CASE_UID 	 from  dbo.L_INV_OTHER_INC  union
-select L_INV_PATIENT_OBS_INC.PAGE_CASE_UID 	 from  dbo.L_INV_PATIENT_OBS_INC  union
-select L_INV_PREGNANCY_BIRTH_INC.PAGE_CASE_UID 	 from  dbo.L_INV_PREGNANCY_BIRTH_INC  union
-select L_INV_RESIDENCY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_RESIDENCY_INC  union
-select L_INV_RISK_FACTOR_INC.PAGE_CASE_UID 	 from  dbo.L_INV_RISK_FACTOR_INC  union
-select L_INV_SOCIAL_HISTORY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_SOCIAL_HISTORY_INC  union
-select L_INV_SYMPTOM_INC.PAGE_CASE_UID 	 from  dbo.L_INV_SYMPTOM_INC  union
-select L_INV_TRAVEL_INC.PAGE_CASE_UID 	 from  dbo.L_INV_TRAVEL_INC  union
-select L_INV_TREATMENT_INC.PAGE_CASE_UID 	 from  dbo.L_INV_TREATMENT_INC  union
-select L_INV_UNDER_CONDITION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_UNDER_CONDITION_INC  union
-select L_INV_VACCINATION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_VACCINATION_INC union
-SELECT L_INVESTIGATION_REPEAT_INC.PAGE_CASE_UID	 from  [dbo].[L_INVESTIGATION_REPEAT_INC] union
-SELECT L_INV_PLACE_REPEAT.PAGE_CASE_UID	 from  [dbo].[L_INV_PLACE_REPEAT]
-;
-
-if @debug  = 'true' select * from #DIMENSION_KEYS_PAGECASEID where page_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
-
-
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 6;
-			SET @Proc_Step_Name = ' Generating DIMENSIONAL_KEYS';
-
-			IF OBJECT_ID('#DIMENSIONAL_KEYS', 'U') IS NOT NULL
-drop table #DIMENSIONAL_KEYS
-;
-
-/**Updated to handle cases when there are no page builder investigation updates.*/
-select  phc.page_case_uid,
-        COALESCE(L_INV_ADMINISTRATIVE_INC.D_INV_ADMINISTRATIVE_KEY , 1) AS 	D_INV_ADMINISTRATIVE_KEY ,
-        COALESCE(L_INV_CLINICAL_INC.D_INV_CLINICAL_KEY , 1) AS 	D_INV_CLINICAL_KEY ,
-        COALESCE(L_INV_COMPLICATION_INC.D_INV_COMPLICATION_KEY , 1) AS 	D_INV_COMPLICATION_KEY ,
-        COALESCE(L_INV_CONTACT_INC.D_INV_CONTACT_KEY , 1) AS 	D_INV_CONTACT_KEY ,
-        COALESCE(L_INV_DEATH_INC.D_INV_DEATH_KEY , 1) AS 	D_INV_DEATH_KEY ,
-        COALESCE(L_INV_EPIDEMIOLOGY_INC.D_INV_EPIDEMIOLOGY_KEY , 1) AS 	D_INV_EPIDEMIOLOGY_KEY ,
-        COALESCE(L_INV_HIV_INC.D_INV_HIV_KEY , 1) AS 	D_INV_HIV_KEY ,
-        COALESCE(L_INV_PATIENT_OBS_INC.D_INV_PATIENT_OBS_KEY , 1) AS 	D_INV_PATIENT_OBS_KEY ,
-        COALESCE(L_INV_ISOLATE_TRACKING_INC.D_INV_ISOLATE_TRACKING_KEY , 1) AS 	D_INV_ISOLATE_TRACKING_KEY ,
-        COALESCE(L_INV_LAB_FINDING_INC.D_INV_LAB_FINDING_KEY , 1) AS 	D_INV_LAB_FINDING_KEY ,
-        COALESCE(L_INV_MEDICAL_HISTORY_INC.D_INV_MEDICAL_HISTORY_KEY , 1) AS 	D_INV_MEDICAL_HISTORY_KEY ,
-        COALESCE(L_INV_MOTHER_INC.D_INV_MOTHER_KEY , 1) AS 	D_INV_MOTHER_KEY ,
-        COALESCE(L_INV_OTHER_INC.D_INV_OTHER_KEY , 1) AS 	D_INV_OTHER_KEY ,
-        COALESCE(L_INV_PREGNANCY_BIRTH_INC.D_INV_PREGNANCY_BIRTH_KEY , 1) AS 	D_INV_PREGNANCY_BIRTH_KEY ,
-        COALESCE(L_INV_RESIDENCY_INC.D_INV_RESIDENCY_KEY , 1) AS 	D_INV_RESIDENCY_KEY ,
-        COALESCE(L_INV_RISK_FACTOR_INC.D_INV_RISK_FACTOR_KEY , 1) AS 	D_INV_RISK_FACTOR_KEY ,
-        COALESCE(L_INV_SOCIAL_HISTORY_INC.D_INV_SOCIAL_HISTORY_KEY , 1) AS 	D_INV_SOCIAL_HISTORY_KEY ,
-        COALESCE(L_INV_SYMPTOM_INC.D_INV_SYMPTOM_KEY , 1) AS 	D_INV_SYMPTOM_KEY ,
-        COALESCE(L_INV_TREATMENT_INC.D_INV_TREATMENT_KEY , 1) AS 	D_INV_TREATMENT_KEY ,
-        COALESCE(L_INV_TRAVEL_INC.D_INV_TRAVEL_KEY , 1) AS 	D_INV_TRAVEL_KEY ,
-        COALESCE(L_INV_UNDER_CONDITION_INC.D_INV_UNDER_CONDITION_KEY , 1) AS 	D_INV_UNDER_CONDITION_KEY ,
-        COALESCE(L_INV_VACCINATION_INC.D_INV_VACCINATION_KEY , 1) AS 	D_INV_VACCINATION_KEY ,
-        COALESCE(L_INVESTIGATION_REPEAT_INC.D_INVESTIGATION_REPEAT_KEY , 1 ) AS	D_INVESTIGATION_REPEAT_KEY,
-        COALESCE(L_INV_PLACE_REPEAT.D_INV_PLACE_REPEAT_KEY , 1 ) AS	D_INV_PLACE_REPEAT_KEY
-into #DIMENSIONAL_KEYS
-from #PHC_UIDS phc
-         LEFT OUTER JOIN  #DIMENSION_KEYS_PAGECASEID DIMC ON DIMC.PAGE_CASE_UID = phc.PAGE_CASE_UID
-         LEFT OUTER JOIN   dbo.L_INV_ADMINISTRATIVE_INC ON  L_INV_ADMINISTRATIVE_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_CLINICAL_INC ON  L_INV_CLINICAL_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_COMPLICATION_INC ON  L_INV_COMPLICATION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_CONTACT_INC ON  L_INV_CONTACT_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_DEATH_INC ON  L_INV_DEATH_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_EPIDEMIOLOGY_INC ON  L_INV_EPIDEMIOLOGY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_HIV_INC ON  L_INV_HIV_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_ISOLATE_TRACKING_INC ON  L_INV_ISOLATE_TRACKING_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_LAB_FINDING_INC ON  L_INV_LAB_FINDING_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_MEDICAL_HISTORY_INC ON  L_INV_MEDICAL_HISTORY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_MOTHER_INC ON  L_INV_MOTHER_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_OTHER_INC ON  L_INV_OTHER_INC.PAGE_CASE_UID = dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_PATIENT_OBS_INC ON  L_INV_PATIENT_OBS_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_PREGNANCY_BIRTH_INC ON  L_INV_PREGNANCY_BIRTH_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_RESIDENCY_INC ON  L_INV_RESIDENCY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_RISK_FACTOR_INC ON  L_INV_RISK_FACTOR_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_SOCIAL_HISTORY_INC ON  L_INV_SOCIAL_HISTORY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_SYMPTOM_INC ON  L_INV_SYMPTOM_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_TRAVEL_INC ON  L_INV_TRAVEL_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_TREATMENT_INC ON   L_INV_TREATMENT_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_UNDER_CONDITION_INC ON   L_INV_UNDER_CONDITION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_VACCINATION_INC ON  L_INV_VACCINATION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INVESTIGATION_REPEAT_INC ON  L_INVESTIGATION_REPEAT_INC.PAGE_CASE_UID =  dimc.page_case_uid
-         LEFT OUTER JOIN   dbo.L_INV_PLACE_REPEAT ON  L_INV_PLACE_REPEAT.PAGE_CASE_UID =  dimc.page_case_uid
-where phc.CASE_MANAGEMENT_UID IS NULL;
-;
-
-if @debug  = 'true' select * from #DIMENSIONAL_KEYS;
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 7;
-			SET @Proc_Step_Name = ' Generating F_PAGE_CASE_TEMP_INC';
-
-			IF OBJECT_ID('#F_PAGE_CASE_TEMP_INC', 'U') IS NOT NULL
-drop table #F_PAGE_CASE_TEMP_INC
-;
-
-
---DROP TABLE dbo.F_PAGE_CASE;
-
---CREATE TABLE 	F_PAGE_CASE AS
-SELECT
-    DIM_KEYS.*,
-    --CAST ( 1 as float ) AS D_INV_PLACE_REPEAT_KEY,
-    KEYSTORE.CONDITION_KEY,
-    KEYSTORE.INVESTIGATION_KEY,
-    KEYSTORE.PHYSICIAN_KEY,
-    KEYSTORE.INVESTIGATOR_KEY,
-    KEYSTORE.HOSPITAL_KEY as HOSPITAL_KEY,
-    KEYSTORE.PATIENT_KEY,
-    KEYSTORE.PERSON_AS_REPORTER_KEY AS PERSON_AS_REPORTER_KEY,
-    KEYSTORE.ORG_AS_REPORTER_KEY AS ORG_AS_REPORTER_KEY,
-    --KEYSTORE.HOSPITAL_KEY AS HOSPITAL_KEY,
-    KEYSTORE.GEOCODING_LOCATION_KEY,
-    DATE1.DATE_KEY AS ADD_DATE_KEY,
-    DATE2.DATE_KEY AS LAST_CHG_DATE_KEY
-
-INTO #F_PAGE_CASE_TEMP_INC
-FROM  #ENTITY_KEYSTORE_INC AS KEYSTORE
-          INNER JOIN #DIMENSIONAL_KEYS as DIM_KEYS ON DIM_KEYS.PAGE_CASE_UID = KEYSTORE.PAGE_CASE_UID
-          LEFT OUTER JOIN dbo.RDB_DATE DATE1 ON cast(DATE1.DATE_MM_DD_YYYY as date)= cast(KEYSTORE.ADD_TIME as date)
-          LEFT OUTER JOIN dbo.RDB_DATE DATE2 ON cast(DATE2.DATE_MM_DD_YYYY as date )=cast(KEYSTORE.LAST_CHG_TIME as date)
-;
-
-
-
-if @debug  = 'true' select * from #DIMENSIONAL_KEYS;
-
-
-SELECT @RowCount_no = @@ROWCOUNT;
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 8;
-			SET @Proc_Step_Name = ' Generating DROP COLUMNS';
-
-		-- DROP COLUMN PAGE_CASE_UID;
-ALTER TABLE  #F_PAGE_CASE_TEMP_INC DROP COLUMN PAGE_CASE_UID ;
-if @debug  = 'true' select * from #F_PAGE_CASE_TEMP_INC;
-
---??PROC SORT DATA=F_PAGE_CASE NODUPKEY; BY PATIENT_KEY; RUN;
-
-IF OBJECT_ID('dbo.F_PAGE_CASE', 'U') IS NOT NULL
-BEGIN
-					 --drop table dbo.F_PAGE_CASE;
-					 DELETE fpagecase FROM dbo.F_PAGE_CASE fpagecase
-					 JOIN #F_PAGE_CASE_TEMP_INC fpagecaseinc ON fpagecase.investigation_key=fpagecaseinc.investigation_key;
-
-INSERT INTO dbo.F_PAGE_CASE SELECT * FROM #F_PAGE_CASE_TEMP_INC;
-END;
-
-
-			IF OBJECT_ID('dbo.F_PAGE_CASE', 'U') IS NULL
-BEGIN
-SELECT *
-into [dbo].F_PAGE_CASE
-FROM
-    (
-    SELECT *,
-    ROW_NUMBER () OVER (PARTITION BY PATIENT_KEY order by PATIENT_KEY) rowid
-    FROM #F_PAGE_CASE_TEMP_INC
-    ) AS Der WHERE rowid=1;
-
-
-ALTER TABLE  dbo.F_PAGE_CASE DROP COLUMN rowid ;
-END;
-			/**
-			This should cover any issue with defect https://nbscentral.sramanaged.com/redmine/issues/12555
-			ETL Error in Dynamic Datamarts Process - Problem Record(s) Causing Million+ Rows in Dynamic Datamart (Total Should Be a Few Thousand)
-			*/
-
-DELETE FROM [DBO].F_PAGE_CASE WHERE INVESTIGATION_KEY IN (SELECT INVESTIGATION_KEY FROM dbo.F_PAGE_CASE
-    GROUP BY INVESTIGATION_KEY HAVING COUNT(INVESTIGATION_KEY)>1) AND PATIENT_KEY =1
-
-INSERT INTO [dbo].[job_flow_log]
-(batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
-VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
-
-
-COMMIT TRANSACTION;
-
-BEGIN TRANSACTION ;
-
-	SET @Proc_Step_no = 9;
-	SET @Proc_Step_Name = 'SP_COMPLETE';
-
-
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[row_count]
-    ,[msg_description1]
-)
-VALUES
-    (
-    @batch_id,
-    'F_PAGE_CASE'
-        ,'S_F_PAGE_CASE'
-        ,'COMPLETE'
-        ,@Proc_Step_no
-        ,@Proc_Step_name
-        ,@RowCount_no
-        ,LEFT('ID List-' + @phc_ids,500)
-    );
-
-
-COMMIT TRANSACTION;
+as
+
+    BEGIN
+        DECLARE @RowCount_no INT ;
+        DECLARE @Proc_Step_no FLOAT = 0 ;
+        DECLARE @Proc_Step_Name VARCHAR(200) = '' ;
+        DECLARE @batch_start_time datetime2(7) = null ;
+        DECLARE @batch_end_time datetime2(7) = null ;
+        DECLARE @batch_id BIGINT;
+        SET @batch_id = cast((format(getdate(),'yyyyMMddHHmmss')) as bigint);
+
+        BEGIN TRY
+
+        SET @Proc_Step_no = 1;
+        SET @Proc_Step_Name = 'SP_Start';
+
+
+        BEGIN TRANSACTION;
+
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1]
+        )
+        VALUES
+            (
+            @batch_id
+                ,'F_PAGE_CASE'
+                ,'F_PAGE_CASE'
+                ,'START'
+                ,@Proc_Step_no
+                ,@Proc_Step_Name
+                ,0
+                ,LEFT('ID List-' + @phc_ids,500)
+            );
+
+        COMMIT TRANSACTION;
+
+
+        select @batch_start_time = batch_start_dttm,@batch_end_time = batch_end_dttm
+        from [dbo].[job_batch_log]
+        where status_type = 'start' and type_code='MasterETL'
+        ;
+
+
+        BEGIN TRANSACTION;
+
+
+                SET @Proc_Step_no = 2;
+                SET @Proc_Step_Name = ' Generating PHC_UIDS_ALL';
+
+                    ---> PHC_UIDS
+        SELECT inv.public_health_case_uid page_case_uid,
+               CASE_MANAGEMENT_UID,
+               INVESTIGATION_FORM_CD,
+               CD,
+               LAST_CHG_TIME
+        INTO #PHC_UIDS
+        FROM dbo.nrt_investigation inv
+                 --LEFT OUTER JOIN NBS_ODSE..CASE_MANAGEMENT cm ON inv.PUBLIC_HEALTH_CASE_UID= cm.PUBLIC_HEALTH_CASE_UID
+                 LEFT OUTER JOIN NBS_SRTE..CONDITION_CODE cc  ON cc.CONDITION_CD= inv.CD
+            AND INVESTIGATION_FORM_CD   NOT IN ( 'INV_FORM_BMDGAS','INV_FORM_BMDGBS','INV_FORM_BMDGEN',
+                                                 'INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV',
+                                                 'INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
+        WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
+
+        if @debug  = 'true' select * from #PHC_UIDS;
+
+        IF OBJECT_ID('#PHC_UIDS_ALL', 'U') IS NOT NULL
+        drop table #PHC_UIDS_ALL
+        ;
+
+        SELECT
+            inv.PUBLIC_HEALTH_CASE_UID  'PAGE_CASE_UID', /* VS LENGTH =8 AS PAGE_CASE_UID 'PAGE_CASE_UID',*/
+                CASE_MANAGEMENT_UID,
+            INVESTIGATION_FORM_CD,
+            CD,
+            LAST_CHG_TIME
+        INTO  #PHC_UIDS_ALL
+        FROM
+            dbo.nrt_investigation inv
+                --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
+                LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND	INVESTIGATION_FORM_CD
+                NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
+        WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
+
+        if @debug  = 'true' select * from #PHC_UIDS_ALL;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+                    SET @Proc_Step_no = 3;
+                    SET @Proc_Step_Name = ' Generating PHC_CASE_UIDS_ALL';
+
+                    IF OBJECT_ID('#PHC_CASE_UIDS_ALL', 'U') IS NOT NULL
+        drop table #PHC_CASE_UIDS_ALL
+        ;
+
+
+        SELECT
+            inv.PUBLIC_HEALTH_CASE_UID  'PAGE_CASE_UID', /* VS LENGTH =8 AS PAGE_CASE_UID 'PAGE_CASE_UID',*/
+                CASE_MANAGEMENT_UID,
+            INVESTIGATION_FORM_CD,
+            CD,
+            LAST_CHG_TIME
+        INTO  #PHC_CASE_UIDS_ALL
+        FROM
+            dbo.nrt_investigation inv
+                --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
+                LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND	INVESTIGATION_FORM_CD
+                NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
+        where inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
+          AND CASE_MANAGEMENT_UID is null;
+
+        if @debug  = 'true' select * from #PHC_CASE_UIDS_ALL;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+                    SET @Proc_Step_no = 4;
+                    SET @Proc_Step_Name = ' Generating ENTITY_KEYSTORE_INC';
+
+                    IF OBJECT_ID('#ENTITY_KEYSTORE_INC', 'U') IS NOT NULL
+        drop table #ENTITY_KEYSTORE_INC
+        ;
+
+        -- drop table dbo.F_S_INV_CASE
+
+        IF OBJECT_ID('#F_S_INV_CASE', 'U') IS NOT NULL
+        drop table #F_S_INV_CASE;
+
+        -- Populate dbo.F_S_INV_CASE
+
+
+        SELECT public_health_case_uid AS PAGE_CASE_UID,
+               nac_last_chg_time as last_chg_time,
+               nac_add_time as add_time,
+               investigator_id as INVESTIGATOR_uid,
+               person_as_reporter_uid as PERSON_AS_REPORTER_UID,
+               patient_id as patient_uid,
+               physician_id as PHYSICIAN_UID,
+               hospital_uid as HOSPITAL_UID,
+               organization_id as ORG_AS_REPORTER_UID,
+               ordering_facility_uid as ORDERING_FACILTY_UID
+        INTO #F_S_INV_CASE
+        FROM dbo.nrt_investigation inv WHERE public_health_case_uid
+                                                 IN (SELECT PAGE_CASE_UID FROM #PHC_UIDS WHERE CASE_MANAGEMENT_UID IS NULL);
+
+        if @debug  = 'true' select * from #F_S_INV_CASE;
+
+
+        SELECT
+            FSIV.ADD_TIME,
+            FSIV.LAST_CHG_TIME,
+            FSIV.PATIENT_UID,
+            COALESCE(PATIENT.PATIENT_KEY, 1)  AS PATIENT_KEY,
+            FSIV.PAGE_CASE_UID,
+            FSIV.HOSPITAL_UID,
+            COALESCE(HOSPITAL.ORGANIZATION_KEY, 1)  AS HOSPITAL_KEY,
+            FSIV.ORG_AS_REPORTER_UID,
+            COALESCE(REPORTERORG.ORGANIZATION_KEY, 1)  AS ORG_AS_REPORTER_KEY,
+            FSIV.PERSON_AS_REPORTER_UID,
+            COALESCE(PERSONREPORTER.PROVIDER_KEY, 1)  AS PERSON_AS_REPORTER_KEY,
+            FSIV.PHYSICIAN_UID,
+            COALESCE(PHYSICIAN.PROVIDER_KEY, 1)  AS PHYSICIAN_KEY,
+            FSIV.INVESTIGATOR_UID,
+            COALESCE(PROVIDER.PROVIDER_KEY, 1)  AS INVESTIGATOR_KEY,
+            COALESCE(INVESTIGATION.INVESTIGATION_KEY,1 ) AS INVESTIGATION_KEY,
+            COALESCE(CONDITION.CONDITION_KEY,1)  AS CONDITION_KEY,
+            COALESCE(LOC.GEOCODING_LOCATION_KEY, 1) AS GEOCODING_LOCATION_KEY
+        --'' as TEMP
+        into #ENTITY_KEYSTORE_INC
+        FROM #F_S_INV_CASE  FSIV
+                 LEFT OUTER JOIN dbo.D_PATIENT PATIENT	 ON	FSIV.PATIENT_UID= PATIENT.PATIENT_UID
+                 LEFT OUTER JOIN dbo.D_ORGANIZATION  HOSPITAL ON 	FSIV.HOSPITAL_UID= HOSPITAL.ORGANIZATION_UID
+                 LEFT OUTER JOIN dbo.D_ORGANIZATION REPORTERORG ON 	FSIV.ORG_AS_REPORTER_UID= REPORTERORG.ORGANIZATION_UID
+                 LEFT OUTER JOIN dbo.D_PROVIDER PERSONREPORTER ON  	FSIV.PERSON_AS_REPORTER_UID= PERSONREPORTER.PROVIDER_UID
+                 LEFT OUTER JOIN dbo.D_PROVIDER PROVIDER ON 	FSIV.INVESTIGATOR_UID= PROVIDER.PROVIDER_UID
+                 LEFT OUTER JOIN dbo.D_PROVIDER PHYSICIAN ON 	FSIV.PHYSICIAN_UID= PHYSICIAN.PROVIDER_UID
+                 LEFT OUTER JOIN dbo.INVESTIGATION  INVESTIGATION ON 	FSIV.PAGE_CASE_UID= INVESTIGATION.CASE_UID
+                 LEFT OUTER JOIN #PHC_CASE_UIDS_ALL  CASE_UID ON 	FSIV.PAGE_CASE_UID= CASE_UID.PAGE_CASE_UID
+                 LEFT OUTER JOIN dbo.CONDITION CONDITION ON 	CASE_UID.CD= CONDITION.CONDITION_CD
+                 LEFT JOIN dbo.GEOCODING_LOCATION AS LOC ON LOC.ENTITY_UID = PATIENT.PATIENT_UID
+        ;
+
+        if @debug  = 'true' select * from #ENTITY_KEYSTORE_INC;
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_no = 5;
+        SET @Proc_Step_Name = ' Generating DIMENSION_KEYS_PAGECASEID';
+
+        IF OBJECT_ID('#DIMENSION_KEYS_PAGECASEID', 'U') IS NOT NULL
+        drop table #DIMENSION_KEYS_PAGECASEID
+        ;
+
+        select L_INV_ADMINISTRATIVE_INC.PAGE_CASE_UID as PAGE_CASE_UID
+        into #DIMENSION_KEYS_PAGECASEID
+        from  dbo.L_INV_ADMINISTRATIVE_INC  union
+        select L_INV_CLINICAL_INC.PAGE_CASE_UID 	 from  dbo.L_INV_CLINICAL_INC  union
+        select L_INV_COMPLICATION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_COMPLICATION_INC  union
+        select L_INV_CONTACT_INC.PAGE_CASE_UID 	 from  dbo.L_INV_CONTACT_INC  union
+        select L_INV_DEATH_INC.PAGE_CASE_UID 	 from  dbo.L_INV_DEATH_INC  union
+        select L_INV_EPIDEMIOLOGY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_EPIDEMIOLOGY_INC  union
+        select L_INV_HIV_INC.PAGE_CASE_UID 	 from  dbo.L_INV_HIV_INC  union
+        select L_INV_ISOLATE_TRACKING_INC.PAGE_CASE_UID 	 from  dbo.L_INV_ISOLATE_TRACKING_INC  union
+        select L_INV_LAB_FINDING_INC.PAGE_CASE_UID 	 from  dbo.L_INV_LAB_FINDING_INC  union
+        select L_INV_MEDICAL_HISTORY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_MEDICAL_HISTORY_INC  union
+        select L_INV_MOTHER_INC.PAGE_CASE_UID 	 from  dbo.L_INV_MOTHER_INC  union
+        select L_INV_OTHER_INC.PAGE_CASE_UID 	 from  dbo.L_INV_OTHER_INC  union
+        select L_INV_PATIENT_OBS_INC.PAGE_CASE_UID 	 from  dbo.L_INV_PATIENT_OBS_INC  union
+        select L_INV_PREGNANCY_BIRTH_INC.PAGE_CASE_UID 	 from  dbo.L_INV_PREGNANCY_BIRTH_INC  union
+        select L_INV_RESIDENCY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_RESIDENCY_INC  union
+        select L_INV_RISK_FACTOR_INC.PAGE_CASE_UID 	 from  dbo.L_INV_RISK_FACTOR_INC  union
+        select L_INV_SOCIAL_HISTORY_INC.PAGE_CASE_UID 	 from  dbo.L_INV_SOCIAL_HISTORY_INC  union
+        select L_INV_SYMPTOM_INC.PAGE_CASE_UID 	 from  dbo.L_INV_SYMPTOM_INC  union
+        select L_INV_TRAVEL_INC.PAGE_CASE_UID 	 from  dbo.L_INV_TRAVEL_INC  union
+        select L_INV_TREATMENT_INC.PAGE_CASE_UID 	 from  dbo.L_INV_TREATMENT_INC  union
+        select L_INV_UNDER_CONDITION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_UNDER_CONDITION_INC  union
+        select L_INV_VACCINATION_INC.PAGE_CASE_UID 	 from  dbo.L_INV_VACCINATION_INC union
+        SELECT L_INVESTIGATION_REPEAT_INC.PAGE_CASE_UID	 from  [dbo].[L_INVESTIGATION_REPEAT_INC] union
+        SELECT L_INV_PLACE_REPEAT.PAGE_CASE_UID	 from  [dbo].[L_INV_PLACE_REPEAT]
+        ;
+
+        if @debug  = 'true' select * from #DIMENSION_KEYS_PAGECASEID where page_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','));
+
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+                    SET @Proc_Step_no = 6;
+                    SET @Proc_Step_Name = ' Generating DIMENSIONAL_KEYS';
+
+                    IF OBJECT_ID('#DIMENSIONAL_KEYS', 'U') IS NOT NULL
+        drop table #DIMENSIONAL_KEYS
+        ;
+
+        /**Updated to handle cases when there are no page builder investigation updates.*/
+        select  phc.page_case_uid,
+                COALESCE(L_INV_ADMINISTRATIVE_INC.D_INV_ADMINISTRATIVE_KEY , 1) AS 	D_INV_ADMINISTRATIVE_KEY ,
+                COALESCE(L_INV_CLINICAL_INC.D_INV_CLINICAL_KEY , 1) AS 	D_INV_CLINICAL_KEY ,
+                COALESCE(L_INV_COMPLICATION_INC.D_INV_COMPLICATION_KEY , 1) AS 	D_INV_COMPLICATION_KEY ,
+                COALESCE(L_INV_CONTACT_INC.D_INV_CONTACT_KEY , 1) AS 	D_INV_CONTACT_KEY ,
+                COALESCE(L_INV_DEATH_INC.D_INV_DEATH_KEY , 1) AS 	D_INV_DEATH_KEY ,
+                COALESCE(L_INV_EPIDEMIOLOGY_INC.D_INV_EPIDEMIOLOGY_KEY , 1) AS 	D_INV_EPIDEMIOLOGY_KEY ,
+                COALESCE(L_INV_HIV_INC.D_INV_HIV_KEY , 1) AS 	D_INV_HIV_KEY ,
+                COALESCE(L_INV_PATIENT_OBS_INC.D_INV_PATIENT_OBS_KEY , 1) AS 	D_INV_PATIENT_OBS_KEY ,
+                COALESCE(L_INV_ISOLATE_TRACKING_INC.D_INV_ISOLATE_TRACKING_KEY , 1) AS 	D_INV_ISOLATE_TRACKING_KEY ,
+                COALESCE(L_INV_LAB_FINDING_INC.D_INV_LAB_FINDING_KEY , 1) AS 	D_INV_LAB_FINDING_KEY ,
+                COALESCE(L_INV_MEDICAL_HISTORY_INC.D_INV_MEDICAL_HISTORY_KEY , 1) AS 	D_INV_MEDICAL_HISTORY_KEY ,
+                COALESCE(L_INV_MOTHER_INC.D_INV_MOTHER_KEY , 1) AS 	D_INV_MOTHER_KEY ,
+                COALESCE(L_INV_OTHER_INC.D_INV_OTHER_KEY , 1) AS 	D_INV_OTHER_KEY ,
+                COALESCE(L_INV_PREGNANCY_BIRTH_INC.D_INV_PREGNANCY_BIRTH_KEY , 1) AS 	D_INV_PREGNANCY_BIRTH_KEY ,
+                COALESCE(L_INV_RESIDENCY_INC.D_INV_RESIDENCY_KEY , 1) AS 	D_INV_RESIDENCY_KEY ,
+                COALESCE(L_INV_RISK_FACTOR_INC.D_INV_RISK_FACTOR_KEY , 1) AS 	D_INV_RISK_FACTOR_KEY ,
+                COALESCE(L_INV_SOCIAL_HISTORY_INC.D_INV_SOCIAL_HISTORY_KEY , 1) AS 	D_INV_SOCIAL_HISTORY_KEY ,
+                COALESCE(L_INV_SYMPTOM_INC.D_INV_SYMPTOM_KEY , 1) AS 	D_INV_SYMPTOM_KEY ,
+                COALESCE(L_INV_TREATMENT_INC.D_INV_TREATMENT_KEY , 1) AS 	D_INV_TREATMENT_KEY ,
+                COALESCE(L_INV_TRAVEL_INC.D_INV_TRAVEL_KEY , 1) AS 	D_INV_TRAVEL_KEY ,
+                COALESCE(L_INV_UNDER_CONDITION_INC.D_INV_UNDER_CONDITION_KEY , 1) AS 	D_INV_UNDER_CONDITION_KEY ,
+                COALESCE(L_INV_VACCINATION_INC.D_INV_VACCINATION_KEY , 1) AS 	D_INV_VACCINATION_KEY ,
+                COALESCE(L_INVESTIGATION_REPEAT_INC.D_INVESTIGATION_REPEAT_KEY , 1 ) AS	D_INVESTIGATION_REPEAT_KEY,
+                COALESCE(L_INV_PLACE_REPEAT.D_INV_PLACE_REPEAT_KEY , 1 ) AS	D_INV_PLACE_REPEAT_KEY
+        into #DIMENSIONAL_KEYS
+        from #PHC_UIDS phc
+                 LEFT OUTER JOIN  #DIMENSION_KEYS_PAGECASEID DIMC ON DIMC.PAGE_CASE_UID = phc.PAGE_CASE_UID
+                 LEFT OUTER JOIN   dbo.L_INV_ADMINISTRATIVE_INC ON  L_INV_ADMINISTRATIVE_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_CLINICAL_INC ON  L_INV_CLINICAL_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_COMPLICATION_INC ON  L_INV_COMPLICATION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_CONTACT_INC ON  L_INV_CONTACT_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_DEATH_INC ON  L_INV_DEATH_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_EPIDEMIOLOGY_INC ON  L_INV_EPIDEMIOLOGY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_HIV_INC ON  L_INV_HIV_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_ISOLATE_TRACKING_INC ON  L_INV_ISOLATE_TRACKING_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_LAB_FINDING_INC ON  L_INV_LAB_FINDING_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_MEDICAL_HISTORY_INC ON  L_INV_MEDICAL_HISTORY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_MOTHER_INC ON  L_INV_MOTHER_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_OTHER_INC ON  L_INV_OTHER_INC.PAGE_CASE_UID = dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_PATIENT_OBS_INC ON  L_INV_PATIENT_OBS_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_PREGNANCY_BIRTH_INC ON  L_INV_PREGNANCY_BIRTH_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_RESIDENCY_INC ON  L_INV_RESIDENCY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_RISK_FACTOR_INC ON  L_INV_RISK_FACTOR_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_SOCIAL_HISTORY_INC ON  L_INV_SOCIAL_HISTORY_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_SYMPTOM_INC ON  L_INV_SYMPTOM_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_TRAVEL_INC ON  L_INV_TRAVEL_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_TREATMENT_INC ON   L_INV_TREATMENT_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_UNDER_CONDITION_INC ON   L_INV_UNDER_CONDITION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_VACCINATION_INC ON  L_INV_VACCINATION_INC.PAGE_CASE_UID  =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INVESTIGATION_REPEAT_INC ON  L_INVESTIGATION_REPEAT_INC.PAGE_CASE_UID =  dimc.page_case_uid
+                 LEFT OUTER JOIN   dbo.L_INV_PLACE_REPEAT ON  L_INV_PLACE_REPEAT.PAGE_CASE_UID =  dimc.page_case_uid
+        where phc.CASE_MANAGEMENT_UID IS NULL;
+        ;
+
+        if @debug  = 'true' select * from #DIMENSIONAL_KEYS;
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+                    SET @Proc_Step_no = 7;
+                    SET @Proc_Step_Name = ' Generating F_PAGE_CASE_TEMP_INC';
+
+                    IF OBJECT_ID('#F_PAGE_CASE_TEMP_INC', 'U') IS NOT NULL
+        drop table #F_PAGE_CASE_TEMP_INC
+        ;
+
+
+        --DROP TABLE dbo.F_PAGE_CASE;
+
+        --CREATE TABLE 	F_PAGE_CASE AS
+        SELECT
+            DIM_KEYS.*,
+            --CAST ( 1 as float ) AS D_INV_PLACE_REPEAT_KEY,
+            KEYSTORE.CONDITION_KEY,
+            KEYSTORE.INVESTIGATION_KEY,
+            KEYSTORE.PHYSICIAN_KEY,
+            KEYSTORE.INVESTIGATOR_KEY,
+            KEYSTORE.HOSPITAL_KEY as HOSPITAL_KEY,
+            KEYSTORE.PATIENT_KEY,
+            KEYSTORE.PERSON_AS_REPORTER_KEY AS PERSON_AS_REPORTER_KEY,
+            KEYSTORE.ORG_AS_REPORTER_KEY AS ORG_AS_REPORTER_KEY,
+            --KEYSTORE.HOSPITAL_KEY AS HOSPITAL_KEY,
+            KEYSTORE.GEOCODING_LOCATION_KEY,
+            DATE1.DATE_KEY AS ADD_DATE_KEY,
+            DATE2.DATE_KEY AS LAST_CHG_DATE_KEY
+
+        INTO #F_PAGE_CASE_TEMP_INC
+        FROM  #ENTITY_KEYSTORE_INC AS KEYSTORE
+                  INNER JOIN #DIMENSIONAL_KEYS as DIM_KEYS ON DIM_KEYS.PAGE_CASE_UID = KEYSTORE.PAGE_CASE_UID
+                  LEFT OUTER JOIN dbo.RDB_DATE DATE1 ON cast(DATE1.DATE_MM_DD_YYYY as date)= cast(KEYSTORE.ADD_TIME as date)
+                  LEFT OUTER JOIN dbo.RDB_DATE DATE2 ON cast(DATE2.DATE_MM_DD_YYYY as date )=cast(KEYSTORE.LAST_CHG_TIME as date)
+        ;
+
+
+
+        if @debug  = 'true' select * from #DIMENSIONAL_KEYS;
+
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION;
+
+                    SET @Proc_Step_no = 8;
+                    SET @Proc_Step_Name = ' Generating DROP COLUMNS';
+
+                -- DROP COLUMN PAGE_CASE_UID;
+        ALTER TABLE  #F_PAGE_CASE_TEMP_INC DROP COLUMN PAGE_CASE_UID ;
+        if @debug  = 'true' select * from #F_PAGE_CASE_TEMP_INC;
+
+        --??PROC SORT DATA=F_PAGE_CASE NODUPKEY; BY PATIENT_KEY; RUN;
+
+        IF OBJECT_ID('dbo.F_PAGE_CASE', 'U') IS NOT NULL
+        BEGIN
+                             --drop table dbo.F_PAGE_CASE;
+                             DELETE fpagecase FROM dbo.F_PAGE_CASE fpagecase
+                             JOIN #F_PAGE_CASE_TEMP_INC fpagecaseinc ON fpagecase.investigation_key=fpagecaseinc.investigation_key;
+
+        INSERT INTO dbo.F_PAGE_CASE SELECT * FROM #F_PAGE_CASE_TEMP_INC;
+        END;
+
+
+                    IF OBJECT_ID('dbo.F_PAGE_CASE', 'U') IS NULL
+        BEGIN
+        SELECT *
+        into [dbo].F_PAGE_CASE
+        FROM
+            (
+            SELECT *,
+            ROW_NUMBER () OVER (PARTITION BY PATIENT_KEY order by PATIENT_KEY) rowid
+            FROM #F_PAGE_CASE_TEMP_INC
+            ) AS Der WHERE rowid=1;
+
+
+        ALTER TABLE  dbo.F_PAGE_CASE DROP COLUMN rowid ;
+        END;
+                    /**
+                    This should cover any issue with defect https://nbscentral.sramanaged.com/redmine/issues/12555
+                    ETL Error in Dynamic Datamarts Process - Problem Record(s) Causing Million+ Rows in Dynamic Datamart (Total Should Be a Few Thousand)
+                    */
+
+        DELETE FROM [DBO].F_PAGE_CASE WHERE INVESTIGATION_KEY IN (SELECT INVESTIGATION_KEY FROM dbo.F_PAGE_CASE
+            GROUP BY INVESTIGATION_KEY HAVING COUNT(INVESTIGATION_KEY)>1) AND PATIENT_KEY =1
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id,[Dataflow_Name],[package_Name] ,[Status_Type],[step_number],[step_name],[row_count])
+        VALUES(@batch_id,'F_PAGE_CASE','F_PAGE_CASE','START',@Proc_Step_no,@Proc_Step_Name,@RowCount_no);
+
+
+        COMMIT TRANSACTION;
+
+        BEGIN TRANSACTION ;
+
+            SET @Proc_Step_no = 9;
+            SET @Proc_Step_Name = 'SP_COMPLETE';
+
+
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[msg_description1]
+        )
+        VALUES
+            (
+            @batch_id,
+            'F_PAGE_CASE'
+                ,'S_F_PAGE_CASE'
+                ,'COMPLETE'
+                ,@Proc_Step_no
+                ,@Proc_Step_name
+                ,@RowCount_no
+                ,LEFT('ID List-' + @phc_ids,500)
+            );
+
+
+        COMMIT TRANSACTION;
 END TRY
 
 BEGIN CATCH
 
 
-IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
+        IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
 
 
-	DECLARE @ErrorNumber INT = ERROR_NUMBER();
-    DECLARE @ErrorLine INT = ERROR_LINE();
-    DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
-    DECLARE @ErrorSeverity INT = ERROR_SEVERITY();
-    DECLARE @ErrorState INT = ERROR_STATE();
+            DECLARE @ErrorNumber INT = ERROR_NUMBER();
+            DECLARE @ErrorLine INT = ERROR_LINE();
+            DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+            DECLARE @ErrorSeverity INT = ERROR_SEVERITY();
+            DECLARE @ErrorState INT = ERROR_STATE();
 
 
-INSERT INTO [dbo].[job_flow_log] (
-                                   batch_id
-    ,[Dataflow_Name]
-    ,[package_Name]
-    ,[Status_Type]
-    ,[step_number]
-    ,[step_name]
-    ,[Error_Description]
-    ,[row_count]
-)
-VALUES
-    (
-    @batch_id
-        ,'F_PAGE_CASE'
-        ,'S_F_PAGE_CASE'
-        ,'ERROR'
-        ,@Proc_Step_no
-        ,'ERROR - '+ @Proc_Step_name
-        , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
-        ,0
-    );
+        INSERT INTO [dbo].[job_flow_log] (
+                                           batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[Error_Description]
+            ,[row_count]
+        )
+        VALUES
+            (
+            @batch_id
+                ,'F_PAGE_CASE'
+                ,'S_F_PAGE_CASE'
+                ,'ERROR'
+                ,@Proc_Step_no
+                ,'ERROR - '+ @Proc_Step_name
+                , 'Step -' +CAST(@Proc_Step_no AS VARCHAR(3))+' -' +CAST(@ErrorMessage AS VARCHAR(500))
+                ,0
+            );
 
 
-return -1 ;
+        return -1 ;
 
 END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb/031-sp_hepatitis_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/031-sp_hepatitis_datamart_postprocessing-001.sql
@@ -1,3511 +1,2590 @@
 CREATE OR ALTER PROCEDURE dbo.sp_hepatitis_datamart_postprocessing
-        @phc_id nvarchar(max),
-		@pat_ids nvarchar(max) = '',
-		@debug bit = 'false'
+    @phc_id nvarchar(max),
+    @pat_ids nvarchar(max) = '',
+    @debug bit = 'false'
 AS
 BEGIN
 
-BEGIN TRY
+    BEGIN TRY
 
 
-	declare @sql nvarchar(4000);
+        declare @sql nvarchar(4000);
 
-	DECLARE @RowCount_no int;
+        DECLARE @RowCount_no int;
 
-	DECLARE @Proc_Step_no float= 0;
+        DECLARE @Proc_Step_no float= 0;
 
-	DECLARE @Proc_Step_Name varchar(200)= '';
+        DECLARE @Proc_Step_Name varchar(200)= '';
 
-	DECLARE @batch_start_time datetime2(7)= NULL;
+        DECLARE @batch_start_time datetime2(7)= NULL;
 
-	DECLARE @batch_end_time datetime2(7)= NULL;
+        DECLARE @batch_end_time datetime2(7)= NULL;
 
-	DECLARE @COUNT_PB_HEP AS int;
+        DECLARE @COUNT_PB_HEP AS int;
 
-	DECLARE @date_last_run datetime2(7)= NULL;
+        DECLARE @date_last_run datetime2(7)= NULL;
 
-	DECLARE @batch_id BIGINT;
-	SET @batch_id = cast((format(getdate(),'yyyyMMddHHmmss')) as bigint);
-	PRINT @batch_id;
-
-
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_no = 1;
-
-			SET @Proc_Step_Name = 'SP_Start';
+        DECLARE @batch_id BIGINT;
+        SET @batch_id = cast((format(getdate(),'yyyyMMddHHmmss')) as bigint);
+        PRINT @batch_id;
 
 
-INSERT INTO [dbo].[job_flow_log]( batch_id, ---------------@batch_id
-    [Dataflow_Name], --------------'HEPATITIS_DATAMART'
-    [package_Name], --------------'Hepatitis_Case_DATAMART'
-    [Status_Type], ---------------START
-    [step_number], ---------------@Proc_Step_no
-    [step_name], ------------------@Proc_Step_Name=sp_start
-    [row_count], --------------------0
-[Msg_Description1]
-)
-VALUES( @batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @Proc_Step_no, @Proc_Step_Name, 0,LEFT('ID List-' + @phc_id,500));
+        BEGIN TRANSACTION;
 
-COMMIT TRANSACTION;
+        SET @Proc_Step_no = 1;
 
-SELECT @batch_start_time = batch_start_dttm, @batch_end_time = batch_end_dttm
-FROM [dbo].[job_batch_log]
-WHERE status_type = 'start';
+        SET @Proc_Step_Name = 'SP_Start';
 
 
----------------------------------------------------------------------2 Create Table HEPATITIS_DATAMART_LAST-----------------------
-BEGIN TRANSACTION;
+        INSERT INTO [dbo].[job_flow_log]( batch_id, ---------------@batch_id
+                                          [Dataflow_Name], --------------'HEPATITIS_DATAMART'
+                                          [package_Name], --------------'Hepatitis_Case_DATAMART'
+                                          [Status_Type], ---------------START
+                                          [step_number], ---------------@Proc_Step_no
+                                          [step_name], ------------------@Proc_Step_Name=sp_start
+                                          [row_count], --------------------0
+                                          [Msg_Description1]
+        )
+        VALUES( @batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @Proc_Step_no, @Proc_Step_Name, 0,LEFT('ID List-' + @phc_id,500));
 
-			SET @Proc_Step_name = 'Generating  HEPATITIS_DATAMART_LAST ';
+        COMMIT TRANSACTION;
 
-			SET @Proc_Step_no = 2;
-
-			IF OBJECT_ID('dbo.HEPATITIS_DATAMART_LAST', 'U') IS NOT NULL
-BEGIN
-DROP TABLE dbo.HEPATITIS_DATAMART_LAST;
-
-END;
-
-CREATE TABLE dbo.HEPATITIS_DATAMART_LAST
-    (
-        date_last_ran datetime2(7), START_DATE datetime2(7)
-    );
-
-INSERT INTO dbo.HEPATITIS_DATAMART_LAST( date_last_ran, START_DATE )
-VALUES( '01jun1900', '01jun1900' );
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-UPDATE dbo.HEPATITIS_DATAMART_LAST
-SET date_last_ran =
-    (
-        SELECT MAX([REFRESH_DATETIME])
-        FROM [dbo].[HEPATITIS_DATAMART]
-    ), START_DATE = GETDATE();
-
-UPDATE dbo.HEPATITIS_DATAMART_LAST
-SET date_last_ran = '01jun1900'
-WHERE date_last_ran IS NULL;
-
-
-SET @date_last_run =
-			(
-				SELECT date_last_ran
-				FROM dbo.HEPATITIS_DATAMART_LAST
-			);
-
-COMMIT TRANSACTION;
-
-
-
------------------------------------------------------------8. Create Table dbo.EXISTING_HEPATITIS_DATAMART-------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  dbo.EXISTING_HEPATITIS_DATAMART';
-
-			SET @Proc_Step_no = 8;
-
-			IF OBJECT_ID('#EXISTING_HEPATITIS_DATAMART', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #EXISTING_HEPATITIS_DATAMART;
-
-END;
-
-SELECT DISTINCT
-    investigation.investigation_key
-INTO #EXISTING_HEPATITIS_DATAMART
-FROM dbo.HEPATITIS_DATAMART WITH(NOLOCK)
-				INNER JOIN dbo.INVESTIGATION WITH(NOLOCK) ON HEPATITIS_DATAMART.[CASE_UID] = INVESTIGATION.[CASE_UID]
-WHERE
-    INVESTIGATION.[CASE_UID] IN (SELECT value FROM STRING_SPLIT(@phc_id, ','));
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
+        SELECT @batch_start_time = batch_start_dttm, @batch_end_time = batch_end_dttm
+        FROM [dbo].[job_batch_log]
+        WHERE status_type = 'start';
 
 
 
 -----------------------------------------------------------9. Create Table #TMP_CONDITION---------------------------------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_CONDITION';
+        SET @Proc_Step_name = 'Generating  #TMP_CONDITION';
 
-			SET @Proc_Step_no = 9;
+        SET @Proc_Step_no = 9;
 
-			IF OBJECT_ID('#TMP_CONDITION', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_CONDITION;
+        IF OBJECT_ID('#TMP_CONDITION', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_CONDITION;
 
-END;
+            END;
 
-SELECT CONDITION_CD, CONDITION_DESC, DISEASE_GRP_DESC, CONDITION_KEY
-INTO #TMP_CONDITION
-FROM [dbo].[CONDITION] WITH(NOLOCK)
-WHERE CONDITION_CD IN( '10110', '10104', '10100', '10106', '10101', '10102', '10103', '10105', '10481', '50248', '999999' );
+        SELECT CONDITION_CD, CONDITION_DESC, DISEASE_GRP_DESC, CONDITION_KEY
+        INTO #TMP_CONDITION
+        FROM [dbo].[CONDITION] WITH(NOLOCK)
+        WHERE CONDITION_CD IN( '10110', '10104', '10100', '10106', '10101', '10102', '10103', '10105', '10481', '50248', '999999' );
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 
 ---------------------------------------------------------------------10. CREATE TABLE #TMP_F_PAGE_CASE-------------------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_F_PAGE_CASE';
+        SET @Proc_Step_name = 'Generating  #TMP_F_PAGE_CASE';
 
-			SET @Proc_Step_no = 10;
+        SET @Proc_Step_no = 10;
 
-			IF OBJECT_ID('#TMP_F_PAGE_CASE', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_PAGE_CASE;
+        IF OBJECT_ID('#TMP_F_PAGE_CASE', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_PAGE_CASE;
 
-END;
+            END;
 
-			/*
+        /* Select Keys that do not exist in Hepatitis Datamart and Investigations that are being updated.*/
 
-			SELECT F_PAGE_CASE.INVESTIGATION_KEY, T.CONDITION_KEY, F_PAGE_CASE.PATIENT_KEY
-			INTO #TMP_F_PAGE_CASE
-			FROM [dbo].[F_PAGE_CASE] WITH(NOLOCK)---Original table
-				 INNER JOIN	 #TMP_CONDITION AS T WITH(NOLOCK) ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY  ------(my table comdition)
-				 INNER JOIN	 [dbo].[D_PATIENT] WITH(NOLOCK)		 ON F_PAGE_CASE.PATIENT_KEY = D_PATIENT.PATIENT_KEY
-				 INNER JOIN	 dbo.INVESTIGATION WITH(NOLOCK)		 ON INVESTIGATION.INVESTIGATION_KEY = F_PAGE_CASE.INVESTIGATION_KEY
-				 LEFT JOIN	 dbo.EXISTING_HEPATITIS_DATAMART WITH(NOLOCK) ON F_PAGE_CASE.INVESTIGATION_KEY = EXISTING_HEPATITIS_DATAMART.INVESTIGATION_KEY
-			WHERE   ( EXISTING_HEPATITIS_DATAMART.INVESTIGATION_KEY IS NULL
-			         or  (INVESTIGATION.[LAST_CHG_TIME]  >= @batch_start_time   AND  INVESTIGATION.[LAST_CHG_TIME]<  @batch_end_time))
-			  AND INVESTIGATION.RECORD_STATUS_CD = 'ACTIVE'
-			ORDER BY F_PAGE_CASE.INVESTIGATION_KEY;
+        SELECT F_PAGE_CASE.INVESTIGATION_KEY, T.CONDITION_KEY, F_PAGE_CASE.PATIENT_KEY
+        INTO #TMP_F_PAGE_CASE
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)---Original table
+                 INNER JOIN	 #TMP_CONDITION AS T WITH(NOLOCK) ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY  ------(my table condition)
+                 INNER JOIN	 dbo.D_PATIENT WITH(NOLOCK)		 ON F_PAGE_CASE.PATIENT_KEY = D_PATIENT.PATIENT_KEY
+                 INNER JOIN	 dbo.INVESTIGATION WITH(NOLOCK)		 ON INVESTIGATION.INVESTIGATION_KEY = F_PAGE_CASE.INVESTIGATION_KEY
+                 LEFT JOIN	 dbo.HEPATITIS_DATAMART hd WITH(NOLOCK) ON F_PAGE_CASE.INVESTIGATION_KEY = hd.INVESTIGATION_KEY
+        WHERE   (hd.INVESTIGATION_KEY IS NULL
+            or  (INVESTIGATION.CASE_UID IN (SELECT value FROM STRING_SPLIT(@phc_id, ','))))
+          AND INVESTIGATION.RECORD_STATUS_CD = 'ACTIVE'
+        ORDER BY F_PAGE_CASE.INVESTIGATION_KEY;
 
-			*/
-
-
-SELECT F_PAGE_CASE.INVESTIGATION_KEY, T.CONDITION_KEY, F_PAGE_CASE.PATIENT_KEY
-INTO #TMP_F_PAGE_CASE
-FROM [dbo].[F_PAGE_CASE] WITH(NOLOCK)---Original table
-    INNER JOIN	 #TMP_CONDITION AS T WITH(NOLOCK) ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY  ------(my table comdition)
-    INNER JOIN	 [dbo].[D_PATIENT] WITH(NOLOCK)		 ON F_PAGE_CASE.PATIENT_KEY = D_PATIENT.PATIENT_KEY
-    INNER JOIN	 dbo.INVESTIGATION WITH(NOLOCK)		 ON INVESTIGATION.INVESTIGATION_KEY = F_PAGE_CASE.INVESTIGATION_KEY
-    LEFT JOIN	 #EXISTING_HEPATITIS_DATAMART ehd WITH(NOLOCK) ON F_PAGE_CASE.INVESTIGATION_KEY = ehd.INVESTIGATION_KEY
-WHERE   ( ehd.INVESTIGATION_KEY IS NULL
-   or  (INVESTIGATION.[CASE_UID] IN (SELECT value FROM STRING_SPLIT(@phc_id, ','))))
-  AND INVESTIGATION.RECORD_STATUS_CD = 'ACTIVE'
-ORDER BY F_PAGE_CASE.INVESTIGATION_KEY;
-
-if @debug ='true' select * from #TMP_F_PAGE_CASE;
+        if @debug ='true' select * from #TMP_F_PAGE_CASE;
 
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 
 ---------------------------------------------------------------------11. CREATE TABLE #TMP_D_INV_ADMINISTRATIVE
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_ADMINISTRATIVE';
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_ADMINISTRATIVE';
 
-			SET @Proc_Step_no = 11;
-
-
-			IF OBJECT_ID('#TMP_F_INV_ADMINISTRATIVE', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_ADMINISTRATIVE;
-
-END;
+        SET @Proc_Step_no = 11;
 
 
-SELECT page_case.D_INV_ADMINISTRATIVE_KEY, page_case.INVESTIGATION_KEY
-INTO #TMP_F_INV_ADMINISTRATIVE
-FROM dbo.F_PAGE_CASE AS page_case WITH(NOLOCK) ----Original table
-				 INNER JOIN	 #TMP_F_PAGE_CASE AS T
-ON T.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY  ---(My Table)--Should it be F-Page or tmp_F_Page
-ORDER BY D_INV_ADMINISTRATIVE_KEY;
+        IF OBJECT_ID('#TMP_F_INV_ADMINISTRATIVE', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_ADMINISTRATIVE;
+
+            END;
 
 
-
-IF OBJECT_ID('#TMP_D_INV_ADMINISTRATIVE', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_ADMINISTRATIVE;
-
-END;
-
-
-SELECT admin.*
-INTO #D_INV_ADMIN_TEMP_COLS
-FROM (
-         SELECT CAST(NULL as varchar(300)) AS ADM_INNC_NOTIFICATION_DT,
-                CAST(NULL as varchar(300)) AS ADM_FIRST_RPT_TO_PHD_DT,
-                CAST(NULL as varchar(300)) AS ADM_BINATIONAL_RPTNG_CRIT
-     ) AS temp_admin_columns
-    CROSS APPLY
-				( SELECT D_INV_ADMINISTRATIVE_KEY,
-					ADM_INNC_NOTIFICATION_DT,
-					ADM_FIRST_RPT_TO_PHD_DT,
-					ADM_BINATIONAL_RPTNG_CRIT
-					FROM dbo.D_INV_ADMINISTRATIVE
-				) AS admin;
-
-
-SELECT F.D_INV_ADMINISTRATIVE_KEY, F.INVESTIGATION_KEY AS ADMIN_INV_KEY,
-       ADM_INNC_NOTIFICATION_DT AS INNC_NOTIFICATION_DT, ADM_FIRST_RPT_TO_PHD_DT AS FIRST_RPT_PHD_DT,
-       ADM_BINATIONAL_RPTNG_CRIT AS BINATIONAL_RPTNG_CRIT
-INTO #TMP_D_INV_ADMINISTRATIVE
-FROM #TMP_F_INV_ADMINISTRATIVE AS F
-         LEFT JOIN #D_INV_ADMIN_TEMP_COLS AS D WITH(NOLOCK) ON F.D_INV_ADMINISTRATIVE_KEY = D.D_INV_ADMINISTRATIVE_KEY
-;
+        SELECT page_case.D_INV_ADMINISTRATIVE_KEY, page_case.INVESTIGATION_KEY
+        INTO #TMP_F_INV_ADMINISTRATIVE
+        FROM dbo.F_PAGE_CASE AS page_case WITH(NOLOCK) ----Original table
+                 INNER JOIN	 #TMP_F_PAGE_CASE AS T
+                                ON T.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY  ---(My Table)--Should it be F-Page or tmp_F_Page
+        ORDER BY D_INV_ADMINISTRATIVE_KEY;
 
 
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        IF OBJECT_ID('#TMP_D_INV_ADMINISTRATIVE', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_ADMINISTRATIVE;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+            END;
 
-COMMIT TRANSACTION;
+        /*D_INV_ADMINISTRATOR columns are temporarily collected. If the columns do not exist, null values are assigned.*/
+
+        SELECT admin.*
+        INTO #D_INV_ADMIN_TEMP_COLS
+        FROM (
+                 SELECT CAST(NULL as varchar(300)) AS ADM_INNC_NOTIFICATION_DT,
+                        CAST(NULL as varchar(300)) AS ADM_FIRST_RPT_TO_PHD_DT,
+                        CAST(NULL as varchar(300)) AS ADM_BINATIONAL_RPTNG_CRIT
+             ) AS temp_admin_columns
+                 CROSS APPLY
+             ( SELECT D_INV_ADMINISTRATIVE_KEY,
+                      ADM_INNC_NOTIFICATION_DT,
+                      ADM_FIRST_RPT_TO_PHD_DT,
+                      ADM_BINATIONAL_RPTNG_CRIT
+               FROM dbo.D_INV_ADMINISTRATIVE
+             ) AS admin;
+
+
+        SELECT F.D_INV_ADMINISTRATIVE_KEY, F.INVESTIGATION_KEY AS ADMIN_INV_KEY,
+               ADM_INNC_NOTIFICATION_DT AS INNC_NOTIFICATION_DT, ADM_FIRST_RPT_TO_PHD_DT AS FIRST_RPT_PHD_DT,
+               ADM_BINATIONAL_RPTNG_CRIT AS BINATIONAL_RPTNG_CRIT
+        INTO #TMP_D_INV_ADMINISTRATIVE
+        FROM #TMP_F_INV_ADMINISTRATIVE AS F
+                 LEFT JOIN #D_INV_ADMIN_TEMP_COLS AS D WITH(NOLOCK) ON F.D_INV_ADMINISTRATIVE_KEY = D.D_INV_ADMINISTRATIVE_KEY
+        ;
+
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
 
 -----------------------------------------------------------------------------12. CREATE TABLE TMP_D_INV_CLINICAL----------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_CLINICAL';
-
-
-			SET @Proc_Step_no = 12;
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_CLINICAL';
+        SET @Proc_Step_no = 12;
 
 
-			IF OBJECT_ID('#TMP_F_INV_CLINICAL', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_CLINICAL;
+        IF OBJECT_ID('#TMP_F_INV_CLINICAL', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_CLINICAL;
 
-END;
-
-
-			IF OBJECT_ID('#TMP_D_INV_CLINICAL', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_CLINICAL;
-
-END;
+            END;
 
 
-SELECT F_PAGE_CASE.D_INV_CLINICAL_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_CLINICAL
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN	 #TMP_F_PAGE_CASE AS PAGE_CASE ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY ---(my Table)
-ORDER BY D_INV_CLINICAL_KEY;
+        IF OBJECT_ID('#TMP_D_INV_CLINICAL', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_CLINICAL;
+
+            END;
 
 
-
-SELECT F.D_INV_CLINICAL_KEY as D_INV_CLINICAL_KEY_1 , F.INVESTIGATION_KEY AS CLINICAL_INV_KEY, D.*,
-       cast( null as varchar(4000)) as HEP_D_INFECTION_IND,
-       cast( null as varchar(4000)) as HEP_MEDS_RECVD_IND
---CAST(CLN_HepDInfection AS varchar(300)) AS HEP_D_INFECTION_IND, CAST(CLN_MedsforHep AS varchar(300)) AS HEP_MEDS_RECVD_IND
-INTO #TMP_D_INV_CLINICAL
-FROM #TMP_F_INV_CLINICAL AS F
-         LEFT JOIN [dbo].[D_INV_CLINICAL] AS D WITH(NOLOCK)  ON F.D_INV_CLINICAL_KEY = D.D_INV_CLINICAL_KEY
-ORDER BY F.INVESTIGATION_KEY;
+        SELECT F_PAGE_CASE.D_INV_CLINICAL_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_CLINICAL
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN	 #TMP_F_PAGE_CASE AS PAGE_CASE ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY ---(my Table)
+        ORDER BY D_INV_CLINICAL_KEY;
 
 
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'CLN_HepDInfection'   AND Object_ID = Object_ID(N'#TMP_D_INV_CLINICAL'))
-BEGIN
-				--declare @sql nvarchar(100)
-			    SET @sql = N'update #TMP_D_INV_CLINICAL set HEP_D_INFECTION_IND=RTRIM(LTRIM(CLN_HepDInfection));'
-			    execute sp_executesql  @sql
-END;
+        SELECT clinical.*
+        INTO #D_INV_CLINICAL_TEMP_COLS
+        FROM (
+                 SELECT CAST(NULL as varchar(4000)) AS CLN_HepDInfection,
+                        CAST(NULL as varchar(4000)) AS CLN_MedsforHep
+             ) AS temp_clinical_columns
+                 CROSS APPLY
+             ( SELECT D_INV_CLINICAL_KEY,
+                      CLN_HepDInfection,
+                      CLN_MedsforHep
+               FROM dbo.D_INV_CLINICAL
+             ) AS clinical;
 
 
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'CLN_MedsforHep'   AND Object_ID = Object_ID(N'#TMP_D_INV_CLINICAL'))
-BEGIN
-				--declare @sql nvarchar(100)
-			    SET @sql = N'update #TMP_D_INV_CLINICAL set HEP_MEDS_RECVD_IND=RTRIM(LTRIM(CLN_MedsforHep));'
-			    execute sp_executesql  @sql
-END;
+        SELECT F.D_INV_CLINICAL_KEY as D_INV_CLINICAL_KEY_1 , F.INVESTIGATION_KEY AS CLINICAL_INV_KEY,
+               RTRIM(LTRIM(CLN_HepDInfection)) as HEP_D_INFECTION_IND,
+               RTRIM(LTRIM(CLN_MedsforHep)) as HEP_MEDS_RECVD_IND
+        INTO #TMP_D_INV_CLINICAL
+        FROM #TMP_F_INV_CLINICAL AS F
+                 LEFT JOIN #D_INV_CLINICAL_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_CLINICAL_KEY = D.D_INV_CLINICAL_KEY
+        ORDER BY F.INVESTIGATION_KEY;
 
 
-			/*UPDATE #TMP_D_INV_CLINICAL
-			  SET HEP_D_INFECTION_IND = ( CASE
-										  WHEN HEP_D_INFECTION_IND IS NULL THEN NULL
-										  ELSE RTRIM(LTRIM(HEP_D_INFECTION_IND))
-										  END );
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-			UPDATE #TMP_D_INV_CLINICAL
-			  SET HEP_MEDS_RECVD_IND = ( CASE
-										 WHEN HEP_MEDS_RECVD_IND IS NULL THEN NULL
-										 ELSE RTRIM(LTRIM(HEP_MEDS_RECVD_IND))
-										 END );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-										 */
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 --------------------------------------------------------------------------------13. CREATE TABLE TMP_D_INV_PATIENT_OBS----------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_PATIENT_OBS';
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_PATIENT_OBS';
 
-			SET @Proc_Step_no = 13;
+        SET @Proc_Step_no = 13;
 
-			IF OBJECT_ID('#TMP_D_INV_PATIENT_OBS', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_PATIENT_OBS;
+        IF OBJECT_ID('#TMP_D_INV_PATIENT_OBS', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_PATIENT_OBS;
 
-END;
+            END;
 
-			IF OBJECT_ID('#TMP_F_INV_PATIENT_OBS', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_PATIENT_OBS;
+        IF OBJECT_ID('#TMP_F_INV_PATIENT_OBS', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_PATIENT_OBS;
 
-END;
-
-
-SELECT F_PAGE_CASE.D_INV_PATIENT_OBS_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_PATIENT_OBS
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN #TMP_F_PAGE_CASE AS PAGE_CASE
-ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
-ORDER BY D_INV_PATIENT_OBS_KEY;
-
-SELECT pat_obs.*
-INTO #D_INV_PAT_OBS_TEMP_COLS
-FROM (
-         SELECT NULL AS IPO_SEXUAL_PREF
-     ) AS temp_pat_obs_columns
-    CROSS APPLY
-				( SELECT D_INV_PATIENT_OBS_KEY,
-					IPO_SEXUAL_PREF
-					FROM dbo.D_INV_PATIENT_OBS
-				) AS pat_obs;
-
-SELECT F.D_INV_PATIENT_OBS_KEY, F.INVESTIGATION_KEY AS PATIENT_OBS_INV_KEY, D.IPO_SEXUAL_PREF, CAST(null AS varchar(300)) AS SEX_PREF
-INTO #TMP_D_INV_PATIENT_OBS
-FROM #TMP_F_INV_PATIENT_OBS AS F
-         LEFT JOIN	#D_INV_PAT_OBS_TEMP_COLS AS D WITH(NOLOCK) ON F.D_INV_PATIENT_OBS_KEY = D.D_INV_PATIENT_OBS_KEY
-ORDER BY F.INVESTIGATION_KEY;
+            END;
 
 
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'IPO_SEXUAL_PREF'   AND Object_ID = Object_ID(N'#TMP_D_INV_PATIENT_OBS'))
-BEGIN
-				--declare @sql nvarchar(100)
-			    SET @sql = N'update #TMP_D_INV_PATIENT_OBS set SEX_PREF=RTRIM(LTRIM(IPO_SEXUAL_PREF));'
-			    execute sp_executesql  @sql
-END;
+        SELECT F_PAGE_CASE.D_INV_PATIENT_OBS_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_PATIENT_OBS
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN #TMP_F_PAGE_CASE AS PAGE_CASE
+                            ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
+        ORDER BY D_INV_PATIENT_OBS_KEY;
+
+        SELECT pat_obs.*
+        INTO #D_INV_PAT_OBS_TEMP_COLS
+        FROM (
+                 SELECT NULL AS IPO_SEXUAL_PREF
+             ) AS temp_pat_obs_columns
+                 CROSS APPLY
+             ( SELECT D_INV_PATIENT_OBS_KEY,
+                      IPO_SEXUAL_PREF
+               FROM dbo.D_INV_PATIENT_OBS
+             ) AS pat_obs;
+
+        SELECT F.D_INV_PATIENT_OBS_KEY, F.INVESTIGATION_KEY AS PATIENT_OBS_INV_KEY,
+               RTRIM(LTRIM(D.IPO_SEXUAL_PREF)) AS SEX_PREF
+        INTO #TMP_D_INV_PATIENT_OBS
+        FROM #TMP_F_INV_PATIENT_OBS AS F
+                 LEFT JOIN	#D_INV_PAT_OBS_TEMP_COLS AS D WITH(NOLOCK) ON F.D_INV_PATIENT_OBS_KEY = D.D_INV_PATIENT_OBS_KEY
+        ORDER BY F.INVESTIGATION_KEY;
 
 
-			/*UPDATE #TMP_D_INV_PATIENT_OBS
-			  SET SEX_PREF = ( CASE
-							   WHEN SEX_PREF IS NULL THEN NULL
-							   ELSE RTRIM(LTRIM(SEX_PREF))
-							   END );
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-			*/
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 --------------------------------------------------------------------------------14. CREATE TABLE TMP_D_INV_EPIDEMIOLOGY----------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_EPIDEMIOLOGY';
-
-			SET @Proc_Step_no = 14;
-
-			IF OBJECT_ID('#TMP_F_INV_EPIDEMIOLOGY', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_EPIDEMIOLOGY;
-
-END;
-
-			IF OBJECT_ID('#TMP_D_INV_EPIDEMIOLOGY', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_EPIDEMIOLOGY;
-
-END;
-
-
-
-SELECT F_PAGE_CASE.[D_INV_EPIDEMIOLOGY_KEY], F_PAGE_CASE.[INVESTIGATION_KEY]
-INTO #TMP_F_INV_EPIDEMIOLOGY
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	 ---(my table)
-ORDER BY D_INV_EPIDEMIOLOGY_KEY;
-
-
-SELECT F.D_INV_EPIDEMIOLOGY_KEY as D_INV_EPIDEMIOLOGY_KEY1, F.INVESTIGATION_KEY AS EPIDEMIOLOGY_INV_KEY, D.*,
-       CAST( null AS varchar(2000)) AS CHILDCARE_CASE_IND, ----1
-       CAST( null  AS varchar(2000)) AS CNTRY_USUAL_RESIDENCE, --2
-       CAST( null  AS varchar(2000)) AS CT_BABYSITTER_IND, ----3
-       CAST( null  AS varchar(2000)) AS CT_CHILDCARE_IND, --4
-       CAST( null  AS varchar(2000)) AS CT_HOUSEHOLD_IND, --5
-       CAST( null  AS varchar(2000)) AS HEP_CONTACT_IND, ----6
-       CAST( null  AS varchar(2000)) AS OTHER_CONTACT_IND, -----7
-       CAST( null  AS varchar(2000)) AS CONTACT_TYPE_OTH, --8
-       CAST( null  AS varchar(2000)) AS CT_PLAYMATE_IND, ----9
-       CAST( null  AS varchar(2000)) AS SEXUAL_PARTNER_IND, ---10
-       CAST( null  AS varchar(2000)) AS DNP_HOUSEHOLD_CT_IND, -----11
-       CAST( null  AS varchar(2000)) AS HEP_A_EPLINK_IND, ----------12
-       CAST( null  AS varchar(2000)) AS FEMALE_SEX_PRTNR_NBR, ------13
-       CAST( null  AS varchar(2000)) AS FOODHNDLR_PRIOR_IND, ------14
-       CAST( null  AS varchar(2000)) AS DNP_EMPLOYEE_IND, ----------15
-       CAST( null  AS varchar(2000)) AS STREET_DRUG_INJECTED, ------16
-       CAST( null  AS varchar(2000)) AS MALE_SEX_PRTNR_NBR, -------17
-       --- EPI_OutbreakAssoc,	   ---OUTBREAK_IND-----18
-       CAST( null  AS varchar(2000)) AS OBRK_FOODHNDLR_IND, -------19
-       CAST( null  AS varchar(2000)) AS FOOD_OBRK_FOOD_ITEM, ------20
-       CAST( null  AS varchar(2000)) AS OBRK_NOFOODHNDLR_IND, -----21
-       CAST( null  AS varchar(2000)) AS OBRK_UNIDENTIFIED_IND, ----22
-       CAST( null  AS varchar(2000)) AS OBRK_WATERBORNE_IND, -----23
-       CAST( null  AS varchar(2000)) AS STREET_DRUG_USED, ----24
-       CAST( null  AS varchar(2000)) AS COM_SRC_OUTBREAK_IND ----25
-INTO #TMP_D_INV_EPIDEMIOLOGY
-FROM #TMP_F_INV_EPIDEMIOLOGY AS F
-         LEFT JOIN [dbo].[D_INV_EPIDEMIOLOGY] AS D WITH(NOLOCK)  ON F.D_INV_EPIDEMIOLOGY_KEY = D.D_INV_EPIDEMIOLOGY_KEY
-ORDER BY F.INVESTIGATION_KEY;
-
-
---				declare @sql nvarchar(100)
-
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakAssoc'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set COM_SRC_OUTBREAK_IND=RTRIM(LTRIM(EPI_OutbreakAssoc));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ChildCareCase'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CHILDCARE_CASE_IND = RTRIM(LTRIM(EPI_ChildCareCase));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_CNTRY_USUAL_RESID'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CNTRY_USUAL_RESIDENCE = RTRIM(LTRIM(EPI_CNTRY_USUAL_RESID));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactBabysitter'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CT_BABYSITTER_IND = RTRIM(LTRIM(EPI_ContactBabysitter));'
-			    execute sp_executesql  @sql
-END;
-
-
-		IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactChildcare'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CT_CHILDCARE_IND = RTRIM(LTRIM(EPI_ContactChildcare));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactHousehold'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CT_HOUSEHOLD_IND = RTRIM(LTRIM(EPI_ContactHousehold));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactOfCase'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set HEP_CONTACT_IND = RTRIM(LTRIM(EPI_ContactOfCase));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactOther'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set OTHER_CONTACT_IND = RTRIM(LTRIM(EPI_ContactOther));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactOthSpecify'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CONTACT_TYPE_OTH = RTRIM(LTRIM(EPI_ContactOthSpecify));'
-			    execute sp_executesql  @sql
-END;
-
-
-			 -- declare @sql nvarchar(2000)
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactPlaymate'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set CT_PLAYMATE_IND = RTRIM(LTRIM(EPI_ContactPlaymate));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_ContactSexPartner'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set SEXUAL_PARTNER_IND = RTRIM(LTRIM(EPI_ContactSexPartner));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_DaycareContact'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set DNP_HOUSEHOLD_CT_IND = RTRIM(LTRIM(EPI_DaycareContact));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_EpiLinked'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set HEP_A_EPLINK_IND = RTRIM(LTRIM(EPI_EpiLinked));'
-			   execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_FemaleSexPartners'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set FEMALE_SEX_PRTNR_NBR = (EPI_FemaleSexPartners);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_FoodHandler'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set FOODHNDLR_PRIOR_IND = RTRIM(LTRIM(EPI_FoodHandler));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_InDayCare'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set DNP_EMPLOYEE_IND = RTRIM(LTRIM(EPI_InDayCare));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_IVDrugUse'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set STREET_DRUG_INJECTED = RTRIM(LTRIM(EPI_IVDrugUse));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_MaleSexPartner'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set MALE_SEX_PRTNR_NBR = RTRIM(LTRIM(EPI_MaleSexPartner));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakFoodHndlr'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set OBRK_FOODHNDLR_IND = RTRIM(LTRIM(EPI_OutbreakFoodHndlr));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakFoodItem'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set FOOD_OBRK_FOOD_ITEM = RTRIM(LTRIM(EPI_OutbreakFoodItem));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_outbreakNonFoodHndlr'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set OBRK_NOFOODHNDLR_IND = RTRIM(LTRIM(EPI_outbreakNonFoodHndlr));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakUnidentified'  AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set OBRK_UNIDENTIFIED_IND = RTRIM(LTRIM(EPI_OutbreakUnidentified));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakWaterborne'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set OBRK_WATERBORNE_IND = RTRIM(LTRIM(EPI_OutbreakWaterborne));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_RecDrugUse'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set STREET_DRUG_USED = RTRIM(LTRIM(EPI_RecDrugUse));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'EPI_OutbreakAssoc'   AND Object_ID = Object_ID(N'#TMP_D_INV_EPIDEMIOLOGY'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_EPIDEMIOLOGY set COM_SRC_OUTBREAK_IND = RTRIM(LTRIM(EPI_OutbreakAssoc));'
-			    execute sp_executesql  @sql
-END;
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_EPIDEMIOLOGY';
+
+        SET @Proc_Step_no = 14;
+
+        IF OBJECT_ID('#TMP_F_INV_EPIDEMIOLOGY', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_EPIDEMIOLOGY;
+
+            END;
+
+        IF OBJECT_ID('#TMP_D_INV_EPIDEMIOLOGY', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_EPIDEMIOLOGY;
+
+            END;
+
+
+
+        SELECT F_PAGE_CASE.[D_INV_EPIDEMIOLOGY_KEY], F_PAGE_CASE.[INVESTIGATION_KEY]
+        INTO #TMP_F_INV_EPIDEMIOLOGY
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	 ---(my table)
+        ORDER BY D_INV_EPIDEMIOLOGY_KEY;
+
+        SELECT epidemiology.*
+        INTO #D_EPIDEMIOLOGY_TEMP_COLS
+        FROM (
+                 SELECT CAST( null AS varchar(2000)) AS EPI_ChildCareCase, ----1
+                        CAST( null  AS varchar(2000)) AS EPI_CNTRY_USUAL_RESID, --2
+                        CAST( null  AS varchar(2000)) AS EPI_ContactBabysitter, ----3
+                        CAST( null  AS varchar(2000)) AS EPI_ContactChildcare, --4
+                        CAST( null  AS varchar(2000)) AS EPI_ContactHousehold, --5
+                        CAST( null  AS varchar(2000)) AS EPI_ContactOfCase, ----6
+                        CAST( null  AS varchar(2000)) AS EPI_ContactOther, -----7
+                        CAST( null  AS varchar(2000)) AS EPI_ContactOthSpecify, --8
+                        CAST( null  AS varchar(2000)) AS EPI_ContactPlaymate, ----9
+                        CAST( null  AS varchar(2000)) AS EPI_ContactSexPartner, ---10
+                        CAST( null  AS varchar(2000)) AS EPI_DaycareContact, -----11
+                        CAST( null  AS varchar(2000)) AS EPI_EpiLinked, ----------12
+                        CAST( null  AS varchar(2000)) AS EPI_FemaleSexPartners, ------13
+                        CAST( null  AS varchar(2000)) AS EPI_FoodHandler, ------14
+                        CAST( null  AS varchar(2000)) AS EPI_InDayCare, ----------15
+                        CAST( null  AS varchar(2000)) AS EPI_IVDrugUse, ------16
+                        CAST( null  AS varchar(2000)) AS EPI_MaleSexPartner, -------17
+                        --- EPI_OutbreakAssoc,	   ---OUTBREAK_IND-----18
+                        CAST( null  AS varchar(2000)) AS EPI_OutbreakFoodHndlr, -------19
+                        CAST( null  AS varchar(2000)) AS EPI_OutbreakFoodItem, ------20
+                        CAST( null  AS varchar(2000)) AS EPI_outbreakNonFoodHndlr, -----21
+                        CAST( null  AS varchar(2000)) AS EPI_OutbreakUnidentified, ----22
+                        CAST( null  AS varchar(2000)) AS EPI_OutbreakWaterborne, -----23
+                        CAST( null  AS varchar(2000)) AS EPI_RecDrugUse, ----24
+                        CAST( null  AS varchar(2000)) AS EPI_OutbreakAssoc ----25
+             ) AS temp_epidemiology_columns
+                 CROSS APPLY
+             ( SELECT D_INV_EPIDEMIOLOGY_KEY,
+                      EPI_ChildCareCase,
+                      EPI_CNTRY_USUAL_RESID,
+                      EPI_ContactBabysitter,
+                      EPI_ContactChildcare,
+                      EPI_ContactHousehold,
+                      EPI_ContactOfCase,
+                      EPI_ContactOther,
+                      EPI_ContactOthSpecify,
+                      EPI_ContactPlaymate,
+                      EPI_ContactSexPartner,
+                      EPI_DaycareContact,
+                      EPI_EpiLinked,
+                      EPI_FemaleSexPartners,
+                      EPI_FoodHandler,
+                      EPI_InDayCare,
+                      EPI_IVDrugUse,
+                      EPI_MaleSexPartner,
+                      EPI_OutbreakFoodHndlr,
+                      EPI_OutbreakFoodItem,
+                      EPI_outbreakNonFoodHndlr,
+                      EPI_OutbreakUnidentified,
+                      EPI_OutbreakWaterborne,
+                      EPI_RecDrugUse,
+                      EPI_OutbreakAssoc
+               FROM dbo.D_INV_EPIDEMIOLOGY
+             ) AS epidemiology;
+
+
+        SELECT F.D_INV_EPIDEMIOLOGY_KEY as D_INV_EPIDEMIOLOGY_KEY1, F.INVESTIGATION_KEY AS EPIDEMIOLOGY_INV_KEY,
+               EPI_ChildCareCase	AS	CHILDCARE_CASE_IND, ----1
+               EPI_CNTRY_USUAL_RESID	AS	CNTRY_USUAL_RESIDENCE, --2
+               EPI_ContactBabysitter	AS	CT_BABYSITTER_IND, ----3
+               EPI_ContactChildcare	AS	CT_CHILDCARE_IND, --4
+               EPI_ContactHousehold	AS	CT_HOUSEHOLD_IND, --5
+               EPI_ContactOfCase	AS	HEP_CONTACT_IND, ----6
+               EPI_ContactOther	AS	OTHER_CONTACT_IND, -----7
+               EPI_ContactOthSpecify	AS	CONTACT_TYPE_OTH, --8
+               EPI_ContactPlaymate	AS	CT_PLAYMATE_IND, ----9
+               EPI_ContactSexPartner	AS	SEXUAL_PARTNER_IND, ---10
+               EPI_DaycareContact	AS	DNP_HOUSEHOLD_CT_IND, -----11
+               EPI_EpiLinked	AS	HEP_A_EPLINK_IND, ----------12
+               EPI_FemaleSexPartners	AS	FEMALE_SEX_PRTNR_NBR, ------13
+               EPI_FoodHandler	AS	FOODHNDLR_PRIOR_IND, ------14
+               EPI_InDayCare	AS	DNP_EMPLOYEE_IND, ----------15
+               EPI_IVDrugUse	AS	STREET_DRUG_INJECTED, ------16
+               EPI_MaleSexPartner	AS	MALE_SEX_PRTNR_NBR, -------17
+               --- EPI_OutbreakAssoc, ---OUTBREAK_IND-----18
+               EPI_OutbreakFoodHndlr	AS	OBRK_FOODHNDLR_IND, -------19
+               EPI_OutbreakFoodItem	AS	FOOD_OBRK_FOOD_ITEM, ------20
+               EPI_outbreakNonFoodHndlr	AS	OBRK_NOFOODHNDLR_IND, -----21
+               EPI_OutbreakUnidentified	AS	OBRK_UNIDENTIFIED_IND, ----22
+               EPI_OutbreakWaterborne	AS	OBRK_WATERBORNE_IND, -----23
+               EPI_RecDrugUse	AS	STREET_DRUG_USED, ----24
+               EPI_OutbreakAssoc	AS	COM_SRC_OUTBREAK_IND ----25
+        INTO #TMP_D_INV_EPIDEMIOLOGY
+        FROM #TMP_F_INV_EPIDEMIOLOGY AS F
+                 LEFT JOIN #D_EPIDEMIOLOGY_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_EPIDEMIOLOGY_KEY = D.D_INV_EPIDEMIOLOGY_KEY
+        ORDER BY F.INVESTIGATION_KEY;
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+        IF @debug = 'true' SELECT * FROM #TMP_D_INV_EPIDEMIOLOGY;
 
 --------------------------------------------------------------------------------------15. CREATE TABLE dbo.D_INV_LAB_FINDING_TMP----------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_LAB_FINDING';
-
-			SET @Proc_Step_no = 15;
-
-
-			IF OBJECT_ID('#TMP_F_INV_LAB_FINDING', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_LAB_FINDING;
-
-END;
-
-
-			IF OBJECT_ID('#TMP_D_INV_LAB_FINDING', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_LAB_FINDING;
-
-END;
-
-
-SELECT F_PAGE_CASE.[D_INV_LAB_FINDING_KEY], F_PAGE_CASE.[INVESTIGATION_KEY]
-INTO #TMP_F_INV_LAB_FINDING
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE AS PAGE_CASE
-ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
-;
-
-
-SELECT F.[D_INV_LAB_FINDING_KEY] as D_INV_LAB_FINDING_KEY1, F.[INVESTIGATION_KEY] AS LAB_INV_KEY,D.*,
-       CAST( null  AS varchar(2000)) AS HEP_C_TOTAL_ANTIBODY, ---1
-       CAST( null  AS date) AS SUPP_ANTI_HCV_DT, ------2
-       CAST( null  AS varchar(2000)) AS ALT_SGPT_RESULT, ---3
-       CAST( null  AS varchar(2000)) AS ANTI_HBS_POS_REAC_IND, ---4
-       CAST( null  AS varchar(2000)) AS ANTI_HBSAG_TESTED_IND, ----5
-       CAST( null  AS varchar(2000)) AS AST_SGOT_RESULT, ---6
-       CAST( null  AS varchar(2000)) AS HEP_E_ANTIGEN, ---7
-       CAST( null  AS date) AS HBE_AG_DT, ---8
-       CAST( null  AS varchar(2000)) AS HEP_B_SURFACE_ANTIGEN, --9
-       CAST( null  AS date) AS HBS_AG_DT, --10
-       CAST( null  AS varchar(2000)) AS HEP_B_DNA, -----11
-       CAST( null  AS date) AS HBV_NAT_DT, ---12
-       CAST( null  AS varchar(2000)) AS HCV_RNA, ---13
-       CAST( null  AS date) AS HCV_RNA_DT, ---14
-       CAST( null  AS varchar(2000)) AS HEP_D_TEST_IND, -----15
-       CAST( null  AS varchar(2000)) AS HEP_A_IGM_ANTIBODY, ---16
-       CAST( null  AS date) AS IGM_ANTI_HAV_DT, ---17
-       CAST( null  AS varchar(2000)) AS HEP_B_IGM_ANTIBODY, ---18
-       CAST( null  AS date) AS IGM_ANTI_HBC_DT, ---19
-       CAST( null  AS varchar(2000)) AS PREV_NEG_HEP_TEST_IND, --20
-       CAST( null  AS varchar(2000)) AS ANTIHCV_SIGCUT_RATIO, ---21
-       CAST( null  AS varchar(2000)) AS ANTIHCV_SUPP_ASSAY, ---22
-       CAST( null  AS date) AS ALT_RESULT_DT, -----23
-       CAST( null  AS date) AS AST_RESULT_DT, ---24
-       CAST( null  AS varchar(2000)) AS ALT_SGPT_RSLT_UP_LMT, ---25
-       CAST( null  AS varchar(2000)) AS AST_SGOT_RSLT_UP_LMT, ---26
-       CAST( null  AS varchar(2000)) AS HEP_A_TOTAL_ANTIBODY, ---27
-       CAST( null  AS date) AS TOTAL_ANTI_HAV_DT, ---28
-       CAST( null  AS varchar(2000)) AS HEP_B_TOTAL_ANTIBODY, ---29
-       CAST( null  AS date) AS TOTAL_ANTI_HBC_DT, ----30
-       CAST( null  AS date) AS TOTAL_ANTI_HCV_DT, --31
-       CAST( null  AS varchar(2000)) AS HEP_D_TOTAL_ANTIBODY, ---32
-       CAST( null  AS date) AS TOTAL_ANTI_HDV_DT, ---33
-       CAST( null  AS varchar(2000)) AS HEP_E_TOTAL_ANTIBODY, ---34
-       CAST( null  AS date) AS TOTAL_ANTI_HEV_DT, ---35
-       CAST( null  AS date) AS VERIFIED_TEST_DT ---36
-INTO #TMP_D_INV_LAB_FINDING
-FROM #TMP_F_INV_LAB_FINDING AS F
-         LEFT JOIN
-    [dbo].[D_INV_LAB_FINDING] AS D WITH(NOLOCK)
-ON F.D_INV_LAB_FINDING_KEY = D.D_INV_LAB_FINDING_KEY
-;
-
-
-
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHCV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_C_TOTAL_ANTIBODY = RTRIM(LTRIM(LAB_TotalAntiHCV));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_Supplem_antiHCV_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set SUPP_ANTI_HCV_DT = (LAB_Supplem_antiHCV_Date);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_ALT_Result'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ALT_SGPT_RESULT = RTRIM(LTRIM(LAB_ALT_Result));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_AntiHBsPositive'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ANTI_HBS_POS_REAC_IND = RTRIM(LTRIM(LAB_AntiHBsPositive));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_AntiHBsTested'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ANTI_HBSAG_TESTED_IND = RTRIM(LTRIM(LAB_AntiHBsTested));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_AST_Result'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set AST_SGOT_RESULT = RTRIM(LTRIM(LAB_AST_Result));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBeAg'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_E_ANTIGEN = RTRIM(LTRIM(LAB_HBeAg));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBeAg_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HBE_AG_DT = (LAB_HBeAg_Date);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBsAg'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_B_SURFACE_ANTIGEN = RTRIM(LTRIM(LAB_HBsAg));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBsAg_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HBS_AG_DT = (LAB_HBsAg_Date);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBV_NAT'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_B_DNA = RTRIM(LTRIM(LAB_HBV_NAT));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HBV_NAT_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HBV_NAT_DT = (LAB_HBV_NAT_Date);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HCVRNA'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HCV_RNA = RTRIM(LTRIM(LAB_HCVRNA));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HCVRNA_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HCV_RNA_DT = (LAB_HCVRNA_Date);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_HepDTest'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_D_TEST_IND = RTRIM(LTRIM(LAB_HepDTest));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_IgM_AntiHAV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_A_IGM_ANTIBODY = RTRIM(LTRIM(LAB_IgM_AntiHAV));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_IgMAntiHAVDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set IGM_ANTI_HAV_DT = (LAB_IgMAntiHAVDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_IgMAntiHBc'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_B_IGM_ANTIBODY = RTRIM(LTRIM(LAB_IgMAntiHBc));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_IgMAntiHBcDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set IGM_ANTI_HBC_DT = (LAB_IgMAntiHBcDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_PrevNegHepTest'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set PREV_NEG_HEP_TEST_IND = RTRIM(LTRIM(LAB_PrevNegHepTest));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_SignalToCutoff'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ANTIHCV_SIGCUT_RATIO = RTRIM(LTRIM(LAB_SignalToCutoff));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_Supplem_antiHCV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ANTIHCV_SUPP_ASSAY = RTRIM(LTRIM(LAB_Supplem_antiHCV));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TestDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ALT_RESULT_DT = (LAB_TestDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TestDate2'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set AST_RESULT_DT = (LAB_TestDate2);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TestResultUpperLimit'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set ALT_SGPT_RSLT_UP_LMT = RTRIM(LTRIM(LAB_TestResultUpperLimit));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TestResultUpperLimit2'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set AST_SGOT_RSLT_UP_LMT = RTRIM(LTRIM(LAB_TestResultUpperLimit2));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHAV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_A_TOTAL_ANTIBODY = RTRIM(LTRIM(LAB_TotalAntiHAV));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHAVDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set TOTAL_ANTI_HAV_DT = (LAB_TotalAntiHAVDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHBc'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_B_TOTAL_ANTIBODY = RTRIM(LTRIM(LAB_TotalAntiHBc));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHBcDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set TOTAL_ANTI_HBC_DT = (LAB_TotalAntiHBcDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHCV_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set TOTAL_ANTI_HCV_DT = (LAB_TotalAntiHCV_Date);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHDV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_D_TOTAL_ANTIBODY = RTRIM(LTRIM(LAB_TotalAntiHDV));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHDV_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set TOTAL_ANTI_HDV_DT = (LAB_TotalAntiHDV_Date);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHEV'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set HEP_E_TOTAL_ANTIBODY = RTRIM(LTRIM(LAB_TotalAntiHEV));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_TotalAntiHEV_Date'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set TOTAL_ANTI_HEV_DT = (LAB_TotalAntiHEV_Date);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'LAB_VerifiedTestDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_LAB_FINDING'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_LAB_FINDING set VERIFIED_TEST_DT = (LAB_VerifiedTestDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-	 /*
-			CAST(LAB_TotalAntiHCV_Date AS date) AS TOTAL_ANTI_HCV_DT, --31
-			CAST(LAB_TotalAntiHDV AS varchar(300)) AS HEP_D_TOTAL_ANTIBODY, ---32
-			CAST(LAB_TotalAntiHDV_Date AS date) AS TOTAL_ANTI_HDV_DT, ---33
-			CAST(LAB_TotalAntiHEV AS varchar(300)) AS HEP_E_TOTAL_ANTIBODY, ---34
-			CAST(LAB_TotalAntiHEV_Date AS date) AS TOTAL_ANTI_HEV_DT, ---35
-			CAST(LAB_VerifiedTestDate AS date) AS VERIFIED_TEST_DT ---36
-
-			*/
-
-
-/*	UPDATE #TMP_D_INV_LAB_FINDING SET HEP_C_TOTAL_ANTIBODY  = Case when  HEP_C_TOTAL_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_C_TOTAL_ANTIBODY)) end;
-
-----1
-																			UPDATE #TMP_D_INV_LAB_FINDING SET ANTI_HBS_POS_REAC_IND = Case when  ANTI_HBS_POS_REAC_IND is null then null Else RTRIM(LTRIM(ANTI_HBS_POS_REAC_IND)) end;
-
-----4
-																			UPDATE #TMP_D_INV_LAB_FINDING SET ANTI_HBSAG_TESTED_IND = Case when  ANTI_HBSAG_TESTED_IND is null then null Else RTRIM(LTRIM(ANTI_HBSAG_TESTED_IND)) end;
-
----5
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_E_ANTIGEN  = Case when  HEP_E_ANTIGEN  is null then null Else RTRIM(LTRIM(HEP_E_ANTIGEN)) end;
-
-----7
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_B_SURFACE_ANTIGEN = Case when HEP_B_SURFACE_ANTIGEN   is null then null Else RTRIM(LTRIM(HEP_B_SURFACE_ANTIGEN )) end;
-
-----9
-																			----UPDATE #TMP_D_INV_LAB_FINDING SET HBS_AG_DT = LAB_HBsAg_Date;
-
------------------------10
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_B_DNA   = Case when  HEP_B_DNA  is null then null Else RTRIM(LTRIM(HEP_B_DNA )) end;
-
----11
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HCV_RNA     = Case when  HCV_RNA    is null then null Else RTRIM(LTRIM(HCV_RNA)) end;
-
-------13
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_D_TEST_IND  = Case when  HEP_D_TEST_IND is null then null Else RTRIM(LTRIM(HEP_D_TEST_IND)) end;
-
-----15
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_A_IGM_ANTIBODY  = Case when HEP_A_IGM_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_A_IGM_ANTIBODY)) end;
-
----16
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_B_IGM_ANTIBODY  = Case when HEP_B_IGM_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_B_IGM_ANTIBODY)) end;
-
-----18
-																			UPDATE #TMP_D_INV_LAB_FINDING SET PREV_NEG_HEP_TEST_IND= Case when  PREV_NEG_HEP_TEST_IND is null then null Else RTRIM(LTRIM(PREV_NEG_HEP_TEST_IND)) end;
-
----20
-																			UPDATE #TMP_D_INV_LAB_FINDING SET ANTIHCV_SIGCUT_RATIO = Case when  ANTIHCV_SIGCUT_RATIO is null then null Else RTRIM(LTRIM(ANTIHCV_SIGCUT_RATIO)) end;
-
-----21
-																			UPDATE #TMP_D_INV_LAB_FINDING SET ANTIHCV_SUPP_ASSAY   = Case when  ANTIHCV_SUPP_ASSAY  is null then null Else RTRIM(LTRIM(ANTIHCV_SUPP_ASSAY )) end;
-
-----22
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_A_TOTAL_ANTIBODY  = Case when  HEP_A_TOTAL_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_A_TOTAL_ANTIBODY)) end;
-
-----27
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_B_TOTAL_ANTIBODY = Case when HEP_B_TOTAL_ANTIBODY  is null then null Else RTRIM(LTRIM(HEP_B_TOTAL_ANTIBODY )) end;
-
-----29
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_D_TOTAL_ANTIBODY  = Case when  HEP_D_TOTAL_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_D_TOTAL_ANTIBODY)) end;
-
-----32
-																			UPDATE #TMP_D_INV_LAB_FINDING SET HEP_E_TOTAL_ANTIBODY  = Case when  HEP_E_TOTAL_ANTIBODY is null then null Else RTRIM(LTRIM(HEP_E_TOTAL_ANTIBODY)) end;
-
-----34
-																		*/
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
----------------------------------------------------------------------------------------16. CREATE TABLE TMP_D_INV_MEDICAL_HISTORY----------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_MEDICAL_HISTORY';
-
-			SET @Proc_Step_no = 16;
-
-			IF OBJECT_ID('#TMP_F_INV_MEDICAL_HISTORY', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_MEDICAL_HISTORY;
-
-END;
-
-			IF OBJECT_ID('#TMP_D_INV_MEDICAL_HISTORY', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_MEDICAL_HISTORY;
-
-END;
-
-SELECT F_PAGE_CASE.D_INV_MEDICAL_HISTORY_KEY, F_PAGE_CASE.[INVESTIGATION_KEY]
-INTO #TMP_F_INV_MEDICAL_HISTORY
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN	 #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
-ORDER BY D_INV_MEDICAL_HISTORY_KEY;
-
-SELECT med_history.*
-INTO #D_INV_MED_HIST_TEMP_COLS
-FROM (
-         SELECT CAST( NULL  AS date) AS MDH_DiabetesDxDate,
-                NULL AS MDH_Diabetes,
-                NULL AS MDH_Jaundiced,
-                NULL AS MDH_PrevAwareInfection,
-                NULL AS MDH_ProviderOfCare,
-                NULL AS MDH_ReasonForTest,
-                NULL AS MDH_ReasonForTestingOth,
-                NULL AS MDH_Symptomatic,
-                CAST( NULL  AS date) AS MDH_DueDate
-     ) AS temp_med_history_columns
-    CROSS APPLY
-				( SELECT D_INV_MEDICAL_HISTORY_KEY,
-					MDH_DiabetesDxDate,
-					MDH_Diabetes,
-					MDH_Jaundiced,
-					MDH_PrevAwareInfection,
-					MDH_ProviderOfCare,
-					MDH_ReasonForTest,
-					MDH_ReasonForTestingOth,
-					MDH_Symptomatic,
-					MDH_DueDate
-					FROM dbo.D_INV_MEDICAL_HISTORY
-				) AS med_history;
-
-
-SELECT F.D_INV_MEDICAL_HISTORY_KEY, F.INVESTIGATION_KEY AS MEDHistory_INV_KEY,
-       CAST(MDH_DiabetesDxDate AS date) AS DIABETES_DX_DT,
-       CAST(MDH_Diabetes AS [varchar](300)) AS DIABETES_IND,
-       CAST(MDH_Jaundiced AS [varchar](300)) AS PAT_JUNDICED_IND,
-       CAST(MDH_PrevAwareInfection AS [varchar](300)) AS PAT_PREV_AWARE_IND,
-       CAST(MDH_ProviderOfCare AS [varchar](300)) AS HEP_CARE_PROVIDER,
-       CAST(MDH_ReasonForTest AS [varchar](300)) AS TEST_REASON,
-       CAST(MDH_ReasonForTestingOth AS [varchar](300)) AS TEST_REASON_OTH,
-       CAST(MDH_Symptomatic AS [varchar](300)) AS SYMPTOMATIC_IND,
-       CAST(MDH_DueDate AS date) AS PREGNANCY_DUE_DT
-INTO #TMP_D_INV_MEDICAL_HISTORY
-FROM #TMP_F_INV_MEDICAL_HISTORY AS F
-         LEFT JOIN	#D_INV_MED_HIST_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_MEDICAL_HISTORY_KEY = D.D_INV_MEDICAL_HISTORY_KEY
-ORDER BY F.INVESTIGATION_KEY;
-
-
---UPDATE #TMP_D_INV_MEDICAL_HISTORY SET DIABETES_DX_DT = MDH_DiabetesDxDate	;
-
-----1
-/*UPDATE #TMP_D_INV_MEDICAL_HISTORY SET DIABETES_IND  = CASE WHEN DIABETES_IND is null then null else RTRIM(LTRIM(DIABETES_IND)) END;
-
-----2
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET PAT_JUNDICED_IND  = CASE WHEN PAT_JUNDICED_IND is null then null else RTRIM(LTRIM(PAT_JUNDICED_IND)) END;
-
----3
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET PAT_PREV_AWARE_IND = CASE WHEN PAT_PREV_AWARE_IND is null then null else RTRIM(LTRIM(PAT_PREV_AWARE_IND)) END;
-
----4
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET HEP_CARE_PROVIDER  = CASE WHEN HEP_CARE_PROVIDER  is null then null else RTRIM(LTRIM(HEP_CARE_PROVIDER)) END;
-
----5
-
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET TEST_REASON = CASE WHEN TEST_REASON is null then Null else RTRIM(LTRIM(TEST_REASON)) END;
-
----6
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET TEST_REASON_OTH = CASE WHEN TEST_REASON_OTH  is null then null else RTRIM(LTRIM( TEST_REASON_OTH)) END;
-
----7
-        UPDATE #TMP_D_INV_MEDICAL_HISTORY SET SYMPTOMATIC_IND = CASE WHEN SYMPTOMATIC_IND is null  then null else RTRIM(LTRIM(SYMPTOMATIC_IND )) END;
-
----8
-        */
---UPDATE #TMP_D_INV_MEDICAL_HISTORY SET PREGNANCY_DUE_DT=MDH_DueDate
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
-
----------------------------------------------------------------------------------17. CREATE TABLE TMP.D_INV_MOTHER-------------------------------------------------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_MOTHER';
-
-			SET @Proc_Step_no = 17;
-
-			IF OBJECT_ID('#TMP_F_INV_MOTHER', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_MOTHER;
-
-END;
-
-			IF OBJECT_ID('#TMP_D_INV_MOTHER', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_MOTHER;
-
-END;
-
-
-SELECT F_PAGE_CASE.D_INV_MOTHER_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_MOTHER
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				#TMP_F_PAGE_CASE AS PAGE_CASE
-ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
-ORDER BY D_INV_MOTHER_KEY;
-
-SELECT mother.*
-INTO #D_INV_MOTHER_TEMP_COLS
-FROM (
-         SELECT NULL AS MTH_MotherBornOutsideUS,
-                NULL AS MTH_MotherEthnicity,
-                NULL AS MTH_MotherHBsAgPosPrior,
-                NULL AS MTH_MotherPositiveAfter,
-                NULL AS MTH_MotherRace,
-                NULL AS MTH_MothersBirthCountry,
-                CAST( NULL  AS date) AS MTH_MotherPosTestDate
-     ) AS temp_med_mother_columns
-    CROSS APPLY
-				( SELECT D_INV_MOTHER_KEY,
-					MTH_MotherBornOutsideUS,
-					MTH_MotherEthnicity,
-					MTH_MotherHBsAgPosPrior,
-					MTH_MotherPositiveAfter,
-					MTH_MotherRace,
-					MTH_MothersBirthCountry,
-					MTH_MotherPosTestDate
-					FROM dbo.D_INV_MOTHER
-				) AS mother;
-
-
-
-/*
-    ---changed it like this on 10/1/2021
-declare @SQL1 varchar(4000)
-set @SQL1='SELECT F.D_INV_MOTHER_KEY D_INV_MOTHER_KEY1, F.INVESTIGATION_KEY AS MOTHER_INV_KEY, D.*,
-    CAST( null AS varchar(2000)) AS MTH_BORN_OUTSIDE_US,
-    CAST( null  AS varchar(2000)) AS MTH_ETHNICITY,
-    CAST( null  AS varchar(2000)) AS MTH_HBS_AG_PRIOR_POS,
-    CAST( null  AS varchar(2000)) AS MTH_POS_AFTER,
-    CAST( null  AS varchar(2000)) AS MTH_RACE,
-    CAST( null AS varchar(2000)) AS MTH_BIRTH_COUNTRY,
-    CAST( null  AS date) AS MTH_POS_TEST_DT
-INTO #TMP_D_INV_MOTHER
-FROM #TMP_F_INV_MOTHER AS F
-     LEFT JOIN
-     [dbo].[D_INV_MOTHER] AS D WITH(NOLOCK)
-  ON 	F.D_INV_MOTHER_KEY = D.D_INV_MOTHER_KEY
-     ORDER BY F.INVESTIGATION_KEY';
-
-
-      exec (@SQL1);
-      */
-
-SELECT F.D_INV_MOTHER_KEY D_INV_MOTHER_KEY1, F.INVESTIGATION_KEY AS MOTHER_INV_KEY, D.*,
-       CAST( null AS varchar(2000)) AS MTH_BORN_OUTSIDE_US,
-       CAST( null  AS varchar(2000)) AS MTH_ETHNICITY,
-       CAST( null  AS varchar(2000)) AS MTH_HBS_AG_PRIOR_POS,
-       CAST( null  AS varchar(2000)) AS MTH_POS_AFTER,
-       CAST( null  AS varchar(2000)) AS MTH_RACE,
-       CAST( null AS varchar(2000)) AS MTH_BIRTH_COUNTRY,
-       CAST( null  AS date) AS MTH_POS_TEST_DT
-INTO #TMP_D_INV_MOTHER
-FROM #TMP_F_INV_MOTHER AS F
-         LEFT JOIN	#D_INV_MOTHER_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_MOTHER_KEY = D.D_INV_MOTHER_KEY
-ORDER BY F.INVESTIGATION_KEY;
-
-
-
-
-/*
-    CAST(MTH_MotherBornOutsideUS AS varchar(300)) AS MTH_BORN_OUTSIDE_US,
-    CAST(MTH_MotherEthnicity AS varchar(300)) AS MTH_ETHNICITY,
-    CAST(MTH_MotherHBsAgPosPrior AS varchar(300)) AS MTH_HBS_AG_PRIOR_POS,
-    CAST(MTH_MotherPositiveAfter AS varchar(300)) AS MTH_POS_AFTER,
-    CAST(MTH_MotherRace AS varchar(300)) AS MTH_RACE,
-    CAST(MTH_MothersBirthCountry AS varchar(300)) AS MTH_BIRTH_COUNTRY,
-    CAST(MTH_MotherPosTestDate AS date) AS MTH_POS_TEST_DT
-*/
-
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherBornOutsideUS'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_BORN_OUTSIDE_US = RTRIM(LTRIM(MTH_MotherBornOutsideUS));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherEthnicity'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_ETHNICITY = RTRIM(LTRIM(MTH_MotherEthnicity));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherHBsAgPosPrior'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_HBS_AG_PRIOR_POS = RTRIM(LTRIM(MTH_MotherHBsAgPosPrior));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherPositiveAfter'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_POS_AFTER = RTRIM(LTRIM(MTH_MotherPositiveAfter));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherRace'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_RACE = RTRIM(LTRIM(MTH_MotherRace));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MothersBirthCountry'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_BIRTH_COUNTRY = RTRIM(LTRIM(MTH_MothersBirthCountry));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'MTH_MotherPosTestDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_MOTHER'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_MOTHER set MTH_POS_TEST_DT = (MTH_MotherPosTestDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_LAB_FINDING';
+
+        SET @Proc_Step_no = 15;
+
+
+        IF OBJECT_ID('#TMP_F_INV_LAB_FINDING', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_LAB_FINDING;
+
+            END;
+
+
+        IF OBJECT_ID('#TMP_D_INV_LAB_FINDING', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_LAB_FINDING;
+
+            END;
+
+
+        SELECT F_PAGE_CASE.[D_INV_LAB_FINDING_KEY], F_PAGE_CASE.[INVESTIGATION_KEY]
+        INTO #TMP_F_INV_LAB_FINDING
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS PAGE_CASE
+             ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
+        ;
+
+        SELECT lab_finding.*
+        INTO #D_INV_LAB_FINDING_TEMP_COLS
+        FROM (
+                 SELECT CAST( null  AS varchar(2000)) AS LAB_TotalAntiHCV, ---1
+                        CAST( null  AS date) AS LAB_Supplem_antiHCV_Date, ------2
+                        CAST( null  AS varchar(2000)) AS LAB_ALT_Result, ---3
+                        CAST( null  AS varchar(2000)) AS LAB_AntiHBsPositive, ---4
+                        CAST( null  AS varchar(2000)) AS LAB_AntiHBsTested, ----5
+                        CAST( null  AS varchar(2000)) AS LAB_AST_Result, ---6
+                        CAST( null  AS varchar(2000)) AS LAB_HBeAg, ---7
+                        CAST( null  AS date) AS LAB_HBeAg_Date, ---8
+                        CAST( null  AS varchar(2000)) AS LAB_HBsAg, --9
+                        CAST( null  AS date) AS LAB_HBsAg_Date, --10
+                        CAST( null  AS varchar(2000)) AS LAB_HBV_NAT, -----11
+                        CAST( null  AS date) AS LAB_HBV_NAT_Date, ---12
+                        CAST( null  AS varchar(2000)) AS LAB_HCVRNA, ---13
+                        CAST( null  AS date) AS LAB_HCVRNA_Date, ---14
+                        CAST( null  AS varchar(2000)) AS LAB_HepDTest, -----15
+                        CAST( null  AS varchar(2000)) AS LAB_IgM_AntiHAV, ---16
+                        CAST( null  AS date) AS LAB_IgMAntiHAVDate, ---17
+                        CAST( null  AS varchar(2000)) AS LAB_IgMAntiHBc, ---18
+                        CAST( null  AS date) AS LAB_IgMAntiHBcDate, ---19
+                        CAST( null  AS varchar(2000)) AS LAB_PrevNegHepTest, --20
+                        CAST( null  AS varchar(2000)) AS LAB_SignalToCutoff, ---21
+                        CAST( null  AS varchar(2000)) AS LAB_Supplem_antiHCV, ---22
+                        CAST( null  AS date) AS LAB_TestDate, -----23
+                        CAST( null  AS date) AS LAB_TestDate2, ---24
+                        CAST( null  AS varchar(2000)) AS LAB_TestResultUpperLimit, ---25
+                        CAST( null  AS varchar(2000)) AS LAB_TestResultUpperLimit2, ---26
+                        CAST( null  AS varchar(2000)) AS LAB_TotalAntiHAV, ---27
+                        CAST( null  AS date) AS LAB_TotalAntiHAVDate, ---28
+                        CAST( null  AS varchar(2000)) AS LAB_TotalAntiHBc, ---29
+                        CAST( null  AS date) AS LAB_TotalAntiHBcDate, ----30
+                        CAST( null  AS date) AS LAB_TotalAntiHCV_Date, --31
+                        CAST( null  AS varchar(2000)) AS LAB_TotalAntiHDV, ---32
+                        CAST( null  AS date) AS LAB_TotalAntiHDV_Date, ---33
+                        CAST( null  AS varchar(2000)) AS LAB_TotalAntiHEV, ---34
+                        CAST( null  AS date) AS LAB_TotalAntiHEV_Date, ---35
+                        CAST( null  AS date) AS LAB_VerifiedTestDate ---36
+             ) AS temp_lab_finding_columns
+                 CROSS APPLY
+             ( SELECT D_INV_LAB_FINDING_KEY,
+                      LAB_TotalAntiHCV, ---1
+                      LAB_Supplem_antiHCV_Date, ------2
+                      LAB_ALT_Result, ---3
+                      LAB_AntiHBsPositive, ---4
+                      LAB_AntiHBsTested, ----5
+                      LAB_AST_Result, ---6
+                      LAB_HBeAg, ---7
+                      LAB_HBeAg_Date, ---8
+                      LAB_HBsAg, --9
+                      LAB_HBsAg_Date, --10
+                      LAB_HBV_NAT, -----11
+                      LAB_HBV_NAT_Date, ---12
+                      LAB_HCVRNA, ---13
+                      LAB_HCVRNA_Date, ---14
+                      LAB_HepDTest, -----15
+                      LAB_IgM_AntiHAV, ---16
+                      LAB_IgMAntiHAVDate, ---17
+                      LAB_IgMAntiHBc, ---18
+                      LAB_IgMAntiHBcDate, ---19
+                      LAB_PrevNegHepTest, --20
+                      LAB_SignalToCutoff, ---21
+                      LAB_Supplem_antiHCV, ---22
+                      LAB_TestDate, -----23
+                      LAB_TestDate2, ---24
+                      LAB_TestResultUpperLimit, ---25
+                      LAB_TestResultUpperLimit2, ---26
+                      LAB_TotalAntiHAV, ---27
+                      LAB_TotalAntiHAVDate, ---28
+                      LAB_TotalAntiHBc, ---29
+                      LAB_TotalAntiHBcDate, ----30
+                      LAB_TotalAntiHCV_Date, --31
+                      LAB_TotalAntiHDV, ---32
+                      LAB_TotalAntiHDV_Date, ---33
+                      LAB_TotalAntiHEV, ---34
+                      LAB_TotalAntiHEV_Date, ---35
+                      LAB_VerifiedTestDate ---36
+               FROM dbo.D_INV_LAB_FINDING
+             ) AS lab_finding;
+
+        if @debug = 'true' select * from #D_INV_LAB_FINDING_TEMP_COLS;
+
+
+        SELECT F.[D_INV_LAB_FINDING_KEY] AS D_INV_LAB_FINDING_KEY1, F.[INVESTIGATION_KEY] AS LAB_INV_KEY,
+               LAB_TotalAntiHCV AS	HEP_C_TOTAL_ANTIBODY, ---1
+               LAB_Supplem_antiHCV_Date	AS	SUPP_ANTI_HCV_DT, ------2
+               LAB_ALT_Result	AS	ALT_SGPT_RESULT, ---3
+               LAB_AntiHBsPositive AS	ANTI_HBS_POS_REAC_IND, ---4
+               LAB_AntiHBsTested AS	ANTI_HBSAG_TESTED_IND, ----5
+               LAB_AST_Result	AS	AST_SGOT_RESULT, ---6
+               LAB_HBeAg	AS	HEP_E_ANTIGEN, ---7
+               LAB_HBeAg_Date	AS	HBE_AG_DT, ---8
+               LAB_HBsAg	AS	HEP_B_SURFACE_ANTIGEN, --9
+               LAB_HBsAg_Date	AS	HBS_AG_DT, --10
+               LAB_HBV_NAT	AS	HEP_B_DNA, -----11
+               LAB_HBV_NAT_Date	AS	HBV_NAT_DT, ---12
+               LAB_HCVRNA	AS	HCV_RNA, ---13
+               LAB_HCVRNA_Date	AS	HCV_RNA_DT, ---14
+               LAB_HepDTest	AS	HEP_D_TEST_IND, -----15
+               LAB_IgM_AntiHAV	AS	HEP_A_IGM_ANTIBODY, ---16
+               LAB_IgMAntiHAVDate	AS	IGM_ANTI_HAV_DT, ---17
+               LAB_IgMAntiHBc	AS	HEP_B_IGM_ANTIBODY, ---18
+               LAB_IgMAntiHBcDate	AS	IGM_ANTI_HBC_DT, ---19
+               LAB_PrevNegHepTest	AS	PREV_NEG_HEP_TEST_IND, --20
+               LAB_SignalToCutoff	AS	ANTIHCV_SIGCUT_RATIO, ---21
+               LAB_Supplem_antiHCV	AS	ANTIHCV_SUPP_ASSAY, ---22
+               LAB_TestDate AS	ALT_RESULT_DT, -----23
+               LAB_TestDate2	AS	AST_RESULT_DT, ---24
+               LAB_TestResultUpperLimit	AS	ALT_SGPT_RSLT_UP_LMT, ---25
+               LAB_TestResultUpperLimit2	AS	AST_SGOT_RSLT_UP_LMT, ---26
+               LAB_TotalAntiHAV	AS	HEP_A_TOTAL_ANTIBODY, ---27
+               LAB_TotalAntiHAVDate	AS	TOTAL_ANTI_HAV_DT, ---28
+               LAB_TotalAntiHBc	AS	HEP_B_TOTAL_ANTIBODY, ---29
+               LAB_TotalAntiHBcDate	AS	TOTAL_ANTI_HBC_DT, ----30
+               LAB_TotalAntiHCV_Date	AS	TOTAL_ANTI_HCV_DT, --31
+               LAB_TotalAntiHDV	AS	HEP_D_TOTAL_ANTIBODY, ---32
+               LAB_TotalAntiHDV_Date	AS	TOTAL_ANTI_HDV_DT, ---33
+               LAB_TotalAntiHEV	AS	HEP_E_TOTAL_ANTIBODY, ---34
+               LAB_TotalAntiHEV_Date	AS	TOTAL_ANTI_HEV_DT, ---35
+               LAB_VerifiedTestDate 	AS	VERIFIED_TEST_DT ---36
+        INTO #TMP_D_INV_LAB_FINDING
+        FROM #TMP_F_INV_LAB_FINDING AS F
+                 LEFT JOIN
+             #D_INV_LAB_FINDING_TEMP_COLS AS D WITH(NOLOCK)
+             ON F.D_INV_LAB_FINDING_KEY = D.D_INV_LAB_FINDING_KEY
+        ;
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+        if @debug = 'true' select * from #TMP_D_INV_LAB_FINDING;
+
+
+        ---------------------------------------------------------------------------------------16. CREATE TABLE TMP_D_INV_MEDICAL_HISTORY----------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_MEDICAL_HISTORY';
+
+        SET @Proc_Step_no = 16;
+
+        IF OBJECT_ID('#TMP_F_INV_MEDICAL_HISTORY', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_MEDICAL_HISTORY;
+
+            END;
+
+        IF OBJECT_ID('#TMP_D_INV_MEDICAL_HISTORY', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_MEDICAL_HISTORY;
+
+            END;
+
+        SELECT F_PAGE_CASE.D_INV_MEDICAL_HISTORY_KEY, F_PAGE_CASE.[INVESTIGATION_KEY]
+        INTO #TMP_F_INV_MEDICAL_HISTORY
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN	 #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
+        ORDER BY D_INV_MEDICAL_HISTORY_KEY;
+
+        SELECT med_history.*
+        INTO #D_INV_MED_HIST_TEMP_COLS
+        FROM (
+                 SELECT CAST( NULL  AS date) AS MDH_DiabetesDxDate,
+                        NULL AS MDH_Diabetes,
+                        NULL AS MDH_Jaundiced,
+                        NULL AS MDH_PrevAwareInfection,
+                        NULL AS MDH_ProviderOfCare,
+                        NULL AS MDH_ReasonForTest,
+                        NULL AS MDH_ReasonForTestingOth,
+                        NULL AS MDH_Symptomatic,
+                        CAST( NULL  AS date) AS MDH_DueDate
+             ) AS temp_med_history_columns
+                 CROSS APPLY
+             ( SELECT D_INV_MEDICAL_HISTORY_KEY,
+                      MDH_DiabetesDxDate,
+                      MDH_Diabetes,
+                      MDH_Jaundiced,
+                      MDH_PrevAwareInfection,
+                      MDH_ProviderOfCare,
+                      MDH_ReasonForTest,
+                      MDH_ReasonForTestingOth,
+                      MDH_Symptomatic,
+                      MDH_DueDate
+               FROM dbo.D_INV_MEDICAL_HISTORY
+             ) AS med_history;
+
+
+        SELECT F.D_INV_MEDICAL_HISTORY_KEY, F.INVESTIGATION_KEY AS MEDHistory_INV_KEY,
+               CAST(MDH_DiabetesDxDate AS date) AS DIABETES_DX_DT,
+               CAST(MDH_Diabetes AS [varchar](300)) AS DIABETES_IND,
+               CAST(MDH_Jaundiced AS [varchar](300)) AS PAT_JUNDICED_IND,
+               CAST(MDH_PrevAwareInfection AS [varchar](300)) AS PAT_PREV_AWARE_IND,
+               CAST(MDH_ProviderOfCare AS [varchar](300)) AS HEP_CARE_PROVIDER,
+               CAST(MDH_ReasonForTest AS [varchar](300)) AS TEST_REASON,
+               CAST(MDH_ReasonForTestingOth AS [varchar](300)) AS TEST_REASON_OTH,
+               CAST(MDH_Symptomatic AS [varchar](300)) AS SYMPTOMATIC_IND,
+               CAST(MDH_DueDate AS date) AS PREGNANCY_DUE_DT
+        INTO #TMP_D_INV_MEDICAL_HISTORY
+        FROM #TMP_F_INV_MEDICAL_HISTORY AS F
+                 LEFT JOIN	#D_INV_MED_HIST_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_MEDICAL_HISTORY_KEY = D.D_INV_MEDICAL_HISTORY_KEY
+        ORDER BY F.INVESTIGATION_KEY;
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+
+        ---------------------------------------------------------------------------------17. CREATE TABLE TMP.D_INV_MOTHER-------------------------------------------------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_MOTHER';
+
+        SET @Proc_Step_no = 17;
+
+        IF OBJECT_ID('#TMP_F_INV_MOTHER', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_MOTHER;
+
+            END;
+
+        IF OBJECT_ID('#TMP_D_INV_MOTHER', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_MOTHER;
+
+            END;
+
+
+        SELECT F_PAGE_CASE.D_INV_MOTHER_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_MOTHER
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS PAGE_CASE
+             ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
+        ORDER BY D_INV_MOTHER_KEY;
+
+        SELECT mother.*
+        INTO #D_INV_MOTHER_TEMP_COLS
+        FROM (
+                 SELECT NULL AS MTH_MotherBornOutsideUS,
+                        NULL AS MTH_MotherEthnicity,
+                        NULL AS MTH_MotherHBsAgPosPrior,
+                        NULL AS MTH_MotherPositiveAfter,
+                        NULL AS MTH_MotherRace,
+                        NULL AS MTH_MothersBirthCountry,
+                        CAST( NULL  AS date) AS MTH_MotherPosTestDate
+             ) AS temp_med_mother_columns
+                 CROSS APPLY
+             ( SELECT D_INV_MOTHER_KEY,
+                      MTH_MotherBornOutsideUS,
+                      MTH_MotherEthnicity,
+                      MTH_MotherHBsAgPosPrior,
+                      MTH_MotherPositiveAfter,
+                      MTH_MotherRace,
+                      MTH_MothersBirthCountry,
+                      MTH_MotherPosTestDate
+               FROM dbo.D_INV_MOTHER
+             ) AS mother;
+
+
+        SELECT F.D_INV_MOTHER_KEY D_INV_MOTHER_KEY1, F.INVESTIGATION_KEY AS MOTHER_INV_KEY,
+               RTRIM(LTRIM(MTH_MotherBornOutsideUS))	AS	MTH_BORN_OUTSIDE_US,
+               RTRIM(LTRIM(MTH_MotherEthnicity))	AS	MTH_ETHNICITY,
+               RTRIM(LTRIM(MTH_MotherHBsAgPosPrior))	AS	MTH_HBS_AG_PRIOR_POS,
+               RTRIM(LTRIM(MTH_MotherPositiveAfter))	AS	MTH_POS_AFTER,
+               RTRIM(LTRIM(MTH_MotherRace))	AS	MTH_RACE,
+               RTRIM(LTRIM(MTH_MothersBirthCountry))	AS	MTH_BIRTH_COUNTRY,
+               RTRIM(LTRIM(MTH_MotherPosTestDate))	AS	MTH_POS_TEST_DT
+        INTO #TMP_D_INV_MOTHER
+        FROM #TMP_F_INV_MOTHER AS F
+                 LEFT JOIN	#D_INV_MOTHER_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_MOTHER_KEY = D.D_INV_MOTHER_KEY
+        ORDER BY F.INVESTIGATION_KEY;
+
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
 
 ----------------------------------------------------------------------------------18. CREATE TABLE TMP_D_INV_RISK_FACTOR---------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_RISK_FACTOR';
-
-			SET @Proc_Step_no = 18;
-
-			IF OBJECT_ID('#TMP_F_INV_RISK_FACTOR', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_RISK_FACTOR;
-
-END;
-
-			IF OBJECT_ID('#TMP_D_INV_RISK_FACTOR', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_RISK_FACTOR;
-
-END;
-
-SELECT F_PAGE_CASE.D_INV_RISK_FACTOR_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_RISK_FACTOR
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
-ORDER BY D_INV_RISK_FACTOR_KEY;
-
-
-SELECT F.D_INV_RISK_FACTOR_KEY D_INV_RISK_FACTOR_KEY1, F.INVESTIGATION_KEY AS RISK_INV_KEY, D.*,
-       CAST( null AS varchar(300)) AS BLD_EXPOSURE_IND, ---1
-       CAST( NULL  AS varchar(1000)) AS BLD_RECVD_IND, ----2
-       CAST( null  AS date) AS BLD_RECVD_DT, ---3
-       CAST( NULL  AS varchar(1000)) AS MED_DEN_BLD_CT_FRQ, ---4
-       CAST( NULL  AS varchar(1000)) AS MED_DEN_EMP_EVER_IND, ---5
-       CAST( NULL  AS varchar(1000)) AS MED_DEN_EMPLOYEE_IND, ---6
-       CAST( NULL  AS varchar(1000)) AS CLOTFACTOR_PRIOR_1987, ----7
-       CAST( NULL  AS varchar(1000)) AS BLD_CONTAM_IND, ----8
-       CAST( NULL  AS varchar(1000)) AS DEN_WORK_OR_SURG_IND, ----9
-       CAST( NULL  AS varchar(1000)) AS HEMODIALYSIS_IND, --10
-       CAST( NULL  AS varchar(1000)) AS LT_HEMODIALYSIS_IND, --11
-       CAST( NULL  AS varchar(1000)) AS HSPTL_PRIOR_ONSET_IND, --12
-       CAST( NULL  AS varchar(1000)) AS EVER_INJCT_NOPRSC_DRG, ------13
-       CAST( NULL  AS varchar(1000)) AS INCAR_24PLUSHRS_IND, ---14
-       CAST( NULL  AS varchar(1000)) AS INCAR_6PLUS_MO_IND, ----15
-       CAST( NULL  AS varchar(1000)) AS EVER_INCAR_IND, ---16
-       CAST( NULL  AS varchar(1000)) AS INCAR_TYPE_JAIL_IND, -- -17
-       CAST( NULL  AS varchar(1000)) AS INCAR_TYPE_PRISON_IND, ---18
-       CAST( NULL  AS varchar(1000)) AS INCAR_TYPE_JUV_IND, ---19
-       CAST( NULL  AS varchar(1000)) AS LAST6PLUSMO_INCAR_PER, ------20
-       CAST( NULL  AS varchar(1000)) AS LAST6PLUSMO_INCAR_YR, ---21
-       CAST( NULL  AS varchar(1000)) AS OUTPAT_IV_INF_IND, ---22
-       CAST( NULL  AS varchar(1000)) AS LTCARE_RESIDENT_IND, ---23
-       CAST( NULL  AS varchar(1000)) AS LIFE_SEX_PRTNR_NBR, ---24
-       CAST( NULL  AS varchar(1000)) AS BLD_EXPOSURE_OTH, ---25
-       CAST( NULL  AS varchar(1000)) AS PIERC_PRIOR_ONSET_IND, ---26
-       CAST( NULL  AS varchar(1000)) AS PIERC_PERF_LOC_OTH, ----27
-       CAST( NULL  AS varchar(1000)) AS PIERC_PERF_LOC, -------28
-       CAST( NULL  AS varchar(1000)) AS PUB_SAFETY_BLD_CT_FRQ, ---29
-       CAST( NULL  AS varchar(1000)) AS PUB_SAFETY_WORKER_IND, ---30
-       CAST( NULL  AS varchar(1000)) AS STD_TREATED_IND, ---31
-       CAST( NULL  AS varchar(1000)) AS STD_LAST_TREATMENT_YR, ---32
-       CAST( NULL  AS varchar(1000)) AS NON_ORAL_SURGERY_IND, -----33
-       CAST( NULL  AS varchar(1000)) AS TATT_PRIOR_ONSET_IND, ----34
-       CAST( NULL  AS varchar(1000)) AS TATTOO_PERF_LOC, ----35
-       CAST( NULL  AS varchar(1000)) AS TATT_PRIOR_LOC_OTH, ---36
-       CAST( NULL  AS varchar(1000)) AS BLD_TRANSF_PRIOR_1992, ---37
-       CAST( NULL  AS varchar(1000)) AS ORGN_TRNSP_PRIOR_1992, ---38
-       CAST( NULL  AS varchar(1000)) AS HEP_CONTACT_EVER_IND     ----39
-INTO #TMP_D_INV_RISK_FACTOR
-FROM #TMP_F_INV_RISK_FACTOR AS F
-         LEFT JOIN
-    [dbo].[D_INV_RISK_FACTOR] AS D WITH(NOLOCK)  ON F.D_INV_RISK_FACTOR_KEY = D.D_INV_RISK_FACTOR_KEY
-ORDER BY RISK_INV_KEY;
-
-/*
-CAST(RSK_BloodExpOther AS varchar(300)) AS BLD_EXPOSURE_IND, ---1
-           CAST(RSK_BloodTransfusion AS varchar(300)) AS BLD_RECVD_IND, ----2
-           CAST(RSK_BloodTransfusionDate AS date) AS BLD_RECVD_DT, ---3
-           CAST(RSK_BloodWorkerCnctFreq AS varchar(300)) AS MED_DEN_BLD_CT_FRQ, ---4
-           CAST(RSK_BloodWorkerEver AS varchar(300)) AS MED_DEN_EMP_EVER_IND, ---5
-           CAST(RSK_BloodWorkerOnset AS varchar(300)) AS MED_DEN_EMPLOYEE_IND, ---6
-           CAST(RSK_ClottingPrior87 AS varchar(300)) AS CLOTFACTOR_PRIOR_1987, ----7
-           CAST(RSK_ContaminatedStick AS varchar(300)) AS BLD_CONTAM_IND, ----8
-           CAST(RSK_DentalOralSx AS varchar(300)) AS DEN_WORK_OR_SURG_IND, ----9
-           CAST(RSK_HEMODIALYSIS_BEFORE_ONSET AS varchar(300)) AS HEMODIALYSIS_IND, --10
-           CAST(RSK_HemodialysisLongTerm AS varchar(300)) AS LT_HEMODIALYSIS_IND, --11
-           CAST(RSK_HospitalizedPrior AS varchar(300)) AS HSPTL_PRIOR_ONSET_IND, --12
-           CAST(RSK_IDU AS varchar(300)) AS EVER_INJCT_NOPRSC_DRG, ------13
-*/
-
-
-
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodExpOther'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_EXPOSURE_IND = RTRIM(LTRIM(RSK_BloodExpOther));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodTransfusion'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_RECVD_IND = RTRIM(LTRIM(RSK_BloodTransfusion));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodTransfusionDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			   SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_RECVD_DT = (RSK_BloodTransfusionDate);'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodWorkerCnctFreq'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set MED_DEN_BLD_CT_FRQ = RTRIM(LTRIM(RSK_BloodWorkerCnctFreq));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodWorkerEver'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set MED_DEN_EMP_EVER_IND = RTRIM(LTRIM(RSK_BloodWorkerEver));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_BloodWorkerOnset'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set MED_DEN_EMPLOYEE_IND = RTRIM(LTRIM(RSK_BloodWorkerOnset));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_ClottingPrior87'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set CLOTFACTOR_PRIOR_1987 = RTRIM(LTRIM(RSK_ClottingPrior87));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_ContaminatedStick'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_CONTAM_IND = RTRIM(LTRIM(RSK_ContaminatedStick));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_DentalOralSx'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set DEN_WORK_OR_SURG_IND = RTRIM(LTRIM(RSK_DentalOralSx));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_HEMODIALYSIS_BEFORE_ONSET'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set HEMODIALYSIS_IND = RTRIM(LTRIM(RSK_HEMODIALYSIS_BEFORE_ONSET));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_HemodialysisLongTerm'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set LT_HEMODIALYSIS_IND = RTRIM(LTRIM(RSK_HemodialysisLongTerm));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_HospitalizedPrior'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set HSPTL_PRIOR_ONSET_IND = RTRIM(LTRIM(RSK_HospitalizedPrior));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IDU'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set EVER_INJCT_NOPRSC_DRG = RTRIM(LTRIM(RSK_IDU));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-
-/*          CAST(RSK_Incarcerated24Hrs AS varchar(300)) AS INCAR_24PLUSHRS_IND, ---14
-			CAST(RSK_Incarcerated6months AS varchar(300)) AS INCAR_6PLUS_MO_IND, ----15
-			CAST(RSK_IncarceratedEver AS varchar(300)) AS EVER_INCAR_IND, ---16
-			CAST(RSK_IncarceratedJail AS varchar(300)) AS INCAR_TYPE_JAIL_IND, -- -17
-			CAST(RSK_IncarcerationPrison AS varchar(300)) AS INCAR_TYPE_PRISON_IND, ---18
-			CAST(RSK_IncarcJuvenileFacilit AS varchar(300)) AS INCAR_TYPE_JUV_IND, ---19
-			CAST(RSK_IncarcTimeMonths AS varchar(300)) AS LAST6PLUSMO_INCAR_PER, ------20
-			CAST(RSK_IncarcYear6Mos AS varchar(300)) AS LAST6PLUSMO_INCAR_YR, ---21
-*/
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_Incarcerated24Hrs'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set INCAR_24PLUSHRS_IND = RTRIM(LTRIM(RSK_Incarcerated24Hrs));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_Incarcerated6months'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set INCAR_6PLUS_MO_IND = RTRIM(LTRIM(RSK_Incarcerated6months));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarceratedEver'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set EVER_INCAR_IND = RTRIM(LTRIM(RSK_IncarceratedEver));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarceratedJail'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set INCAR_TYPE_JAIL_IND = RTRIM(LTRIM(RSK_IncarceratedJail));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarcerationPrison'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set INCAR_TYPE_PRISON_IND = RTRIM(LTRIM(RSK_IncarcerationPrison));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarcJuvenileFacilit'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set INCAR_TYPE_JUV_IND = RTRIM(LTRIM(RSK_IncarcJuvenileFacilit));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarcTimeMonths'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set LAST6PLUSMO_INCAR_PER = RTRIM(LTRIM(RSK_IncarcTimeMonths));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IncarcYear6Mos'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set LAST6PLUSMO_INCAR_YR = RTRIM(LTRIM(RSK_IncarcYear6Mos));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-/*
-CAST(RSK_IVInjectInfuseOutpt AS varchar(300)) AS OUTPAT_IV_INF_IND, ---22
-			CAST(RSK_LongTermCareRes AS varchar(300)) AS LTCARE_RESIDENT_IND, ---23
-			CAST(RSK_NumSexPrtners AS varchar(300)) AS LIFE_SEX_PRTNR_NBR, ---24
-			CAST(RSK_OtherBldExpSpec AS varchar(300)) AS BLD_EXPOSURE_OTH, ---25
-			CAST(RSK_Piercing AS varchar(300)) AS PIERC_PRIOR_ONSET_IND, ---26
-			CAST(RSK_PiercingOthLocSpec AS varchar(300)) AS PIERC_PERF_LOC_OTH, ----27
-			CAST(RSK_PiercingRcvdFrom AS varchar(300)) AS PIERC_PERF_LOC, -------28
-			CAST(RSK_PSWrkrBldCnctFreq AS varchar(300)) AS PUB_SAFETY_BLD_CT_FRQ, ---29
-			CAST(RSK_PublicSafetyWorker AS varchar(300)) AS PUB_SAFETY_WORKER_IND, ---30
-			CAST(RSK_STDTxEver AS varchar(300)) AS STD_TREATED_IND, ---31
-			CAST(RSK_STDTxYr AS varchar(300)) AS STD_LAST_TREATMENT_YR, ---32
-			CAST(RSK_SurgeryOther AS varchar(300)) AS NON_ORAL_SURGERY_IND, -----33
-			CAST(RSK_Tattoo AS varchar(300)) AS TATT_PRIOR_ONSET_IND, ----34
-			CAST(RSK_TattooLocation AS varchar(300)) AS TATTOO_PERF_LOC, ----35
-			CAST(RSK_TattooLocOthSpec AS varchar(300)) AS TATT_PRIOR_LOC_OTH, ---36
-			CAST(RSK_TransfusionPrior92 AS varchar(300)) AS BLD_TRANSF_PRIOR_1992, ---37
-			CAST(RSK_TransplantPrior92 AS varchar(300)) AS ORGN_TRNSP_PRIOR_1992, ---38
-			CAST(RSK_HepContactEver AS varchar(300)) AS HEP_CONTACT_EVER_IND     ----39
-		*/
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_IVInjectInfuseOutpt'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set OUTPAT_IV_INF_IND = RTRIM(LTRIM(RSK_IVInjectInfuseOutpt));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_LongTermCareRes' AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set LTCARE_RESIDENT_IND = RTRIM(LTRIM(RSK_LongTermCareRes));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_NumSexPrtners'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set LIFE_SEX_PRTNR_NBR = RTRIM(LTRIM(RSK_NumSexPrtners));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_OtherBldExpSpec'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_EXPOSURE_OTH = RTRIM(LTRIM(RSK_OtherBldExpSpec));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_Piercing'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set PIERC_PRIOR_ONSET_IND = RTRIM(LTRIM(RSK_Piercing));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_PiercingOthLocSpec'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set PIERC_PERF_LOC_OTH = RTRIM(LTRIM(RSK_PiercingOthLocSpec));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_PiercingRcvdFrom'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set PIERC_PERF_LOC = RTRIM(LTRIM(RSK_PiercingRcvdFrom));'
-			  execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_PSWrkrBldCnctFreq'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set PUB_SAFETY_BLD_CT_FRQ = RTRIM(LTRIM(RSK_PSWrkrBldCnctFreq));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_PublicSafetyWorker'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set PUB_SAFETY_WORKER_IND = RTRIM(LTRIM(RSK_PublicSafetyWorker));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_STDTxEver'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set STD_TREATED_IND = RTRIM(LTRIM(RSK_STDTxEver));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_STDTxYr'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set STD_LAST_TREATMENT_YR = RTRIM(LTRIM(RSK_STDTxYr));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_SurgeryOther'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set NON_ORAL_SURGERY_IND = RTRIM(LTRIM(RSK_SurgeryOther));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_Tattoo'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set TATT_PRIOR_ONSET_IND = RTRIM(LTRIM(RSK_Tattoo));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_TattooLocation'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set TATTOO_PERF_LOC = RTRIM(LTRIM(RSK_TattooLocation));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_TattooLocOthSpec'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set TATT_PRIOR_LOC_OTH = RTRIM(LTRIM(RSK_TattooLocOthSpec));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_TransfusionPrior92'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set BLD_TRANSF_PRIOR_1992 = RTRIM(LTRIM(RSK_TransfusionPrior92));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_TransplantPrior92'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set ORGN_TRNSP_PRIOR_1992 = RTRIM(LTRIM(RSK_TransplantPrior92));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'RSK_HepContactEver'   AND Object_ID = Object_ID(N'#TMP_D_INV_RISK_FACTOR'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_RISK_FACTOR set HEP_CONTACT_EVER_IND = RTRIM(LTRIM(RSK_HepContactEver));'
-			    execute sp_executesql  @sql
-END;
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_RISK_FACTOR';
+
+        SET @Proc_Step_no = 18;
+
+        IF OBJECT_ID('#TMP_F_INV_RISK_FACTOR', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_RISK_FACTOR;
+
+            END;
+
+        IF OBJECT_ID('#TMP_D_INV_RISK_FACTOR', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_RISK_FACTOR;
+
+            END;
+
+        SELECT F_PAGE_CASE.D_INV_RISK_FACTOR_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_RISK_FACTOR
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
+        ORDER BY D_INV_RISK_FACTOR_KEY;
+
+
+        SELECT risk.*
+        INTO #D_INV_RISK_FACT_TEMP_COLS
+        FROM (
+                 SELECT CAST( null AS varchar(300)) AS RSK_BloodExpOther, ---1
+                        CAST( NULL  AS varchar(1000)) AS RSK_BloodTransfusion, ----2
+                        CAST( null  AS date) AS RSK_BloodTransfusionDate, ---3
+                        CAST( NULL  AS varchar(1000)) AS RSK_BloodWorkerCnctFreq, ---4
+                        CAST( NULL  AS varchar(1000)) AS RSK_BloodWorkerEver, ---5
+                        CAST( NULL  AS varchar(1000)) AS RSK_BloodWorkerOnset, ---6
+                        CAST( NULL  AS varchar(1000)) AS RSK_ClottingPrior87, ----7
+                        CAST( NULL  AS varchar(1000)) AS RSK_ContaminatedStick, ----8
+                        CAST( NULL  AS varchar(1000)) AS RSK_DentalOralSx, ----9
+                        CAST( NULL  AS varchar(1000)) AS RSK_HEMODIALYSIS_BEFORE_ONSET, --10
+                        CAST( NULL  AS varchar(1000)) AS RSK_HemodialysisLongTerm, --11
+                        CAST( NULL  AS varchar(1000)) AS RSK_HospitalizedPrior, --12
+                        CAST( NULL  AS varchar(1000)) AS RSK_IDU, ------13
+                        CAST( NULL  AS varchar(1000)) AS RSK_Incarcerated24Hrs, ---14
+                        CAST( NULL  AS varchar(1000)) AS RSK_Incarcerated6months, ----15
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarceratedEver, ---16
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarceratedJail, -- -17
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarcerationPrison, ---18
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarcJuvenileFacilit, ---19
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarcTimeMonths, ------20
+                        CAST( NULL  AS varchar(1000)) AS RSK_IncarcYear6Mos, ---21
+                        CAST( NULL  AS varchar(1000)) AS RSK_IVInjectInfuseOutpt, ---22
+                        CAST( NULL  AS varchar(1000)) AS RSK_LongTermCareRes, ---23
+                        CAST( NULL  AS varchar(1000)) AS RSK_NumSexPrtners, ---24
+                        CAST( NULL  AS varchar(1000)) AS RSK_OtherBldExpSpec, ---25
+                        CAST( NULL  AS varchar(1000)) AS RSK_Piercing, ---26
+                        CAST( NULL  AS varchar(1000)) AS RSK_PiercingOthLocSpec, ----27
+                        CAST( NULL  AS varchar(1000)) AS RSK_PiercingRcvdFrom, -------28
+                        CAST( NULL  AS varchar(1000)) AS RSK_PSWrkrBldCnctFreq, ---29
+                        CAST( NULL  AS varchar(1000)) AS RSK_PublicSafetyWorker, ---30
+                        CAST( NULL  AS varchar(1000)) AS RSK_STDTxEver, ---31
+                        CAST( NULL  AS varchar(1000)) AS RSK_STDTxYr, ---32
+                        CAST( NULL  AS varchar(1000)) AS RSK_SurgeryOther, -----33
+                        CAST( NULL  AS varchar(1000)) AS RSK_Tattoo, ----34
+                        CAST( NULL  AS varchar(1000)) AS RSK_TattooLocation, ----35
+                        CAST( NULL  AS varchar(1000)) AS RSK_TattooLocOthSpec, ---36
+                        CAST( NULL  AS varchar(1000)) AS RSK_TransfusionPrior92, ---37
+                        CAST( NULL  AS varchar(1000)) AS RSK_TransplantPrior92, ---38
+                        CAST( NULL  AS varchar(1000)) AS RSK_HepContactEver     ----39
+             ) AS temp_risk_columns
+                 CROSS APPLY
+             ( SELECT D_INV_RISK_FACTOR_KEY,
+                      RSK_BloodExpOther,
+                      RSK_BloodTransfusion,
+                      RSK_BloodTransfusionDate,
+                      RSK_BloodWorkerCnctFreq,
+                      RSK_BloodWorkerEver,
+                      RSK_BloodWorkerOnset,
+                      RSK_ClottingPrior87,
+                      RSK_ContaminatedStick,
+                      RSK_DentalOralSx,
+                      RSK_HEMODIALYSIS_BEFORE_ONSET,
+                      RSK_HemodialysisLongTerm,
+                      RSK_HospitalizedPrior,
+                      RSK_IDU,
+                      RSK_Incarcerated24Hrs,
+                      RSK_Incarcerated6months,
+                      RSK_IncarceratedEver,
+                      RSK_IncarceratedJail,
+                      RSK_IncarcerationPrison,
+                      RSK_IncarcJuvenileFacilit,
+                      RSK_IncarcTimeMonths,
+                      RSK_IncarcYear6Mos,
+                      RSK_IVInjectInfuseOutpt,
+                      RSK_LongTermCareRes,
+                      RSK_NumSexPrtners,
+                      RSK_OtherBldExpSpec,
+                      RSK_Piercing,
+                      RSK_PiercingOthLocSpec,
+                      RSK_PiercingRcvdFrom,
+                      RSK_PSWrkrBldCnctFreq,
+                      RSK_PublicSafetyWorker,
+                      RSK_STDTxEver,
+                      RSK_STDTxYr,
+                      RSK_SurgeryOther,
+                      RSK_Tattoo,
+                      RSK_TattooLocation,
+                      RSK_TattooLocOthSpec,
+                      RSK_TransfusionPrior92,
+                      RSK_TransplantPrior92,
+                      RSK_HepContactEver
+               FROM dbo.D_INV_RISK_FACTOR
+             ) AS risk;
+
+
+        SELECT F.D_INV_RISK_FACTOR_KEY D_INV_RISK_FACTOR_KEY1, F.INVESTIGATION_KEY AS RISK_INV_KEY,
+               RTRIM(LTRIM(RSK_BloodExpOther))	AS	BLD_EXPOSURE_IND, ---1
+               RTRIM(LTRIM(RSK_BloodTransfusion))	AS	BLD_RECVD_IND, ----2
+               RSK_BloodTransfusionDate	AS	BLD_RECVD_DT, ---3
+               RTRIM(LTRIM(RSK_BloodWorkerCnctFreq))	AS	MED_DEN_BLD_CT_FRQ, ---4
+               RTRIM(LTRIM(RSK_BloodWorkerEver))	AS	MED_DEN_EMP_EVER_IND, ---5
+               RTRIM(LTRIM(RSK_BloodWorkerOnset))	AS	MED_DEN_EMPLOYEE_IND, ---6
+               RTRIM(LTRIM(RSK_ClottingPrior87))	AS	CLOTFACTOR_PRIOR_1987, ----7
+               RTRIM(LTRIM(RSK_ContaminatedStick))	AS	BLD_CONTAM_IND, ----8
+               RTRIM(LTRIM(RSK_DentalOralSx))	AS	DEN_WORK_OR_SURG_IND, ----9
+               RTRIM(LTRIM(RSK_HEMODIALYSIS_BEFORE_ONSET))	AS	HEMODIALYSIS_IND, --10
+               RTRIM(LTRIM(RSK_HemodialysisLongTerm))	AS	LT_HEMODIALYSIS_IND, --11
+               RTRIM(LTRIM(RSK_HospitalizedPrior))	AS	HSPTL_PRIOR_ONSET_IND, --12
+               RTRIM(LTRIM(RSK_IDU))	AS	EVER_INJCT_NOPRSC_DRG, ------13
+               RTRIM(LTRIM(RSK_Incarcerated24Hrs))	AS	INCAR_24PLUSHRS_IND, ---14
+               RTRIM(LTRIM(RSK_Incarcerated6months))	AS	INCAR_6PLUS_MO_IND, ----15
+               RTRIM(LTRIM(RSK_IncarceratedEver))	AS	EVER_INCAR_IND, ---16
+               RTRIM(LTRIM(RSK_IncarceratedJail))	AS	INCAR_TYPE_JAIL_IND, -- -17
+               RTRIM(LTRIM(RSK_IncarcerationPrison))	AS	INCAR_TYPE_PRISON_IND, ---18
+               RTRIM(LTRIM(RSK_IncarcJuvenileFacilit))	AS	INCAR_TYPE_JUV_IND, ---19
+               RTRIM(LTRIM(RSK_IncarcTimeMonths))	AS	LAST6PLUSMO_INCAR_PER, ------20
+               RTRIM(LTRIM(RSK_IncarcYear6Mos))	AS	LAST6PLUSMO_INCAR_YR, ---21
+               RTRIM(LTRIM(RSK_IVInjectInfuseOutpt))	AS	OUTPAT_IV_INF_IND, ---22
+               RTRIM(LTRIM(RSK_LongTermCareRes))	AS	LTCARE_RESIDENT_IND, ---23
+               RTRIM(LTRIM(RSK_NumSexPrtners))	AS	LIFE_SEX_PRTNR_NBR, ---24
+               RTRIM(LTRIM(RSK_OtherBldExpSpec))	AS	BLD_EXPOSURE_OTH, ---25
+               RTRIM(LTRIM(RSK_Piercing))	AS	PIERC_PRIOR_ONSET_IND, ---26
+               RTRIM(LTRIM(RSK_PiercingOthLocSpec))	AS	PIERC_PERF_LOC_OTH, ----27
+               RTRIM(LTRIM(RSK_PiercingRcvdFrom))	AS	PIERC_PERF_LOC, -------28
+               RTRIM(LTRIM(RSK_PSWrkrBldCnctFreq))	AS	PUB_SAFETY_BLD_CT_FRQ, ---29
+               RTRIM(LTRIM(RSK_PublicSafetyWorker))	AS	PUB_SAFETY_WORKER_IND, ---30
+               RTRIM(LTRIM(RSK_STDTxEver))	AS	STD_TREATED_IND, ---31
+               RTRIM(LTRIM(RSK_STDTxYr))	AS	STD_LAST_TREATMENT_YR, ---32
+               RTRIM(LTRIM(RSK_SurgeryOther))	AS	NON_ORAL_SURGERY_IND, -----33
+               RTRIM(LTRIM(RSK_Tattoo))	AS	TATT_PRIOR_ONSET_IND, ----34
+               RTRIM(LTRIM(RSK_TattooLocation))	AS	TATTOO_PERF_LOC, ----35
+               RTRIM(LTRIM(RSK_TattooLocOthSpec))	AS	TATT_PRIOR_LOC_OTH, ---36
+               RTRIM(LTRIM(RSK_TransfusionPrior92))	AS	BLD_TRANSF_PRIOR_1992, ---37
+               RTRIM(LTRIM(RSK_TransplantPrior92))	AS	ORGN_TRNSP_PRIOR_1992, ---38
+               RTRIM(LTRIM(RSK_HepContactEver))	AS	HEP_CONTACT_EVER_IND ----39
+        INTO #TMP_D_INV_RISK_FACTOR
+        FROM #TMP_F_INV_RISK_FACTOR AS F
+                 LEFT JOIN
+             #D_INV_RISK_FACT_TEMP_COLS AS D WITH(NOLOCK)  ON F.D_INV_RISK_FACTOR_KEY = D.D_INV_RISK_FACTOR_KEY
+        ORDER BY RISK_INV_KEY;
+
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
 
 ---------------------------------------------------19. CREATE TABLE #TMP_D_INV_TRAVEL---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_INV_TRAVEL';
+        SET @Proc_Step_name = 'Generating  #TMP_D_INV_TRAVEL';
 
-			SET @Proc_Step_no = 19;
+        SET @Proc_Step_no = 19;
 
-			IF OBJECT_ID('#TMP_F_INV_TRAVEL', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_TRAVEL;
+        IF OBJECT_ID('#TMP_F_INV_TRAVEL', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_TRAVEL;
 
-END;
+            END;
 
-			IF OBJECT_ID('#TMP_D_INV_TRAVEL', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_TRAVEL;
+        IF OBJECT_ID('#TMP_D_INV_TRAVEL', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_TRAVEL;
 
-END;
+            END;
 
-SELECT F_PAGE_CASE.D_INV_TRAVEL_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_TRAVEL
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE AS PAGE_CASE
-ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
-ORDER BY D_INV_TRAVEL_KEY;
-
-
-
-SELECT F.D_INV_TRAVEL_KEY D_INV_TRAVEL_KEY1, F.INVESTIGATION_KEY AS Travel_INV_KEY, d.*,
-       CAST( NULL  AS varchar(1000)) AS HOUSEHOLD_TRAVEL_IND,
-       CAST( NULL  AS varchar(1000)) AS TRAVEL_OUT_USACAN_IND,
-       CAST( NULL  AS varchar(1000)) AS TRAVEL_OUT_USACAN_LOC,
-       CAST( NULL  AS varchar(1000)) AS HOUSEHOLD_TRAVEL_LOC,
-       CAST( NULL  AS varchar(1000)) AS TRAVEL_REASON
-INTO #TMP_D_INV_TRAVEL
-FROM #TMP_F_INV_TRAVEL AS F
-         LEFT JOIN
-    [dbo].[D_INV_TRAVEL] AS D WITH(NOLOCK)
-ON F.D_INV_TRAVEL_KEY = D.D_INV_TRAVEL_KEY
-ORDER BY F.INVESTIGATION_KEY;
+        SELECT F_PAGE_CASE.D_INV_TRAVEL_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_TRAVEL
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS PAGE_CASE
+             ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY---(my table)
+        ORDER BY D_INV_TRAVEL_KEY;
 
 
-
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'TRV_HouseholdTravel'   AND Object_ID = Object_ID(N'#TMP_D_INV_TRAVEL'))
-BEGIN
-
-			    SET @sql = N'update #TMP_D_INV_TRAVEL set HOUSEHOLD_TRAVEL_IND = RTRIM(LTRIM(TRV_HouseholdTravel));'
-			    execute sp_executesql  @sql
-END;
-
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'TRV_PatientTravel'   AND Object_ID = Object_ID(N'#TMP_D_INV_TRAVEL'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_TRAVEL set TRAVEL_OUT_USACAN_IND = RTRIM(LTRIM(TRV_PatientTravel));'
-			    execute sp_executesql  @sql
-END;
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'TRV_PtTravelCountries'   AND Object_ID = Object_ID(N'#TMP_D_INV_TRAVEL'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_TRAVEL set TRAVEL_OUT_USACAN_LOC = RTRIM(LTRIM(TRV_PtTravelCountries));'
-			    execute sp_executesql  @sql
-END;
+        SELECT travel.*
+        INTO #D_INV_TRAVEL_TEMP_COLS
+        FROM (
+                 SELECT CAST( NULL  AS varchar(1000)) AS TRV_HouseholdTravel,
+                        CAST( NULL  AS varchar(1000)) AS TRV_PatientTravel,
+                        CAST( NULL  AS varchar(1000)) AS TRV_PtTravelCountries,
+                        CAST( NULL  AS varchar(1000)) AS TRV_TravelCountryHouse,
+                        CAST( NULL  AS varchar(1000)) AS TRV_VHF_TRAVEL_REASON
+             ) AS temp_travel_columns
+                 CROSS APPLY
+             ( SELECT D_INV_TRAVEL_KEY,
+                      TRV_HouseholdTravel,
+                      TRV_PatientTravel,
+                      TRV_PtTravelCountries,
+                      TRV_TravelCountryHouse,
+                      TRV_VHF_TRAVEL_REASON
+               FROM dbo.D_INV_TRAVEL
+             ) AS travel;
 
 
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'TRV_TravelCountryHouse'   AND Object_ID = Object_ID(N'#TMP_D_INV_TRAVEL'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_TRAVEL set HOUSEHOLD_TRAVEL_LOC = RTRIM(LTRIM(TRV_TravelCountryHouse));'
-			    execute sp_executesql  @sql
-END;
+        SELECT F.D_INV_TRAVEL_KEY D_INV_TRAVEL_KEY1, F.INVESTIGATION_KEY AS Travel_INV_KEY,
+               RTRIM(LTRIM(TRV_HouseholdTravel)) AS HOUSEHOLD_TRAVEL_IND,
+               RTRIM(LTRIM(TRV_PatientTravel)) AS TRAVEL_OUT_USACAN_IND,
+               RTRIM(LTRIM(TRV_PtTravelCountries)) AS TRAVEL_OUT_USACAN_LOC,
+               RTRIM(LTRIM(TRV_TravelCountryHouse)) AS HOUSEHOLD_TRAVEL_LOC,
+               RTRIM(LTRIM(TRV_VHF_TRAVEL_REASON)) AS TRAVEL_REASON
+        INTO #TMP_D_INV_TRAVEL
+        FROM #TMP_F_INV_TRAVEL AS F
+                 LEFT JOIN
+             #D_INV_TRAVEL_TEMP_COLS AS D WITH(NOLOCK)
+             ON F.D_INV_TRAVEL_KEY = D.D_INV_TRAVEL_KEY
+        ORDER BY F.INVESTIGATION_KEY;
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+
+        -------------------------------------------------------------------20. CREATE TABLE TMP_D_INV_VACCINATION--------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating  TMP_D_INV_VACCINATION';
+
+        SET @Proc_Step_no = 20;
+
+        IF OBJECT_ID('#TMP_F_INV_VACCINATION', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INV_VACCINATION;
+
+            END;
+
+        IF OBJECT_ID('#TMP_D_INV_VACCINATION', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INV_VACCINATION;
+
+            END;
+
+        SELECT F_PAGE_CASE.D_INV_VACCINATION_KEY, F_PAGE_CASE.INVESTIGATION_KEY
+        INTO #TMP_F_INV_VACCINATION
+        FROM dbo.F_PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS PAGE_CASE
+             ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
+        ORDER BY D_INV_VACCINATION_KEY;
+
+        SELECT vacc.*
+        INTO #D_INV_VACCINATION_TEMP_COLS
+        FROM (
+                 SELECT CAST( NULL  AS varchar(1000)) AS VAC_ImmuneGlobulin,
+                        CAST( NULL  AS varchar(1000)) AS RSK_STDTxYr,
+                        CAST( NULL  AS varchar(1000)) AS VAC_LastIGDose,
+                        CAST( NULL  AS varchar(1000)) AS VAC_Vacc_Rcvd,
+                        CAST( NULL  AS varchar(1000)) AS VAC_VaccineDoses,
+                        CAST( NULL  AS varchar(1000)) AS VAC_YearofLastDose,
+                        CAST( NULL  AS date) AS VAC_VaccinationDate
+             ) AS temp_vaccination_columns
+                 CROSS APPLY
+             ( SELECT D_INV_VACCINATION_KEY,
+                      VAC_ImmuneGlobulin,
+                      RSK_STDTxYr,
+                      VAC_LastIGDose,
+                      VAC_Vacc_Rcvd,
+                      VAC_VaccineDoses,
+                      VAC_YearofLastDose,
+                      VAC_VaccinationDate
+               FROM dbo.D_INV_VACCINATION
+             ) AS vacc;
+
+
+        SELECT F.D_INV_VACCINATION_KEY D_INV_VACCINATION_KEY1, F.INVESTIGATION_KEY AS VACCINATION_INV_KEY,
+               VAC_ImmuneGlobulin AS IMM_GLOB_RECVD_IND, ----EXT_IMM_GLOB_RECVD_IND,
+               RSK_STDTxYr AS STD_LAST_TREATMENT_YR, -----EXT_STD_LAST_TREATMENT_YR,
+               VAC_LastIGDose AS GLOB_LAST_RECVD_YR, -----EXT_GLOB_LAST_RECVD_YR,
+               VAC_Vacc_Rcvd AS VACC_RECVD_IND, ---- ---EXT_VACC_RECVD_IND--------------5-13-2021
+               VAC_VaccineDoses AS VACC_DOSE_RECVD_NBR, ---EXT_VACC_DOSE_RECVD_NBR,-----INPUT(VAC_VaccineDoses, comma20.);
+               VAC_YearofLastDose AS VACC_LAST_RECVD_YR, -----EXT_VACC_LAST_RECVD_YR,-------INPUT(VAC_YearofLastDose, comma20.);
+               VAC_VaccinationDate  ---EXT_VACC_RECVD_DT,------------VAC_VaccinationDate---could not find
+        INTO #TMP_D_INV_VACCINATION
+        FROM #TMP_F_INV_VACCINATION AS F
+                 LEFT JOIN
+             #D_INV_VACCINATION_TEMP_COLS AS V WITH(NOLOCK)
+             ON F.D_INV_VACCINATION_KEY = V.D_INV_VACCINATION_KEY
+        ORDER BY F.INVESTIGATION_KEY;
 
 
 
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'TRV_VHF_TRAVEL_REASON'   AND Object_ID = Object_ID(N'#TMP_D_INV_TRAVEL'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_TRAVEL set TRAVEL_REASON = RTRIM(LTRIM(TRV_VHF_TRAVEL_REASON));'
-			    execute sp_executesql  @sql
-END;
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
-
--------------------------------------------------------------------20. CREATE TABLE TMP_D_INV_VACCINATION--------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating  TMP_D_INV_VACCINATION';
-
-			SET @Proc_Step_no = 20;
-
-			IF OBJECT_ID('#TMP_F_INV_VACCINATION', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INV_VACCINATION;
-
-END;
-
-			IF OBJECT_ID('#TMP_D_INV_VACCINATION', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INV_VACCINATION;
-
-END;
-
-SELECT F_PAGE_CASE.D_INV_VACCINATION_KEY, F_PAGE_CASE.INVESTIGATION_KEY
-INTO #TMP_F_INV_VACCINATION
-FROM dbo.F_PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE AS PAGE_CASE
-ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY	---(my table)
-ORDER BY D_INV_VACCINATION_KEY;
-
-
-SELECT F.D_INV_VACCINATION_KEY D_INV_VACCINATION_KEY1, F.INVESTIGATION_KEY AS VACCINATION_INV_KEY, V.*,
-       CAST( NULL  AS varchar(1000)) AS IMM_GLOB_RECVD_IND, ----EXT_IMM_GLOB_RECVD_IND,
-       CAST( NULL  AS varchar(1000)) AS STD_LAST_TREATMENT_YR, -----EXT_STD_LAST_TREATMENT_YR,
-       CAST( NULL  AS varchar(1000)) AS GLOB_LAST_RECVD_YR, -----EXT_GLOB_LAST_RECVD_YR,
-       CAST( NULL  AS varchar(1000)) AS VACC_RECVD_IND, ---- ---EXT_VACC_RECVD_IND--------------5-13-2021
-       CAST( NULL  AS varchar(1000)) AS VACC_DOSE_RECVD_NBR, ---EXT_VACC_DOSE_RECVD_NBR,-----INPUT(VAC_VaccineDoses, comma20.);
-       CAST( NULL  AS varchar(1000)) AS VACC_LAST_RECVD_YR -----EXT_VACC_LAST_RECVD_YR,-------INPUT(VAC_YearofLastDose, comma20.);
---	Cast( null   as varchar(2000)) as VAC_VaccinationDate  ---EXT_VACC_RECVD_DT,------------VAC_VaccinationDate---could not find
-INTO #TMP_D_INV_VACCINATION
-FROM #TMP_F_INV_VACCINATION AS F
-         LEFT JOIN
-    [dbo].[D_INV_VACCINATION] AS V WITH(NOLOCK)
-ON F.D_INV_VACCINATION_KEY = V.D_INV_VACCINATION_KEY
-ORDER BY F.INVESTIGATION_KEY;
-
-
-
-IF NOT  EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_VaccinationDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'alter table  #TMP_D_INV_VACCINATION add  VAC_VaccinationDate  varchar(2000) NULL;'
-			    execute sp_executesql  @sql
-END;
-
- /*
-
- 	        CAST(VAC_ImmuneGlobulin AS varchar(300)) AS IMM_GLOB_RECVD_IND, ----EXT_IMM_GLOB_RECVD_IND,
-			CAST(RSK_STDTxYr AS varchar(300)) AS STD_LAST_TREATMENT_YR, -----EXT_STD_LAST_TREATMENT_YR,
-			CAST(VAC_LastIGDose AS varchar(300)) AS GLOB_LAST_RECVD_YR, -----EXT_GLOB_LAST_RECVD_YR,
-			CAST(VAC_Vacc_Rcvd AS varchar(10)) AS VACC_RECVD_IND, ---- ---EXT_VACC_RECVD_IND--------------5-13-2021
-			CAST(VAC_VaccineDoses AS varchar(300)) AS VACC_DOSE_RECVD_NBR, ---EXT_VACC_DOSE_RECVD_NBR,-----INPUT(VAC_VaccineDoses, comma20.);
-			CAST(VAC_YearofLastDose AS varchar(300)) AS VACC_LAST_RECVD_YR ,-----EXT_VACC_LAST_RECVD_YR,-------INPUT(VAC_YearofLastDose, comma20.);
- 			Cast(VAC_VaccinationDate  as varchar(2000)) as VAC_VaccinationDate  ---EXT_VACC_RECVD_DT,------------VAC_VaccinationDate---could not find
-		*/
-
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_ImmuneGlobulin'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set IMM_GLOB_RECVD_IND = RTRIM(LTRIM(VAC_ImmuneGlobulin));'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns  WHERE Name = N'RSK_STDTxYr'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set STD_LAST_TREATMENT_YR = (RSK_STDTxYr);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_LastIGDose'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set GLOB_LAST_RECVD_YR = (VAC_LastIGDose);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_Vacc_Rcvd'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set VACC_RECVD_IND = RTRIM(LTRIM(VAC_Vacc_Rcvd));'
-			    execute sp_executesql  @sql
-END;
-
-
-			 -- declare @sql nvarchar(2000);
-
- 				IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_VaccineDoses'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set VACC_DOSE_RECVD_NBR= (VAC_VaccineDoses);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_YearofLastDose'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set VACC_LAST_RECVD_YR = (VAC_YearofLastDose);'
-			    execute sp_executesql  @sql
-END;
-
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_VaccinationDate'   AND Object_ID = Object_ID(N'#TMP_D_INV_VACCINATION'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INV_VACCINATION set VAC_VaccinationDate = (VAC_VaccinationDate);'
-			    execute sp_executesql  @sql
-END;
-
-			--------Could Not find
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 ----------------------------------------------------------21. CREATE TABLE #TMP_D_Patient---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_Patient';
+        SET @Proc_Step_name = 'Generating  #TMP_D_Patient';
 
-			SET @Proc_Step_no = 21;
+        SET @Proc_Step_no = 21;
 
-			IF OBJECT_ID('#TMP_D_Patient', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_Patient;
+        IF OBJECT_ID('#TMP_D_Patient', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_Patient;
 
-END;
+            END;
 
-SELECT F_PAGE_CASE.INVESTIGATION_KEY AS Patient_INV_KEY, D_PATIENT.PATIENT_UID, D_PATIENT.PATIENT_ETHNICITY AS PAT_ETHNICITY, D_PATIENT.PATIENT_AGE_REPORTED AS PAT_REPORTED_AGE, D_PATIENT.PATIENT_AGE_REPORTED_UNIT AS PAT_REPORTED_AGE_UNIT, D_PATIENT.PATIENT_CITY AS PAT_CITY, D_PATIENT.PATIENT_COUNTRY AS PAT_COUNTRY, D_PATIENT.PATIENT_BIRTH_COUNTRY AS PAT_BIRTH_COUNTRY, D_PATIENT.PATIENT_COUNTY AS PAT_COUNTY, D_PATIENT.PATIENT_CURRENT_SEX AS PAT_CURR_GENDER, D_PATIENT.PATIENT_DOB AS PAT_DOB, D_PATIENT.PATIENT_FIRST_NAME AS PAT_FIRST_NM, D_PATIENT.PATIENT_LAST_NAME AS PAT_LAST_NM, SUBSTRING(LTRIM(RTRIM(D_PATIENT.PATIENT_LOCAL_ID)), 1, 25) AS PAT_LOCAL_ID, ---added 9/9/2021
-       D_PATIENT.PATIENT_MIDDLE_NAME AS PAT_MIDDLE_NM, D_PATIENT.PATIENT_RACE_CALCULATED AS PAT_RACE, D_PATIENT.PATIENT_STATE AS PAT_STATE, D_PATIENT.PATIENT_STREET_ADDRESS_1 AS PAT_STREET_ADDR_1, D_PATIENT.PATIENT_STREET_ADDRESS_2 AS PAT_STREET_ADDR_2, SUBSTRING(LTRIM(RTRIM(D_PATIENT.PATIENT_ZIP)), 1, 10) AS PAT_ZIP_CODE, ---added 9/9/2021
-       D_PATIENT.PATIENT_ENTRY_METHOD AS PAT_ELECTRONIC_IND, D_PATIENT.PATIENT_ADD_TIME AS INV_ADD_TIME
-INTO #TMP_D_Patient
-----FROM F_PAGE_CASE
-FROM #TMP_F_PAGE_CASE AS F_PAGE_CASE---(my table)
-         INNER JOIN
-     #TMP_CONDITION AS T
-     ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY---(my table)
-         INNER JOIN
-     dbo.D_PATIENT WITH(NOLOCK)
-ON D_PATIENT.PATIENT_KEY = F_PAGE_CASE.PATIENT_KEY
-ORDER BY INVESTIGATION_KEY;
+        SELECT F_PAGE_CASE.INVESTIGATION_KEY AS Patient_INV_KEY, D_PATIENT.PATIENT_UID, D_PATIENT.PATIENT_ETHNICITY AS PAT_ETHNICITY, D_PATIENT.PATIENT_AGE_REPORTED AS PAT_REPORTED_AGE, D_PATIENT.PATIENT_AGE_REPORTED_UNIT AS PAT_REPORTED_AGE_UNIT, D_PATIENT.PATIENT_CITY AS PAT_CITY, D_PATIENT.PATIENT_COUNTRY AS PAT_COUNTRY, D_PATIENT.PATIENT_BIRTH_COUNTRY AS PAT_BIRTH_COUNTRY, D_PATIENT.PATIENT_COUNTY AS PAT_COUNTY, D_PATIENT.PATIENT_CURRENT_SEX AS PAT_CURR_GENDER, D_PATIENT.PATIENT_DOB AS PAT_DOB, D_PATIENT.PATIENT_FIRST_NAME AS PAT_FIRST_NM, D_PATIENT.PATIENT_LAST_NAME AS PAT_LAST_NM, SUBSTRING(LTRIM(RTRIM(D_PATIENT.PATIENT_LOCAL_ID)), 1, 25) AS PAT_LOCAL_ID, ---added 9/9/2021
+               D_PATIENT.PATIENT_MIDDLE_NAME AS PAT_MIDDLE_NM, D_PATIENT.PATIENT_RACE_CALCULATED AS PAT_RACE, D_PATIENT.PATIENT_STATE AS PAT_STATE, D_PATIENT.PATIENT_STREET_ADDRESS_1 AS PAT_STREET_ADDR_1, D_PATIENT.PATIENT_STREET_ADDRESS_2 AS PAT_STREET_ADDR_2, SUBSTRING(LTRIM(RTRIM(D_PATIENT.PATIENT_ZIP)), 1, 10) AS PAT_ZIP_CODE, ---added 9/9/2021
+               D_PATIENT.PATIENT_ENTRY_METHOD AS PAT_ELECTRONIC_IND, D_PATIENT.PATIENT_ADD_TIME AS INV_ADD_TIME
+        INTO #TMP_D_Patient
+        ----FROM F_PAGE_CASE
+        FROM #TMP_F_PAGE_CASE AS F_PAGE_CASE---(my table)
+                 INNER JOIN
+             #TMP_CONDITION AS T
+             ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY---(my table)
+                 INNER JOIN
+             dbo.D_PATIENT WITH(NOLOCK)
+             ON D_PATIENT.PATIENT_KEY = F_PAGE_CASE.PATIENT_KEY
+        ORDER BY INVESTIGATION_KEY;
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 ---------------------------------------------------22. CREATE TABLE TMP_INVESTIGATION---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_Investigation';
+        SET @Proc_Step_name = 'Generating  #TMP_Investigation';
 
-			SET @Proc_Step_no = 22;
+        SET @Proc_Step_no = 22;
 
-			IF OBJECT_ID('#TMP_Investigation', 'U') IS NOT NULL
-BEGIN
-DROP TABLE TMP_Investigation;
+        IF OBJECT_ID('#TMP_Investigation', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE TMP_Investigation;
 
-END;
+            END;
 
-SELECT PAGE_CASE.INVESTIGATION_KEY, INVESTIGATION.CASE_UID, T.CONDITION_CD AS CONDITION_CD, INVESTIGATION.CASE_OID AS PROGRAM_JURISDICTION_OID, CAST([CASE_RPT_MMWR_WK] AS varchar(100)) AS CASE_RPT_MMWR_WEEK, CAST([CASE_RPT_MMWR_YR] AS varchar(100)) AS CASE_RPT_MMWR_YEAR, INVESTIGATION.DIAGNOSIS_DT AS DIAGNOSIS_DT, INVESTIGATION.DIE_FRM_THIS_ILLNESS_IND AS DIE_FRM_THIS_ILLNESS_IND, INVESTIGATION.DISEASE_IMPORTED_IND AS DISEASE_IMPORTED_IND, INVESTIGATION.EARLIEST_RPT_TO_CNTY_DT AS EARLIEST_RPT_TO_CNTY, INVESTIGATION.EARLIEST_RPT_TO_STATE_DT AS EARLIEST_RPT_TO_STATE_DT,
-       INVESTIGATION.HSPTL_ADMISSION_DT AS HSPTL_ADMISSION_DT, INVESTIGATION.HSPTL_DISCHARGE_DT AS HSPTL_DISCHARGE_DT,
-       INVESTIGATION.HSPTL_DURATION_DAYS AS HSPTL_DURATION_DAYS, INVESTIGATION.HSPTLIZD_IND AS HSPTLIZD_IND, INVESTIGATION.ILLNESS_ONSET_DT AS ILLNESS_ONSET_DT, INVESTIGATION.IMPORT_FRM_CITY AS IMPORT_FROM_CITY, INVESTIGATION.IMPORT_FRM_CNTRY AS IMPORT_FROM_COUNTRY, INVESTIGATION.IMPORT_FRM_CNTY AS IMPORT_FROM_COUNTY, INVESTIGATION.IMPORT_FRM_STATE AS IMPORT_FROM_STATE, INVESTIGATION.INV_CASE_STATUS AS INV_CASE_STATUS, LTRIM(RTRIM(INVESTIGATION.INV_COMMENTS)) AS INV_COMMENTS, ---added 7/21/2021
-       INVESTIGATION.INV_LOCAL_ID AS INV_LOCAL_ID, INVESTIGATION.INV_RPT_DT AS INV_RPT_DT, INVESTIGATION.INV_START_DT AS INV_START_DT,
-       ----	INVESTIGATION.INVESTIGATION_KEY	AS 	INVESTIGATION_KEY,
-       INVESTIGATION.INVESTIGATION_STATUS AS INVESTIGATION_STATUS, INVESTIGATION.JURISDICTION_NM AS JURISDICTION_NM, INVESTIGATION.OUTBREAK_IND AS OUTBREAK_IND, INVESTIGATION.PATIENT_PREGNANT_IND AS PAT_PREGNANT_IND, INVESTIGATION.RPT_SRC_CD_DESC AS RPT_SRC_CD_DESC, INVESTIGATION.TRANSMISSION_MODE AS TRANSMISSION_MODE, SUBSTRING(LTRIM(RTRIM(INVESTIGATION.LEGACY_CASE_ID)), 1, 15) AS LEGACY_CASE_ID, ----added on 9/8/2021
-       DATE_MM_DD_YYYY AS NOT_SUBMIT_DT
-INTO #TMP_Investigation
-FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)---(original table)
-				 INNER JOIN  #TMP_F_PAGE_CASE AS F_PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY--(myTable)
-    INNER JOIN	 #TMP_CONDITION AS T		 ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY---(my table)
-    INNER JOIN	 dbo.D_PATIENT WITH(NOLOCK)	 ON F_PAGE_CASE.patient_key = D_PATIENT.patient_key
-    INNER JOIN	 dbo.INVESTIGATION WITH(NOLOCK)	 ON F_PAGE_CASE.INVESTIGATION_KEY = INVESTIGATION.INVESTIGATION_KEY
-    LEFT OUTER JOIN	 dbo.NOTIFICATION_EVENT WITH(NOLOCK) 	 ON NOTIFICATION_EVENT.PATIENT_KEY = F_PAGE_CASE.PATIENT_KEY
-    LEFT OUTER JOIN	 dbo.RDB_DATE WITH(NOLOCK)		 ON NOTIFICATION_EVENT.NOTIFICATION_SUBMIT_DT_KEY = DATE_KEY
-ORDER BY PAGE_CASE.INVESTIGATION_key;
+        SELECT PAGE_CASE.INVESTIGATION_KEY, INVESTIGATION.CASE_UID, T.CONDITION_CD AS CONDITION_CD, INVESTIGATION.CASE_OID AS PROGRAM_JURISDICTION_OID, CAST([CASE_RPT_MMWR_WK] AS varchar(100)) AS CASE_RPT_MMWR_WEEK, CAST([CASE_RPT_MMWR_YR] AS varchar(100)) AS CASE_RPT_MMWR_YEAR, INVESTIGATION.DIAGNOSIS_DT AS DIAGNOSIS_DT, INVESTIGATION.DIE_FRM_THIS_ILLNESS_IND AS DIE_FRM_THIS_ILLNESS_IND, INVESTIGATION.DISEASE_IMPORTED_IND AS DISEASE_IMPORTED_IND, INVESTIGATION.EARLIEST_RPT_TO_CNTY_DT AS EARLIEST_RPT_TO_CNTY, INVESTIGATION.EARLIEST_RPT_TO_STATE_DT AS EARLIEST_RPT_TO_STATE_DT,
+               INVESTIGATION.HSPTL_ADMISSION_DT AS HSPTL_ADMISSION_DT, INVESTIGATION.HSPTL_DISCHARGE_DT AS HSPTL_DISCHARGE_DT,
+               INVESTIGATION.HSPTL_DURATION_DAYS AS HSPTL_DURATION_DAYS, INVESTIGATION.HSPTLIZD_IND AS HSPTLIZD_IND, INVESTIGATION.ILLNESS_ONSET_DT AS ILLNESS_ONSET_DT, INVESTIGATION.IMPORT_FRM_CITY AS IMPORT_FROM_CITY, INVESTIGATION.IMPORT_FRM_CNTRY AS IMPORT_FROM_COUNTRY, INVESTIGATION.IMPORT_FRM_CNTY AS IMPORT_FROM_COUNTY, INVESTIGATION.IMPORT_FRM_STATE AS IMPORT_FROM_STATE, INVESTIGATION.INV_CASE_STATUS AS INV_CASE_STATUS, LTRIM(RTRIM(INVESTIGATION.INV_COMMENTS)) AS INV_COMMENTS, ---added 7/21/2021
+               INVESTIGATION.INV_LOCAL_ID AS INV_LOCAL_ID, INVESTIGATION.INV_RPT_DT AS INV_RPT_DT, INVESTIGATION.INV_START_DT AS INV_START_DT,
+               ----	INVESTIGATION.INVESTIGATION_KEY	AS 	INVESTIGATION_KEY,
+               INVESTIGATION.INVESTIGATION_STATUS AS INVESTIGATION_STATUS, INVESTIGATION.JURISDICTION_NM AS JURISDICTION_NM, INVESTIGATION.OUTBREAK_IND AS OUTBREAK_IND, INVESTIGATION.PATIENT_PREGNANT_IND AS PAT_PREGNANT_IND, INVESTIGATION.RPT_SRC_CD_DESC AS RPT_SRC_CD_DESC, INVESTIGATION.TRANSMISSION_MODE AS TRANSMISSION_MODE, SUBSTRING(LTRIM(RTRIM(INVESTIGATION.LEGACY_CASE_ID)), 1, 15) AS LEGACY_CASE_ID, ----added on 9/8/2021
+               DATE_MM_DD_YYYY AS NOT_SUBMIT_DT
+        INTO #TMP_Investigation
+        FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)---(original table)
+                 INNER JOIN  #TMP_F_PAGE_CASE AS F_PAGE_CASE  ON F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY--(myTable)
+                 INNER JOIN	 #TMP_CONDITION AS T		 ON F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY---(my table)
+                 INNER JOIN	 dbo.D_PATIENT WITH(NOLOCK)	 ON F_PAGE_CASE.patient_key = D_PATIENT.patient_key
+                 INNER JOIN	 dbo.INVESTIGATION WITH(NOLOCK)	 ON F_PAGE_CASE.INVESTIGATION_KEY = INVESTIGATION.INVESTIGATION_KEY
+                 LEFT OUTER JOIN	 dbo.NOTIFICATION_EVENT WITH(NOLOCK) 	 ON NOTIFICATION_EVENT.PATIENT_KEY = F_PAGE_CASE.PATIENT_KEY
+                 LEFT OUTER JOIN	 dbo.RDB_DATE WITH(NOLOCK)		 ON NOTIFICATION_EVENT.NOTIFICATION_SUBMIT_DT_KEY = DATE_KEY
+        ORDER BY PAGE_CASE.INVESTIGATION_key;
 
 
-/*
-																							CASE_RPT_MMWR_WEEK= INPUT(CASE_RPT_MMWR_WK, comma20.);
+        /*
+                                                                                                    CASE_RPT_MMWR_WEEK= INPUT(CASE_RPT_MMWR_WK, comma20.);
 
-																							CASE_RPT_MMWR_YEAR= INPUT(CASE_RPT_MMWR_YR, comma20.);
+                                                                                                    CASE_RPT_MMWR_YEAR= INPUT(CASE_RPT_MMWR_YR, comma20.);
 
-*/
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        */
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 ---------------------------------------------------23. CREATE TABLE TMP_HEP_PAT_PROV ---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_HEP_PAT_PROV';
+        SET @Proc_Step_name = 'Generating  #TMP_HEP_PAT_PROV';
 
-			SET @Proc_Step_no = 23;
+        SET @Proc_Step_no = 23;
 
-			IF OBJECT_ID('#TMP_HEP_PAT_PROV', 'U') IS NOT NULL
-BEGIN
-DROP TABLE TMP_HEP_PAT_PROV;
+        IF OBJECT_ID('#TMP_HEP_PAT_PROV', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE TMP_HEP_PAT_PROV;
 
-END;
+            END;
 
-SELECT DISTINCT
-    TMP_F_PAGE_CASE.INVESTIGATION_KEY AS HEP_PAT_PROV_INV_KEY, P.PROVIDER_LOCAL_ID, P.PROVIDER_FIRST_NAME AS PHYSICIAN_FIRST_NM, P.PROVIDER_MIDDLE_NAME AS PHYSICIAN_MIDDLE_NM, P.PROVIDER_LAST_NAME AS PHYSICIAN_LAST_NM, CAST(NULL AS varchar(300)) AS PHYS_NAME, P.PROVIDER_CITY AS PHYS_CITY, P.PROVIDER_STATE AS PHYS_STATE, P.PROVIDER_COUNTY AS PHYS_COUNTY, CAST(NULL AS varchar(300)) AS PHYSICIAN_ADDRESS_USE_DESC, CAST(NULL AS varchar(300)) AS PHYSICIAN_ADDRESS_TYPE_DESC, P.PROVIDER_ADD_TIME, P.PROVIDER_LAST_CHANGE_TIME, P.PROVIDER_UID AS PHYSICIAN_UID, INVGTR.PROVIDER_FIRST_NAME AS INVESTIGATOR_FIRST_NM, INVGTR.PROVIDER_MIDDLE_NAME AS INVESTIGATOR_MIDDLE_NM, INVGTR.PROVIDER_LAST_NAME AS INVESTIGATOR_LAST_NM, CAST(NULL AS varchar(300)) AS INVESTIGATOR_NAME, INVGTR.PROVIDER_UID AS INVESTIGATOR_UID, REPTORG.ORGANIZATION_NAME AS RPT_SRC_SOURCE_NM, REPTORG.ORGANIZATION_COUNTY_CODE AS RPT_SRC_COUNTY_CD, REPTORG.ORGANIZATION_COUNTY AS RPT_SRC_COUNTY, REPTORG.ORGANIZATION_CITY AS RPT_SRC_CITY, REPTORG.ORGANIZATION_STATE AS RPT_SRC_STATE, CAST(NULL AS varchar(300)) AS REPORTING_SOURCE_ADDRESS_USE, CAST(NULL AS varchar(300)) AS REPORTING_SOURCE_ADDRESS_TYPE, REPTORG.ORGANIZATION_UID AS REPORTING_SOURCE_UID
-INTO #TMP_HEP_PAT_PROV
-FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE TMP_F_PAGE_CASE
-ON TMP_F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY------ (My table)
-    INNER JOIN
-    #TMP_CONDITION AS T
-    ON TMP_F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY------ (My table)
-    LEFT OUTER JOIN
-    dbo.D_PROVIDER AS P WITH(NOLOCK)
-ON PAGE_CASE.PHYSICIAN_KEY = P.PROVIDER_KEY
-    LEFT OUTER JOIN
-    dbo.D_PROVIDER AS INVGTR WITH(NOLOCK)
-ON PAGE_CASE.INVESTIGATOR_KEY = INVGTR.PROVIDER_KEY
-    LEFT OUTER JOIN
-    dbo.D_ORGANIZATION AS REPTORG WITH(NOLOCK)
-ON PAGE_CASE.ORG_AS_REPORTER_KEY = REPTORG.ORGANIZATION_KEY
-ORDER BY HEP_PAT_PROV_INV_KEY;
+        SELECT DISTINCT
+            TMP_F_PAGE_CASE.INVESTIGATION_KEY AS HEP_PAT_PROV_INV_KEY, P.PROVIDER_LOCAL_ID, P.PROVIDER_FIRST_NAME AS PHYSICIAN_FIRST_NM, P.PROVIDER_MIDDLE_NAME AS PHYSICIAN_MIDDLE_NM, P.PROVIDER_LAST_NAME AS PHYSICIAN_LAST_NM, CAST(NULL AS varchar(300)) AS PHYS_NAME, P.PROVIDER_CITY AS PHYS_CITY, P.PROVIDER_STATE AS PHYS_STATE, P.PROVIDER_COUNTY AS PHYS_COUNTY, CAST(NULL AS varchar(300)) AS PHYSICIAN_ADDRESS_USE_DESC, CAST(NULL AS varchar(300)) AS PHYSICIAN_ADDRESS_TYPE_DESC, P.PROVIDER_ADD_TIME, P.PROVIDER_LAST_CHANGE_TIME, P.PROVIDER_UID AS PHYSICIAN_UID, INVGTR.PROVIDER_FIRST_NAME AS INVESTIGATOR_FIRST_NM, INVGTR.PROVIDER_MIDDLE_NAME AS INVESTIGATOR_MIDDLE_NM, INVGTR.PROVIDER_LAST_NAME AS INVESTIGATOR_LAST_NM, CAST(NULL AS varchar(300)) AS INVESTIGATOR_NAME, INVGTR.PROVIDER_UID AS INVESTIGATOR_UID, REPTORG.ORGANIZATION_NAME AS RPT_SRC_SOURCE_NM, REPTORG.ORGANIZATION_COUNTY_CODE AS RPT_SRC_COUNTY_CD, REPTORG.ORGANIZATION_COUNTY AS RPT_SRC_COUNTY, REPTORG.ORGANIZATION_CITY AS RPT_SRC_CITY, REPTORG.ORGANIZATION_STATE AS RPT_SRC_STATE, CAST(NULL AS varchar(300)) AS REPORTING_SOURCE_ADDRESS_USE, CAST(NULL AS varchar(300)) AS REPORTING_SOURCE_ADDRESS_TYPE, REPTORG.ORGANIZATION_UID AS REPORTING_SOURCE_UID
+        INTO #TMP_HEP_PAT_PROV
+        FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE TMP_F_PAGE_CASE
+             ON TMP_F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY------ (My table)
+                 INNER JOIN
+             #TMP_CONDITION AS T
+             ON TMP_F_PAGE_CASE.CONDITION_KEY = T.CONDITION_KEY------ (My table)
+                 LEFT OUTER JOIN
+             dbo.D_PROVIDER AS P WITH(NOLOCK)
+             ON PAGE_CASE.PHYSICIAN_KEY = P.PROVIDER_KEY
+                 LEFT OUTER JOIN
+             dbo.D_PROVIDER AS INVGTR WITH(NOLOCK)
+             ON PAGE_CASE.INVESTIGATOR_KEY = INVGTR.PROVIDER_KEY
+                 LEFT OUTER JOIN
+             dbo.D_ORGANIZATION AS REPTORG WITH(NOLOCK)
+             ON PAGE_CASE.ORG_AS_REPORTER_KEY = REPTORG.ORGANIZATION_KEY
+        ORDER BY HEP_PAT_PROV_INV_KEY;
 
-UPDATE #TMP_HEP_PAT_PROV
-SET PHYS_NAME = RTRIM(LTRIM(PHYSICIAN_first_nm));
+        UPDATE #TMP_HEP_PAT_PROV
+        SET PHYS_NAME = RTRIM(LTRIM(PHYSICIAN_first_nm));
 
-UPDATE #TMP_HEP_PAT_PROV
-SET PHYS_NAME = CASE
-    WHEN PHYS_NAME IS NOT NULL THEN CONCAT(PHYSICIAN_Last_nm, ', ', RTRIM(LTRIM(PHYSICIAN_first_nm)), ' ', PHYSICIAN_middle_nm)
-    ELSE PHYS_NAME
-    END;
+        UPDATE #TMP_HEP_PAT_PROV
+        SET PHYS_NAME = CASE
+            WHEN PHYS_NAME IS NOT NULL THEN CONCAT(PHYSICIAN_Last_nm, ', ', RTRIM(LTRIM(PHYSICIAN_first_nm)), ' ', PHYSICIAN_middle_nm)
+            ELSE PHYS_NAME
+            END;
 
-UPDATE #TMP_HEP_PAT_PROV
-SET PHYS_NAME = CASE
-    WHEN LEN(PHYSICIAN_middle_nm) > 0 THEN PHYS_NAME
-    ELSE RTRIM(LTRIM(PHYS_NAME))
-    END;
+        UPDATE #TMP_HEP_PAT_PROV
+        SET PHYS_NAME = CASE
+            WHEN LEN(PHYSICIAN_middle_nm) > 0 THEN PHYS_NAME
+            ELSE RTRIM(LTRIM(PHYS_NAME))
+            END;
 
-----5-17-2021
-UPDATE #TMP_HEP_PAT_PROV
-SET INVESTIGATOR_NAME = RTRIM(LTRIM(INVESTIGATOR_FIRST_NM));
+        ----5-17-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        SET INVESTIGATOR_NAME = RTRIM(LTRIM(INVESTIGATOR_FIRST_NM));
 
-UPDATE #TMP_HEP_PAT_PROV
-SET INVESTIGATOR_NAME = CASE
-    WHEN INVESTIGATOR_NAME IS NOT NULL THEN CONCAT(INVESTIGATOR_Last_nm, ', ', RTRIM(LTRIM(INVESTIGATOR_FIRST_NM)), ' ', INVESTIGATOR_MIDDLE_NM)
-    ELSE INVESTIGATOR_NAME
-    END;
+        UPDATE #TMP_HEP_PAT_PROV
+        SET INVESTIGATOR_NAME = CASE
+            WHEN INVESTIGATOR_NAME IS NOT NULL THEN CONCAT(INVESTIGATOR_Last_nm, ', ', RTRIM(LTRIM(INVESTIGATOR_FIRST_NM)), ' ', INVESTIGATOR_MIDDLE_NM)
+            ELSE INVESTIGATOR_NAME
+            END;
 
-UPDATE #TMP_HEP_PAT_PROV
-SET INVESTIGATOR_NAME = CASE
-    WHEN LEN(INVESTIGATOR_middle_nm) > 0 THEN INVESTIGATOR_NAME
-    ELSE RTRIM(LTRIM(INVESTIGATOR_NAME))
-    END;
+        UPDATE #TMP_HEP_PAT_PROV
+        SET INVESTIGATOR_NAME = CASE
+            WHEN LEN(INVESTIGATOR_middle_nm) > 0 THEN INVESTIGATOR_NAME
+            ELSE RTRIM(LTRIM(INVESTIGATOR_NAME))
+            END;
 
-----5-21-2021
-UPDATE #TMP_HEP_PAT_PROV
---SET PHYSICIAN_ADDRESS_USE_DESC =concat_ws(' ',RTRIM(LTRIM(PHYS_CITY)),RTRIM(LTRIM(PHYS_STATE)),RTRIM(LTRIM(PHYS_COUNTY)))
-SET PHYSICIAN_ADDRESS_USE_DESC = concat(RTRIM(LTRIM(ISNULL(PHYS_CITY, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_COUNTY, ''))));
+        ----5-21-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        --SET PHYSICIAN_ADDRESS_USE_DESC =concat_ws(' ',RTRIM(LTRIM(PHYS_CITY)),RTRIM(LTRIM(PHYS_STATE)),RTRIM(LTRIM(PHYS_COUNTY)))
+        SET PHYSICIAN_ADDRESS_USE_DESC = concat(RTRIM(LTRIM(ISNULL(PHYS_CITY, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_COUNTY, ''))));
 
----8-31-2021
-UPDATE #TMP_HEP_PAT_PROV
-SET PHYSICIAN_ADDRESS_USE_DESC = CASE
-    WHEN LEN(PHYSICIAN_ADDRESS_USE_DESC) > 0 THEN 'Primary Work Place'
-    ELSE NULL
-    END;
+        ---8-31-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        SET PHYSICIAN_ADDRESS_USE_DESC = CASE
+            WHEN LEN(PHYSICIAN_ADDRESS_USE_DESC) > 0 THEN 'Primary Work Place'
+            ELSE NULL
+            END;
 
-UPDATE #TMP_HEP_PAT_PROV
---SET PHYSICIAN_ADDRESS_TYPE_DESC =concat_ws(' ',RTRIM(LTRIM(RPT_SRC_COUNTY)),RTRIM(LTRIM(RPT_SRC_STATE)),RTRIM(LTRIM(RPT_SRC_CITY)))
-SET PHYSICIAN_ADDRESS_TYPE_DESC = concat(RTRIM(LTRIM(ISNULL(RPT_SRC_COUNTY, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_CITY, ''))));
+        UPDATE #TMP_HEP_PAT_PROV
+        --SET PHYSICIAN_ADDRESS_TYPE_DESC =concat_ws(' ',RTRIM(LTRIM(RPT_SRC_COUNTY)),RTRIM(LTRIM(RPT_SRC_STATE)),RTRIM(LTRIM(RPT_SRC_CITY)))
+        SET PHYSICIAN_ADDRESS_TYPE_DESC = concat(RTRIM(LTRIM(ISNULL(RPT_SRC_COUNTY, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_CITY, ''))));
 
----8-31-2021
-UPDATE #TMP_HEP_PAT_PROV
-SET PHYSICIAN_ADDRESS_TYPE_DESC = CASE
-    WHEN LEN(PHYSICIAN_ADDRESS_TYPE_DESC) > 0 THEN 'Office'
-    ELSE NULL
-    END;
+        ---8-31-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        SET PHYSICIAN_ADDRESS_TYPE_DESC = CASE
+            WHEN LEN(PHYSICIAN_ADDRESS_TYPE_DESC) > 0 THEN 'Office'
+            ELSE NULL
+            END;
 
-UPDATE #TMP_HEP_PAT_PROV
----SET REPORTING_SOURCE_ADDRESS_USE =concat_ws(' ',RTRIM(LTRIM(PHYS_CITY)),RTRIM(LTRIM(PHYS_STATE)),RTRIM(LTRIM(PHYS_COUNTY)))
-SET REPORTING_SOURCE_ADDRESS_USE = concat(RTRIM(LTRIM(ISNULL(PHYS_CITY, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_COUNTY, ''))));
+        UPDATE #TMP_HEP_PAT_PROV
+        ---SET REPORTING_SOURCE_ADDRESS_USE =concat_ws(' ',RTRIM(LTRIM(PHYS_CITY)),RTRIM(LTRIM(PHYS_STATE)),RTRIM(LTRIM(PHYS_COUNTY)))
+        SET REPORTING_SOURCE_ADDRESS_USE = concat(RTRIM(LTRIM(ISNULL(PHYS_CITY, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(PHYS_COUNTY, ''))));
 
----8-31-2021
-UPDATE #TMP_HEP_PAT_PROV
-SET REPORTING_SOURCE_ADDRESS_USE = CASE
-    WHEN LEN(REPORTING_SOURCE_ADDRESS_USE) > 0 THEN 'Primary Work Place'
-    ELSE NULL
-    END;
+        ---8-31-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        SET REPORTING_SOURCE_ADDRESS_USE = CASE
+            WHEN LEN(REPORTING_SOURCE_ADDRESS_USE) > 0 THEN 'Primary Work Place'
+            ELSE NULL
+            END;
 
-UPDATE #TMP_HEP_PAT_PROV
----SET REPORTING_SOURCE_ADDRESS_TYPE =concat_ws(' ',RTRIM(LTRIM(RPT_SRC_COUNTY)),RTRIM(LTRIM(RPT_SRC_STATE)),RTRIM(LTRIM(RPT_SRC_CITY)))
-SET REPORTING_SOURCE_ADDRESS_TYPE = concat(RTRIM(LTRIM(ISNULL(RPT_SRC_COUNTY, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_CITY, ''))));
+        UPDATE #TMP_HEP_PAT_PROV
+        ---SET REPORTING_SOURCE_ADDRESS_TYPE =concat_ws(' ',RTRIM(LTRIM(RPT_SRC_COUNTY)),RTRIM(LTRIM(RPT_SRC_STATE)),RTRIM(LTRIM(RPT_SRC_CITY)))
+        SET REPORTING_SOURCE_ADDRESS_TYPE = concat(RTRIM(LTRIM(ISNULL(RPT_SRC_COUNTY, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_STATE, ''))), ' ', RTRIM(LTRIM(ISNULL(RPT_SRC_CITY, ''))));
 
----8-31-2021
-UPDATE #TMP_HEP_PAT_PROV
-SET REPORTING_SOURCE_ADDRESS_TYPE = CASE
-    WHEN LEN(REPORTING_SOURCE_ADDRESS_TYPE) > 0 THEN 'office'
-    ELSE NULL
-    END;
+        ---8-31-2021
+        UPDATE #TMP_HEP_PAT_PROV
+        SET REPORTING_SOURCE_ADDRESS_TYPE = CASE
+            WHEN LEN(REPORTING_SOURCE_ADDRESS_TYPE) > 0 THEN 'office'
+            ELSE NULL
+            END;
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 -------------------------------------------------24. CREATE TABLE TMP_D_INVESTIGATION_REPEAT ---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating  #TMP_D_INVESTIGATION_REPEAT';
+        SET @Proc_Step_name = 'Generating  #TMP_D_INVESTIGATION_REPEAT';
 
-------is same as dataset- D_INVESTIGATION_REPEAT
-			SET @Proc_Step_no = 24;
+        ------is same as dataset- D_INVESTIGATION_REPEAT
+        SET @Proc_Step_no = 24;
 
-			IF OBJECT_ID('#TMP_F_INVESTIGATION_REPEAT', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_F_INVESTIGATION_REPEAT;
+        IF OBJECT_ID('#TMP_F_INVESTIGATION_REPEAT', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_F_INVESTIGATION_REPEAT;
 
-END;
+            END;
 
-			IF OBJECT_ID('#TMP_D_INVESTIGATION_REPEAT', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_D_INVESTIGATION_REPEAT;
+        IF OBJECT_ID('#TMP_D_INVESTIGATION_REPEAT', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_D_INVESTIGATION_REPEAT;
 
-END;
+            END;
 
-SELECT PAGE_CASE.D_INVESTIGATION_REPEAT_KEY, PAGE_CASE.INVESTIGATION_KEY, TMP_F_PAGE_CASE.CONDITION_KEY
-INTO #TMP_F_INVESTIGATION_REPEAT
-FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_F_PAGE_CASE AS TMP_F_PAGE_CASE
-ON TMP_F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY   ----(my table) since in sas it is dbo
-ORDER BY D_INVESTIGATION_REPEAT_KEY;
+        SELECT PAGE_CASE.D_INVESTIGATION_REPEAT_KEY, PAGE_CASE.INVESTIGATION_KEY, TMP_F_PAGE_CASE.CONDITION_KEY
+        INTO #TMP_F_INVESTIGATION_REPEAT
+        FROM dbo.F_PAGE_CASE AS PAGE_CASE WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_F_PAGE_CASE AS TMP_F_PAGE_CASE
+             ON TMP_F_PAGE_CASE.INVESTIGATION_KEY = PAGE_CASE.INVESTIGATION_KEY   ----(my table) since in sas it is dbo
+        ORDER BY D_INVESTIGATION_REPEAT_KEY;
 
-SELECT DISTINCT
-    F.D_INVESTIGATION_REPEAT_KEY D_INVESTIGATION_REPEAT_KEY1, F.INVESTIGATION_KEY, F.CONDITION_KEY,D.*,
-    CAST( NULL  AS varchar(1000)) AS VAC_VaccineDoseNum1 ,
-    Cast( null   as varchar(2000)) as VAC_VaccinationDate1 ,
-    PAGE_CASE_UID PAGE_CASE_UID1, BLOCK_NM BLOCK_NM1, ANSWER_GROUP_SEQ_NBR ANSWER_GROUP_SEQ_NBR1
-INTO #TMP_D_INVESTIGATION_REPEAT
-FROM #TMP_F_INVESTIGATION_REPEAT AS F
-         LEFT JOIN
-    [dbo].[D_INVESTIGATION_REPEAT] AS D WITH(NOLOCK)
-ON D.D_INVESTIGATION_REPEAT_KEY = F.D_INVESTIGATION_REPEAT_KEY
-ORDER BY F.INVESTIGATION_KEY;
+        SELECT inv_repeat.*
+        INTO #D_INV_REPEAT_TEMP_COLS
+        FROM (
+                 SELECT CAST( NULL  AS varchar(1000)) AS VAC_VaccineDoseNum ,
+                        CAST( NULL   AS varchar(2000)) AS VAC_VaccinationDate,
+                        CAST( NULL AS FLOAT) AS PAGE_CASE_UID,
+                        CAST( NULL AS VARCHAR(30)) AS BLOCK_NM,
+                        CAST( NULL AS BIGINT) AS ANSWER_GROUP_SEQ_NBR
+             ) AS temp_inv_repeat_columns
+                 CROSS APPLY
+             ( SELECT D_INVESTIGATION_REPEAT_KEY,
+                      VAC_VaccineDoseNum,
+                      VAC_VaccinationDate,
+                      PAGE_CASE_UID,
+                      BLOCK_NM,
+                      ANSWER_GROUP_SEQ_NBR
+               FROM dbo.D_INVESTIGATION_REPEAT
+             ) AS inv_repeat;
+
+        SELECT DISTINCT
+            F.D_INVESTIGATION_REPEAT_KEY D_INVESTIGATION_REPEAT_KEY1, F.INVESTIGATION_KEY, F.CONDITION_KEY, D.*,
+            RTRIM(LTRIM(VAC_VaccineDoseNum)) AS VAC_VaccineDoseNum1 ,
+            VAC_VaccinationDate as VAC_VaccinationDate1 ,
+            PAGE_CASE_UID PAGE_CASE_UID1, BLOCK_NM BLOCK_NM1, ANSWER_GROUP_SEQ_NBR ANSWER_GROUP_SEQ_NBR1
+        INTO #TMP_D_INVESTIGATION_REPEAT
+        FROM #TMP_F_INVESTIGATION_REPEAT AS F
+                 LEFT JOIN
+             #D_INV_REPEAT_TEMP_COLS AS D WITH(NOLOCK)
+             ON D.D_INVESTIGATION_REPEAT_KEY = F.D_INVESTIGATION_REPEAT_KEY
+        ORDER BY F.INVESTIGATION_KEY;
 
 
-IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_VaccineDoseNum'   AND Object_ID = Object_ID(N'#TMP_D_INVESTIGATION_REPEAT'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INVESTIGATION_REPEAT set VAC_VaccineDoseNum1 = RTRIM(LTRIM(VAC_VaccineDoseNum));'
-			    execute sp_executesql  @sql
-END;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-			IF EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'VAC_VaccinationDate'   AND Object_ID = Object_ID(N'#TMP_D_INVESTIGATION_REPEAT'))
-BEGIN
-			    SET @sql = N'update #TMP_D_INVESTIGATION_REPEAT set VAC_VaccinationDate1 = (VAC_VaccinationDate);'
-			    execute sp_executesql  @sql
-END;
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-
-
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 
 --------------------------------------------------25. CREATE TABLE TMP_METADATA_TEST---------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating #TMP_METADATA_TEST';
+        SET @Proc_Step_name = 'Generating #TMP_METADATA_TEST';
 
-			SET @Proc_Step_no = 25;
+        SET @Proc_Step_no = 25;
 
-			IF OBJECT_ID('#TMP_METADATA_TEST', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_METADATA_TEST;
+        IF OBJECT_ID('#TMP_METADATA_TEST', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_METADATA_TEST;
 
-END;
+            END;
 
-SELECT C.CONDITION_KEY, M.block_nm, M.investigation_form_cd
-INTO #TMP_METADATA_TEST
-FROM NBS_ODSE.dbo.NBS_UI_METADATA AS M WITH(NOLOCK)
-				 INNER JOIN
-				 #TMP_CONDITION AS C
-ON M.INVESTIGATION_FORM_CD = C.DISEASE_GRP_DESC ----(My table)
-WHERE M.question_identifier IN( 'VAC103', 'VAC120' ) AND
-    M.[block_nm] IS NOT NULL;
+        SELECT C.CONDITION_KEY, M.block_nm, M.investigation_form_cd
+        INTO #TMP_METADATA_TEST
+        FROM RDB_MODERN.dbo.nrt_page_case_answer AS M WITH(NOLOCK)
+                 INNER JOIN
+             #TMP_CONDITION AS C
+             ON M.INVESTIGATION_FORM_CD = C.DISEASE_GRP_DESC ----(My table)
+        WHERE M.question_identifier IN( 'VAC103', 'VAC120' ) AND
+            M.[block_nm] IS NOT NULL;
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-COMMIT TRANSACTION;
+        COMMIT TRANSACTION;
 
 
 --------------------------------------------------26a. CREATE TABLE TMP_VAC_REPEAT------------------------------------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating #TMP_VAC_REPEAT';
+        SET @Proc_Step_name = 'Generating #TMP_VAC_REPEAT';
 
-			SET @Proc_Step_no = 26;
-
------a
-			IF OBJECT_ID('#TMP_VAC_REPEAT', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT;
-
-END;
-
-SELECT DISTINCT
-    D.D_INVESTIGATION_REPEAT_KEY, D.INVESTIGATION_KEY,
-    VAC_VaccinationDate1 VAC_VaccinationDate ,
-    VAC_VaccineDoseNum1 VAC_VaccineDoseNum,
-    D.PAGE_CASE_UID, D.ANSWER_GROUP_SEQ_NBR AS SEQNBR, D.BLOCK_NM, CAST(NULL  AS varchar(1000)) AS VAC_GT_4_IND, -----Date Indicator
-    CAST(NULL AS varchar(1000)) AS VAC_DOSE_4_IND, ---Dose Indicator
-    CAST(NULL  AS varchar(1000)) AS VACC_GT_4_IND   ---------FinalIndicator
-INTO #TMP_VAC_REPEAT
-FROM #TMP_D_INVESTIGATION_REPEAT AS D
-         INNER JOIN	 #TMP_CONDITION AS C  ON C.CONDITION_KEY = D.CONDITION_KEY----My Table
-         INNER JOIN	 #TMP_METADATA_TEST AS M ON M.CONDITION_KEY = D.CONDITION_KEY
-WHERE M.block_nm = D.BLOCK_NM
-  AND   M.block_nm IN
-        (
-            SELECT DISTINCT
-                BLOCK_NM
-            FROM NBS_ODSE.dbo.NBS_UI_METADATA WITH(NOLOCK)
-WHERE QUESTION_IDENTIFIER IN( 'VAC103', 'VAC120' ) AND
-    BLOCK_NM IS NOT NULL
-    )
-ORDER BY PAGE_CASE_UID;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
+        SET @Proc_Step_no = 26;
 
 
----------------------------------------------------26b. CREATE TABLE TMP_VAC_REPEAT_OUT_DATE_Pivot---------------------------
-BEGIN TRANSACTION;
+        IF OBJECT_ID('#TMP_VAC_REPEAT', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT;
 
-			SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_DATE_Pivot';
+            END;
 
-			SET @Proc_Step_no = 26;
+        SELECT DISTINCT
+            D.D_INVESTIGATION_REPEAT_KEY, D.INVESTIGATION_KEY,
+            VAC_VaccinationDate1 VAC_VaccinationDate ,
+            VAC_VaccineDoseNum1 VAC_VaccineDoseNum,
+            D.PAGE_CASE_UID, D.ANSWER_GROUP_SEQ_NBR AS SEQNBR, D.BLOCK_NM, CAST(NULL  AS varchar(1000)) AS VAC_GT_4_IND, -----Date Indicator
+            CAST(NULL AS varchar(1000)) AS VAC_DOSE_4_IND, ---Dose Indicator
+            CAST(NULL  AS varchar(1000)) AS VACC_GT_4_IND   ---------FinalIndicator
+        INTO #TMP_VAC_REPEAT
+        FROM #TMP_D_INVESTIGATION_REPEAT AS D
+                 INNER JOIN	 #TMP_CONDITION AS C  ON C.CONDITION_KEY = D.CONDITION_KEY----My Table
+                 INNER JOIN	 #TMP_METADATA_TEST AS M ON M.CONDITION_KEY = D.CONDITION_KEY
+        WHERE M.block_nm = D.BLOCK_NM
+          AND   M.block_nm IN
+                (
+                    SELECT DISTINCT
+                        BLOCK_NM
+                    FROM RDB_MODERN.dbo.nrt_page_case_answer WITH(NOLOCK)
+                    WHERE QUESTION_IDENTIFIER IN( 'VAC103', 'VAC120' ) AND
+                        BLOCK_NM IS NOT NULL
+                )
+        ORDER BY PAGE_CASE_UID;
 
-----b
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE_Pivot', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_DATE_Pivot;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-END;
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_DATE;
-
-END;
-
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE_Final', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_DATE_Final;
-
-END;
-
-			DECLARE @cols AS nvarchar(max)= STUFF(
-			(
-				SELECT DISTINCT
-					   ',[' + CAST(NUM AS varchar) + ']'
-				FROM
-				(
-					SELECT ROW_NUMBER() OVER(
-					ORDER BY(SELECT NULL)) AS num
-					FROM Sys.Objects
-				) AS X
-				WHERE num <= 5 FOR XML PATH('')
-			), 1, 1, '');
-
-			PRINT @cols;
+        COMMIT TRANSACTION;
 
 
-CREATE TABLE #TMP_VAC_REPEAT_OUT_DATE_Pivot
-    (	D_INVESTIGATION_REPEAT_KEY BIGINT,
-         INVESTIGATION_KEY BIGINT,
-         Page_Case_UId BIGINT,
-         VACC_RECVD_DT_1 DATE,
-         VACC_RECVD_DT_2 DATE,
-         VACC_RECVD_DT_3 DATE,
-         VACC_RECVD_DT_4 DATE,
-         VACC_RECVD_DT_5 DATE
-    );
+        ---------------------------------------------------26b. CREATE TABLE TMP_VAC_REPEAT_OUT_DATE_Pivot---------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_DATE_Pivot';
+
+        SET @Proc_Step_no = 26;
+
+        ----b
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE_Pivot', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_DATE_Pivot;
+
+            END;
+
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_DATE;
+
+            END;
+
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_DATE_Final', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_DATE_Final;
+
+            END;
+
+        DECLARE @cols AS nvarchar(max)= STUFF(
+                (
+                    SELECT DISTINCT
+                        ',[' + CAST(NUM AS varchar) + ']'
+                    FROM
+                        (
+                            SELECT ROW_NUMBER() OVER(
+                                ORDER BY(SELECT NULL)) AS num
+                            FROM Sys.Objects
+                        ) AS X
+                    WHERE num <= 5 FOR XML PATH('')
+                ), 1, 1, '');
+
+        PRINT @cols;
 
 
-DECLARE @SqlCmd nvarchar(max)= '';
+        CREATE TABLE #TMP_VAC_REPEAT_OUT_DATE_Pivot
+            (	D_INVESTIGATION_REPEAT_KEY BIGINT,
+                 INVESTIGATION_KEY BIGINT,
+                 Page_Case_UId BIGINT,
+                 VACC_RECVD_DT_1 DATE,
+                 VACC_RECVD_DT_2 DATE,
+                 VACC_RECVD_DT_3 DATE,
+                 VACC_RECVD_DT_4 DATE,
+                 VACC_RECVD_DT_5 DATE
+            );
 
-			SET @SqlCmd = '
-																						SELECT
-																						 D_INVESTIGATION_REPEAT_KEY,INVESTIGATION_KEY,Page_Case_UId,
-																							[1] as VACC_RECVD_DT_1,
-																							[2] as VACC_RECVD_DT_2,
-																							[3] as VACC_RECVD_DT_3,
-																							[4] as VACC_RECVD_DT_4,
-																							[5] as VACC_RECVD_DT_5
 
-																						 Into #TMP_VAC_REPEAT_OUT_DATE_Pivot FROM
-																						(
-																						SELECT p.*
-																						 FROM
-																						 (
-																							SELECT D_INVESTIGATION_REPEAT_KEY,VAC_VaccinationDate,SEQNBR,INVESTIGATION_KEY, Page_Case_UId
-																							FROM #TMP_VAC_REPEAT
-																						 ) AS tbl
-																						 PIVOT
-																						 (
-																							MAX(VAC_VaccinationDate) FOR SEQNBR IN(' + @cols + ')
-																						 ) AS p)
-																						 as c
-																						 ';
+        DECLARE @SqlCmd nvarchar(max)= '';
 
-			PRINT @SqlCmd;
+        SET @SqlCmd = '
+																								SELECT
+																								 D_INVESTIGATION_REPEAT_KEY,INVESTIGATION_KEY,Page_Case_UId,
+																									[1] as VACC_RECVD_DT_1,
+																									[2] as VACC_RECVD_DT_2,
+																									[3] as VACC_RECVD_DT_3,
+																									[4] as VACC_RECVD_DT_4,
+																									[5] as VACC_RECVD_DT_5
 
-EXEC sp_executesql @SqlCmd;
+																								 Into #TMP_VAC_REPEAT_OUT_DATE_Pivot FROM
+																								(
+																								SELECT p.*
+																								 FROM
+																								 (
+																									SELECT D_INVESTIGATION_REPEAT_KEY,VAC_VaccinationDate,SEQNBR,INVESTIGATION_KEY, Page_Case_UId
+																									FROM #TMP_VAC_REPEAT
+																								 ) AS tbl
+																								 PIVOT
+																								 (
+																									MAX(VAC_VaccinationDate) FOR SEQNBR IN(' + @cols + ')
+																								 ) AS p)
+																								 as c
+																								 ';
 
-SELECT *, CAST(NULL  AS varchar(1000)) AS VAC_GT_4_IND      -----Date Indicator---change the length to 300 on 5-13-2021
-INTO #TMP_VAC_REPEAT_OUT_DATE
-FROM #TMP_VAC_REPEAT_OUT_DATE_Pivot
-WHERE LEN(VACC_RECVD_DT_1) > 0 OR
-    LEN(VACC_RECVD_DT_2) > 0 OR
-    LEN(VACC_RECVD_DT_3) > 0 OR
-    LEN(VACC_RECVD_DT_4) > 0 OR
-    LEN(VACC_RECVD_DT_5) > 0 AND
-    PAGE_CASE_UID > 0;
+        PRINT @SqlCmd;
 
-UPDATE #TMP_VAC_REPEAT_OUT_DATE
-SET VAC_GT_4_IND = CASE
-    WHEN VACC_RECVD_DT_5 IS NULL THEN NULL
-    ELSE 'True'
-    END;
+        EXEC sp_executesql @SqlCmd;
 
-SELECT DISTINCT
-    Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_RECVD_DT_1, VACC_RECVD_DT_2, VACC_RECVD_DT_3, VACC_RECVD_DT_4, VAC_GT_4_IND
-INTO #TMP_VAC_REPEAT_OUT_DATE_Final
-FROM #TMP_VAC_REPEAT_OUT_DATE
-ORDER BY D_INVESTIGATION_REPEAT_KEY;
+        SELECT *, CAST(NULL  AS varchar(1000)) AS VAC_GT_4_IND      -----Date Indicator---change the length to 300 on 5-13-2021
+        INTO #TMP_VAC_REPEAT_OUT_DATE
+        FROM #TMP_VAC_REPEAT_OUT_DATE_Pivot
+        WHERE LEN(VACC_RECVD_DT_1) > 0 OR
+            LEN(VACC_RECVD_DT_2) > 0 OR
+            LEN(VACC_RECVD_DT_3) > 0 OR
+            LEN(VACC_RECVD_DT_4) > 0 OR
+            LEN(VACC_RECVD_DT_5) > 0 AND
+            PAGE_CASE_UID > 0;
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        UPDATE #TMP_VAC_REPEAT_OUT_DATE
+        SET VAC_GT_4_IND = CASE
+            WHEN VACC_RECVD_DT_5 IS NULL THEN NULL
+            ELSE 'True'
+            END;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        if @debug = 'true' select * from #TMP_VAC_REPEAT_OUT_DATE;
 
-COMMIT TRANSACTION;
+        SELECT DISTINCT
+            Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_RECVD_DT_1, VACC_RECVD_DT_2, VACC_RECVD_DT_3, VACC_RECVD_DT_4, VAC_GT_4_IND
+        INTO #TMP_VAC_REPEAT_OUT_DATE_Final
+        FROM #TMP_VAC_REPEAT_OUT_DATE
+        ORDER BY D_INVESTIGATION_REPEAT_KEY;
 
----------------------------------------26c. CREATE TABLE TMP_VAC_REPEAT_OUT_NUM_Pivot-------------------------------------------------------------
-BEGIN TRANSACTION;
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-			SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_NUM_Pivot';
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
 
-			SET @Proc_Step_no = 26;
+        COMMIT TRANSACTION;
 
-----c
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM_Pivot', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_NUM_Pivot;
+        ---------------------------------------26c. CREATE TABLE TMP_VAC_REPEAT_OUT_NUM_Pivot-------------------------------------------------------------
+        BEGIN TRANSACTION;
 
-END;
+        SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_NUM_Pivot';
 
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_NUM;
+        SET @Proc_Step_no = 26;
 
-END;
+        ----c
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM_Pivot', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_NUM_Pivot;
 
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM_final', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_NUM_Final;
+            END;
 
-END;
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_NUM;
 
-			DECLARE @col AS nvarchar(max)= STUFF(
-			(
-				SELECT DISTINCT
-					   ',[' + CAST(NUM AS varchar) + ']'
-				FROM
-				(
-					SELECT ROW_NUMBER() OVER(
-					ORDER BY(SELECT NULL)) AS num
-					FROM Sys.Objects
-				) AS X
-				WHERE num <= 5 FOR XML PATH('')
-			), 1, 1, '');
+            END;
 
-			PRINT @col;
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_NUM_final', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_NUM_Final;
 
-CREATE TABLE #TMP_VAC_REPEAT_OUT_NUM_Pivot
-    (
-        D_INVESTIGATION_REPEAT_KEY BIGINT,
-        INVESTIGATION_KEY BIGINT,
-        Page_Case_UId BIGINT,
-        VACC_DOSE_NBR_1 BIGINT,
-        VACC_DOSE_NBR_2 BIGINT,
-        VACC_DOSE_NBR_3 BIGINT,
-        VACC_DOSE_NBR_4 BIGINT,
-        VACC_DOSE_NBR_5 BIGINT
-    );
+            END;
 
-DECLARE @SqlCmds nvarchar(max)= '';
+        DECLARE @col AS nvarchar(max)= STUFF(
+                (
+                    SELECT DISTINCT
+                        ',[' + CAST(NUM AS varchar) + ']'
+                    FROM
+                        (
+                            SELECT ROW_NUMBER() OVER(
+                                ORDER BY(SELECT NULL)) AS num
+                            FROM Sys.Objects
+                        ) AS X
+                    WHERE num <= 5 FOR XML PATH('')
+                ), 1, 1, '');
 
-			SET @SqlCmds = '
-																						SELECT
-																						 D_INVESTIGATION_REPEAT_KEY,INVESTIGATION_KEY,Page_Case_UId,
-																							[1] as VACC_DOSE_NBR_1,
-																							[2] as VACC_DOSE_NBR_2,
-																							[3] as VACC_DOSE_NBR_3,
-																							[4] as VACC_DOSE_NBR_4,
-																							[5] as VACC_DOSE_NBR_5
+        PRINT @col;
 
-																						 Into #TMP_VAC_REPEAT_OUT_NUM_Pivot FROM
-																						(
-																						SELECT p.*
-																						 FROM
-																						 (
-																							SELECT  D_INVESTIGATION_REPEAT_KEY,VAC_VaccineDoseNum,SEQNBR,INVESTIGATION_KEY, Page_Case_UId
-																							FROM #TMP_VAC_REPEAT
-																						 ) AS tbl
-																						 PIVOT
-																						 (
-																							MAX(VAC_VaccineDoseNum) FOR SEQNBR IN(' + @col + ')
-																						 ) AS p)
-																						 as c
-																						 ';
+        CREATE TABLE #TMP_VAC_REPEAT_OUT_NUM_Pivot
+            (
+                D_INVESTIGATION_REPEAT_KEY BIGINT,
+                INVESTIGATION_KEY BIGINT,
+                Page_Case_UId BIGINT,
+                VACC_DOSE_NBR_1 BIGINT,
+                VACC_DOSE_NBR_2 BIGINT,
+                VACC_DOSE_NBR_3 BIGINT,
+                VACC_DOSE_NBR_4 BIGINT,
+                VACC_DOSE_NBR_5 BIGINT
+            );
 
-			PRINT @SqlCmds;
+        DECLARE @SqlCmds nvarchar(max)= '';
 
-EXEC sp_executesql @SqlCmds;
+        SET @SqlCmds = '
+																								SELECT
+																								 D_INVESTIGATION_REPEAT_KEY,INVESTIGATION_KEY,Page_Case_UId,
+																									[1] as VACC_DOSE_NBR_1,
+																									[2] as VACC_DOSE_NBR_2,
+																									[3] as VACC_DOSE_NBR_3,
+																									[4] as VACC_DOSE_NBR_4,
+																									[5] as VACC_DOSE_NBR_5
 
-SELECT *, CAST(NULL AS [varchar](2000)) AS VAC_DOSE_4_IND     ---Dose Indicator
-INTO #TMP_VAC_REPEAT_OUT_NUM
-FROM #TMP_VAC_REPEAT_OUT_NUM_Pivot
-WHERE LEN(VACC_DOSE_NBR_1) > 0 OR
-    LEN(VACC_DOSE_NBR_2) > 0 OR
-    LEN(VACC_DOSE_NBR_3) > 0 OR
-    LEN(VACC_DOSE_NBR_4) > 0 OR
-    LEN(VACC_DOSE_NBR_5) > 0 AND
-    PAGE_CASE_UID > 0;
+																								 Into #TMP_VAC_REPEAT_OUT_NUM_Pivot FROM
+																								(
+																								SELECT p.*
+																								 FROM
+																								 (
+																									SELECT  D_INVESTIGATION_REPEAT_KEY,VAC_VaccineDoseNum,SEQNBR,INVESTIGATION_KEY, Page_Case_UId
+																									FROM #TMP_VAC_REPEAT
+																								 ) AS tbl
+																								 PIVOT
+																								 (
+																									MAX(VAC_VaccineDoseNum) FOR SEQNBR IN(' + @col + ')
+																								 ) AS p)
+																								 as c
+																								 ';
 
-UPDATE #TMP_VAC_REPEAT_OUT_NUM
-SET VAC_DOSE_4_IND = CASE
-    WHEN VACC_DOSE_NBR_5 IS NULL THEN NULL
-    ELSE 'True'
-    END;
+        PRINT @SqlCmds;
 
-SELECT DISTINCT
-    Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_DOSE_NBR_2, VACC_DOSE_NBR_3, VACC_DOSE_NBR_4, VAC_DOSE_4_IND
-INTO #TMP_VAC_REPEAT_OUT_NUM_Final
-FROM #TMP_VAC_REPEAT_OUT_NUM
-ORDER BY D_INVESTIGATION_REPEAT_KEY;
+        EXEC sp_executesql @SqlCmds;
 
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        SELECT *, CAST(NULL AS [varchar](2000)) AS VAC_DOSE_4_IND     ---Dose Indicator
+        INTO #TMP_VAC_REPEAT_OUT_NUM
+        FROM #TMP_VAC_REPEAT_OUT_NUM_Pivot
+        WHERE LEN(VACC_DOSE_NBR_1) > 0 OR
+            LEN(VACC_DOSE_NBR_2) > 0 OR
+            LEN(VACC_DOSE_NBR_3) > 0 OR
+            LEN(VACC_DOSE_NBR_4) > 0 OR
+            LEN(VACC_DOSE_NBR_5) > 0 AND
+            PAGE_CASE_UID > 0;
 
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+        UPDATE #TMP_VAC_REPEAT_OUT_NUM
+        SET VAC_DOSE_4_IND = CASE
+            WHEN VACC_DOSE_NBR_5 IS NULL THEN NULL
+            ELSE 'True'
+            END;
 
-COMMIT TRANSACTION;
+
+        SELECT DISTINCT
+            Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_DOSE_NBR_2, VACC_DOSE_NBR_3, VACC_DOSE_NBR_4, VAC_DOSE_4_IND
+        INTO #TMP_VAC_REPEAT_OUT_NUM_Final
+        FROM #TMP_VAC_REPEAT_OUT_NUM
+        ORDER BY D_INVESTIGATION_REPEAT_KEY;
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
 
 
 -------------------------------------------------------26d. CREATE TABLE TMP_VAC_REPEAT_OUT_FINAL1--------------------------------------------------------------------------
-BEGIN TRANSACTION;
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_FINAL1';
+        SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_FINAL1';
 
-			SET @Proc_Step_no = 26;
+        SET @Proc_Step_no = 26;
 
 ----d
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_FINAL1', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_FINAL1;
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_FINAL1', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_FINAL1;
 
-END;
-
-
-/*
-																				DATA VAC_REPEAT_OUT_FINAL;
-
-																				MERGE  VAC_REPEAT_OUT_DATE(IN=in1) VAC_REPEAT_OUT_NUM(IN=in2);
-
-																				BY D_INVESTIGATION_REPEAT_KEY;
-
-																				*/
-SELECT DISTINCT
-    D.Page_Case_UId, D.D_INVESTIGATION_REPEAT_KEY, D.INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_RECVD_DT_1, VACC_DOSE_NBR_2, VACC_RECVD_DT_2, VACC_DOSE_NBR_3, VACC_RECVD_DT_3, VACC_DOSE_NBR_4, VACC_RECVD_DT_4, VAC_GT_4_IND, VAC_DOSE_4_IND, CAST(NULL  AS varchar(1000)) AS VACC_GT_4_IND   ---------FinalIndicator
-INTO #TMP_VAC_REPEAT_OUT_FINAL1
-FROM #TMP_VAC_REPEAT_OUT_Date_Final AS D
-         INNER JOIN
-     #TMP_VAC_REPEAT_OUT_NUM_Final AS N
-     ON D.D_INVESTIGATION_REPEAT_KEY = N.D_INVESTIGATION_REPEAT_KEY
-ORDER BY D.D_INVESTIGATION_REPEAT_KEY;
-
-UPDATE #TMP_VAC_REPEAT_OUT_FINAL1
-SET VACC_GT_4_IND = CASE
-    WHEN LEN(RTRIM(VAC_DOSE_4_IND)) > 0 OR
-         LEN(RTRIM(VAC_GT_4_IND)) > 0 THEN 'True'
-    ELSE NULL
-    END;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
---------------------------------------------------26e. CREATE TABLE TMP_VAC_REPEAT_OUT_FINAL--------------------------------------------------------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_FINAL';
-
-			SET @Proc_Step_no = 26;
-
-----e
-			IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_FINAL', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_VAC_REPEAT_OUT_FINAL;
-
-END;
-
-SELECT Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_RECVD_DT_1, VACC_DOSE_NBR_2, VACC_RECVD_DT_2, VACC_DOSE_NBR_3, VACC_RECVD_DT_3, VACC_DOSE_NBR_4, VACC_RECVD_DT_4, VACC_GT_4_IND   ---------FinalIndicator
-INTO #TMP_VAC_REPEAT_OUT_FINAL
-FROM #TMP_VAC_REPEAT_OUT_FINAL1;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
-
----------------------------------------------------------Final Table 27 TMP_HEPATITIS_CASE_BASE------------------------------------------------------------------------------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Generating TMP_HEPATITIS_CASE_BASE';
-
-			SET @Proc_Step_no = 27;
-
-			IF OBJECT_ID('#TMP_HEPATITIS_CASE_BASE', 'U') IS NOT NULL
-BEGIN
-DROP TABLE #TMP_HEPATITIS_CASE_BASE;
-
-END;
-
-SELECT DISTINCT
-    A.INNC_NOTIFICATION_DT, ---1
-    I.CASE_RPT_MMWR_WEEK, ---2
-    I.CASE_RPT_MMWR_YEAR, ----3
-    C.HEP_D_INFECTION_IND, ----4
-    C.HEP_MEDS_RECVD_IND, ----5
-    L.HEP_C_TOTAL_ANTIBODY, ----6
-    I.DIAGNOSIS_DT, ------------7
-    I.DIE_FRM_THIS_ILLNESS_IND, ----8
-    I.DISEASE_IMPORTED_IND, -----9
-    I.EARLIEST_RPT_TO_CNTY, ----10
-    I.EARLIEST_RPT_TO_STATE_DT, ---11
-    RTRIM(LTRIM(SUBSTRING(A.BINATIONAL_RPTNG_CRIT,1,300))) as BINATIONAL_RPTNG_CRIT, ---12
-    E.CHILDCARE_CASE_IND, ---13
-    E.CNTRY_USUAL_RESIDENCE, ---14
-    E.CT_BABYSITTER_IND, ---15
-    E.CT_CHILDCARE_IND, ----16
-    E.CT_HOUSEHOLD_IND, ---17
-    E.HEP_CONTACT_IND, ----18
-    R.HEP_CONTACT_EVER_IND, ----19
-    E.OTHER_CONTACT_IND, ---20
-    ISNULL(NULLIF(E.COM_SRC_OUTBREAK_IND, ''), NULL) AS COM_SRC_OUTBREAK_IND, ---21
-    E.CONTACT_TYPE_OTH, ----22
-    E.CT_PLAYMATE_IND, ----23
-    E.SEXUAL_PARTNER_IND, ----24
-    E.DNP_HOUSEHOLD_CT_IND, ---25
-    E.HEP_A_EPLINK_IND, ----25
-    E.FEMALE_SEX_PRTNR_NBR, ---27
-    E.FOODHNDLR_PRIOR_IND, ----28
-    ISNULL(NULLIF(E.DNP_EMPLOYEE_IND, ''), NULL) AS DNP_EMPLOYEE_IND, -----29
-    ISNULL(NULLIF(E.STREET_DRUG_INJECTED, ''), NULL) AS STREET_DRUG_INJECTED, -----30
-    ISNULL(NULLIF(E.MALE_SEX_PRTNR_NBR, ''), NULL) AS MALE_SEX_PRTNR_NBR, ----31
-    I.OUTBREAK_IND, -----32
-    ISNULL(NULLIF(E.OBRK_FOODHNDLR_IND, ''), NULL) AS OBRK_FOODHNDLR_IND, ----33
-    ISNULL(NULLIF(E.FOOD_OBRK_FOOD_ITEM, ''), NULL) AS FOOD_OBRK_FOOD_ITEM, ----34
-    ISNULL(NULLIF(E.OBRK_NOFOODHNDLR_IND, ''), NULL) AS OBRK_NOFOODHNDLR_IND, ----35
-    ISNULL(NULLIF(E.OBRK_UNIDENTIFIED_IND, ''), NULL) AS OBRK_UNIDENTIFIED_IND, ----36
-    ISNULL(NULLIF(E.OBRK_WATERBORNE_IND, ''), NULL) AS OBRK_WATERBORNE_IND, ----37
-    ISNULL(NULLIF(E.STREET_DRUG_USED, ''), NULL) AS STREET_DRUG_USED, ---38
-    PO.SEX_PREF, ----39
-    I.HSPTL_ADMISSION_DT, ----40
-    I.HSPTL_DISCHARGE_DT, ----41
-    I.HSPTL_DURATION_DAYS, ----42
-    I.HSPTLIZD_IND, ---43
-    I.ILLNESS_ONSET_DT, ----44
-    I.INV_CASE_STATUS, ----45
-    ----	ltrim(rtrim(I.INV_COMMENTS)) as INV_COMMENTS,----46--------7/21/2021
-    LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE([INV_COMMENTS], CHAR(10), CHAR(32)), CHAR(13), CHAR(32)), CHAR(160), CHAR(32)), CHAR(9), CHAR(32)))) AS INV_COMMENTS, ----46--------7/21/2021
-    I.INV_LOCAL_ID, ---47
-    I.INV_RPT_DT, ---48
-    I.INV_START_DT, ---49
-    I.INVESTIGATION_STATUS, ---50
-    I.JURISDICTION_NM, ---51
-    L.ALT_SGPT_RESULT, ----52
-    L.ANTI_HBS_POS_REAC_IND, -----53
-    L.AST_SGOT_RESULT, ---54
-    L.HEP_E_ANTIGEN, ----55
-    L.HBE_AG_DT, ---56
-    L.HEP_B_SURFACE_ANTIGEN, ----57
-    L.HBS_AG_DT, ----58
-    L.HEP_B_DNA, -----59
-    L.HBV_NAT_DT, ----60
-    L.HCV_RNA, ----61
-    L.HCV_RNA_DT, ----62
-    L.HEP_D_TEST_IND, ----63
-    L.HEP_A_IGM_ANTIBODY, ----64
-    L.IGM_ANTI_HAV_DT, ----65
-    L.HEP_B_IGM_ANTIBODY, ----66
-    L.IGM_ANTI_HBC_DT, ----67
-    L.PREV_NEG_HEP_TEST_IND, ------68
-    L.ANTIHCV_SIGCUT_RATIO, ----69
-    L.ANTIHCV_SUPP_ASSAY, -----70
-    L.SUPP_ANTI_HCV_DT, -----71
-    L.ALT_RESULT_DT, ----72
-    L.AST_RESULT_DT, -----73
-    L.ALT_SGPT_RSLT_UP_LMT, ----74
-    L.AST_SGOT_RSLT_UP_LMT, ----75
-    L.HEP_A_TOTAL_ANTIBODY, ----76
-    L.TOTAL_ANTI_HAV_DT, ----77
-    L.HEP_B_TOTAL_ANTIBODY, ----78
-    L.TOTAL_ANTI_HBC_DT, ----79
-    L.TOTAL_ANTI_HCV_DT, ----80
-    L.HEP_D_TOTAL_ANTIBODY, ----81
-    L.TOTAL_ANTI_HDV_DT, ----82
-    L.HEP_E_TOTAL_ANTIBODY, ----83
-    L.TOTAL_ANTI_HEV_DT, ----84
-    L.VERIFIED_TEST_DT, ----85
-    I.LEGACY_CASE_ID, ---86
-    MH.DIABETES_IND, ----87
-    MH.DIABETES_DX_DT, ----88
-    MH.PREGNANCY_DUE_DT, ----89
-    MH.PAT_JUNDICED_IND, -----90
-    MH.PAT_PREV_AWARE_IND, ----91
-    MH.HEP_CARE_PROVIDER, ----92
-    MH.TEST_REASON, ------93
-    RTRIM(LTRIM(SUBSTRING(MH.TEST_REASON_OTH,1,150))) as TEST_REASON_OTH, -----94----10/18/2021 added the trim since the dest has only 150 length
-    MH.SYMPTOMATIC_IND, -----95
-    M.MTH_BORN_OUTSIDE_US, ---96
-    M.MTH_ETHNICITY, ------97
-    M.MTH_HBS_AG_PRIOR_POS, ----98
-    M.MTH_POS_AFTER, ------99
-    M.MTH_POS_TEST_DT, ----100
-    M.MTH_RACE, -----101
-    M.MTH_BIRTH_COUNTRY, ----102
-    I.NOT_SUBMIT_DT, ----103
-    P.PAT_REPORTED_AGE, ----104
-    P.PAT_REPORTED_AGE_UNIT, ----105
-    P.PAT_CITY, ----106
-    P.PAT_COUNTRY, ----107
-    P.PAT_COUNTY, ----108
-    P.PAT_CURR_GENDER, ---109
-    P.PAT_DOB, ---110
-    LTRIM(RTRIM(P.PAT_ETHNICITY)) AS PAT_ETHNICITY, ---111
-    P.PAT_FIRST_NM, ---112
-    P.PAT_LAST_NM, ---113
-    P.PAT_LOCAL_ID, ---114
-    P.PAT_MIDDLE_NM, ---115
-    I.PAT_PREGNANT_IND, ---116
-    P.PAT_RACE, ----117
-    P.PAT_STATE, ----118
-    LTRIM(RTRIM(P.PAT_STREET_ADDR_1)) AS PAT_STREET_ADDR_1, ---119-------------------7/14/2021
-    P.PAT_STREET_ADDR_2, ----120
-    P.PAT_ZIP_CODE, ----121
-    HP.RPT_SRC_SOURCE_NM, ----122
-    HP.RPT_SRC_STATE, ----123
-    I.RPT_SRC_CD_DESC, ---124
-    R.BLD_EXPOSURE_IND, ----125
-    R.BLD_RECVD_IND, ----126
-    R.BLD_RECVD_DT, ----127
-    R.MED_DEN_BLD_CT_FRQ, ----128
-    R.MED_DEN_EMP_EVER_IND, ----129
-    R.MED_DEN_EMPLOYEE_IND, ---130
-    R.CLOTFACTOR_PRIOR_1987, ----131
-    R.BLD_CONTAM_IND, ------132
-    R.DEN_WORK_OR_SURG_IND, ----133
-    R.HEMODIALYSIS_IND, ----134
-    R.LT_HEMODIALYSIS_IND, -----135
-    R.HSPTL_PRIOR_ONSET_IND, ----136
-    R.EVER_INJCT_NOPRSC_DRG, -----137
-    R.INCAR_24PLUSHRS_IND, ---138
-    R.INCAR_6PLUS_MO_IND, ---139
-    R.EVER_INCAR_IND, ----140
-    R.INCAR_TYPE_JAIL_IND, ----141
-    R.INCAR_TYPE_PRISON_IND, ----142
-    R.INCAR_TYPE_JUV_IND, ----143
-    R.LAST6PLUSMO_INCAR_PER, ----144
-    R.LAST6PLUSMO_INCAR_YR, ----145
-    R.OUTPAT_IV_INF_IND, ----146
-    R.LTCARE_RESIDENT_IND, ----147
-    R.LIFE_SEX_PRTNR_NBR, ----148
-    R.BLD_EXPOSURE_OTH, ----149
-    R.PIERC_PRIOR_ONSET_IND, ----150
-    R.PIERC_PERF_LOC_OTH, ----151
-    R.PIERC_PERF_LOC, -----152
-    R.PUB_SAFETY_BLD_CT_FRQ, ----153
-    R.PUB_SAFETY_WORKER_IND, ----154
-    R.STD_TREATED_IND, ----155
-    R.STD_LAST_TREATMENT_YR, ---156
-    R.NON_ORAL_SURGERY_IND, ---157
-    R.TATT_PRIOR_ONSET_IND, ---158
-    R.TATTOO_PERF_LOC, ----158
-    R.TATT_PRIOR_LOC_OTH, ----160
-    R.BLD_TRANSF_PRIOR_1992, ---161
-    R.ORGN_TRNSP_PRIOR_1992, ----162
-    I.TRANSMISSION_MODE, ----163
-    T.HOUSEHOLD_TRAVEL_IND, ----164
-    T.TRAVEL_OUT_USACAN_IND, ----165
-    T.TRAVEL_OUT_USACAN_LOC, -----166
-    T.HOUSEHOLD_TRAVEL_LOC, ----167
-    T.TRAVEL_REASON, -----168
-    V.IMM_GLOB_RECVD_IND, ----169
-    V.GLOB_LAST_RECVD_YR, ----170
-    V.VACC_RECVD_IND, ----171-------Has to be 10 digits long
-    VAC.VACC_DOSE_NBR_1, ----172
-    VAC.VACC_RECVD_DT_1, ----173
-    VAC.VACC_DOSE_NBR_2, ----174
-    VAC.VACC_RECVD_DT_2, ----175
-    VAC.VACC_DOSE_NBR_3, ----176
-    VAC.VACC_RECVD_DT_3, -----177
-    VAC.VACC_DOSE_NBR_4, -----178
-    VAC.VACC_RECVD_DT_4, ---179
-    VAC.VACC_GT_4_IND, -----180
-    V.VACC_DOSE_RECVD_NBR, ----181
-    V.VACC_LAST_RECVD_YR, -----182
-    L.ANTI_HBSAG_TESTED_IND, ----183
-    I.CONDITION_CD, -----184
-    CAST(NULL AS datetime) AS EVENT_DATE, ----185
-    I.IMPORT_FROM_CITY, ----186
-    I.IMPORT_FROM_COUNTRY, ----187
-    I.IMPORT_FROM_COUNTY, ----188
-    I.IMPORT_FROM_STATE, ----189
-    I.INVESTIGATION_KEY, -----190
-    HP.INVESTIGATOR_NAME, -----191
-    P.PAT_ELECTRONIC_IND, ----192
-    HP.PHYS_CITY, ----193
-    HP.PHYS_COUNTY, ----194
-    HP.PHYS_NAME, ----195
-    HP.PHYS_STATE, ----196
-    I.PROGRAM_JURISDICTION_OID, ----197
-    HP.RPT_SRC_CITY, ---198
-    HP.RPT_SRC_COUNTY, ----199
-    HP.RPT_SRC_COUNTY_CD, ---200
-    HP.PHYSICIAN_UID, ----201
-    P.PATIENT_UID, ----202
-    I.CASE_UID, ---203
-    HP.INVESTIGATOR_UID, ---204
-    HP.REPORTING_SOURCE_UID, ---205
-    CAST(NULL AS datetime) AS REFRESH_DATETIME, ---206
-    P.PAT_BIRTH_COUNTRY,----207
-    CAST(NULL AS varchar(2000)) AS EVENT_DATE_TYPE
-INTO #TMP_HEPATITIS_CASE_BASE
-FROM #TMP_Investigation AS I WITH(NOLOCK)
-				 FULL OUTER JOIN  #TMP_D_INV_LAB_FINDING AS L WITH(NOLOCK)  ON I.INVESTIGATION_KEY = L.LAB_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_RISK_FACTOR AS R WITH(NOLOCK)  ON I.INVESTIGATION_KEY = R.RISK_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_EPIDEMIOLOGY AS E WITH(NOLOCK) ON I.INVESTIGATION_KEY = E.EPIDEMIOLOGY_INV_KEY
-    FULL OUTER JOIN  #TMP_D_Patient AS P WITH(NOLOCK)          ON I.INVESTIGATION_KEY = P.Patient_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_VACCINATION AS V WITH(NOLOCK)  ON I.INVESTIGATION_KEY = V.VACCINATION_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_TRAVEL AS T WITH(NOLOCK)  ON I.INVESTIGATION_KEY = T.Travel_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_MOTHER AS M WITH(NOLOCK)  ON I.INVESTIGATION_KEY = M.Mother_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_MEDICAL_HISTORY AS MH WITH(NOLOCK)  ON I.INVESTIGATION_KEY = MH.MEDHistory_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_ADMINISTRATIVE AS A WITH(NOLOCK)  ON I.INVESTIGATION_KEY = A.ADMIN_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_PATIENT_OBS AS PO WITH(NOLOCK)  ON I.INVESTIGATION_KEY = PO.PATIENT_OBS_INV_KEY
-    FULL OUTER JOIN  #TMP_HEP_PAT_PROV AS HP WITH(NOLOCK)  ON I.INVESTIGATION_KEY = HP.HEP_PAT_PROV_INV_KEY
-    FULL OUTER JOIN  #TMP_D_INV_CLINICAL AS C WITH(NOLOCK)  ON I.INVESTIGATION_KEY = C.CLINICAL_INV_KEY
-    FULL OUTER JOIN  #TMP_VAC_REPEAT_OUT_FINAL AS VAC WITH(NOLOCK)  ON I.INVESTIGATION_KEY = VAC.INVESTIGATION_KEY
-;
-
-
-if @debug = 'true'
-select * from #TMP_HEPATITIS_CASE_BASE;
-
-
-
--------(--Actually Should be inner Join)
-/*data HEPATITIS_CASE_BASE;
-
-																						set HEPATITIS_CASE_BASE;
-
-																						if RTRIM(LTRIM(LENGTHN(VACC_GT_4_IND)))<1 then do;
-
-																						VACC_GT_4_IND="FALSE";
-
- end;
-
-
-																						run;
-
-*/
----7/14/2021(since getting error converting varchar to int)
-UPDATE #TMP_HEPATITIS_CASE_BASE
-SET LAST6PLUSMO_INCAR_PER = CASE
-    WHEN LAST6PLUSMO_INCAR_PER NOT LIKE N'%[^0-9.,-]%' AND
-         LAST6PLUSMO_INCAR_PER NOT LIKE '.' AND
-         ISNUMERIC(LAST6PLUSMO_INCAR_PER) = 1 THEN LAST6PLUSMO_INCAR_PER
-    ELSE 0
-    END
-where LAST6PLUSMO_INCAR_PER is not null
-;
-
-
-------------  /*EXT_LAST6PLUSMO_INCAR_PER= INPUT(RSK_IncarcTimeMonths, comma20.)*/----20
-UPDATE #TMP_HEPATITIS_CASE_BASE
-SET LAST6PLUSMO_INCAR_YR = CASE
-    WHEN LAST6PLUSMO_INCAR_YR NOT LIKE N'%[^0-9.,-]%' AND
-         LAST6PLUSMO_INCAR_YR NOT LIKE '.' AND
-         ISNUMERIC(LAST6PLUSMO_INCAR_YR) = 1 THEN LAST6PLUSMO_INCAR_YR
-    ELSE 0
-    END
-where LAST6PLUSMO_INCAR_YR is not null
-;
-
-------------  /*EXT_LAST6PLUSMO_INCAR_PER= INPUT(RSK_IncarcTimeMonths, comma20.)*/----20
-UPDATE #TMP_HEPATITIS_CASE_BASE
-SET VACC_GT_4_IND = CASE
-    WHEN LEN(ISNULL(RTRIM(LTRIM(VACC_GT_4_IND)), '')) < 1 THEN 'False'
-    ELSE VACC_GT_4_IND
-    END;
-
-
-/*proc sql;
-
-																					DELETE from HEPATITIS_CASE_BASE where patient_uid is null;
-
-																					quit;
-
-*/
-DELETE FROM #TMP_HEPATITIS_CASE_BASE
-WHERE PATIENT_UID IS NULL;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
-------------------------------------------------------------------------------------------------------------------------------------------------------
-UPDATE #TMP_HEPATITIS_CASE_BASE
-SET REFRESH_DATETIME = GETDATE();
-
-/*------------------
-       /* Note = FIRST_RPT_TO_CNTY_DT   is EARLIEST_RPT_TO_CNTY */
-       ----1.---HSPTL_DISCHARGE_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = HSPTL_DISCHARGE_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > HSPTL_DISCHARGE_DT AND
-             HSPTL_DISCHARGE_DT IS NOT NULL;
-
-
-       ----2.---- HSPTL_ADMISSION_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = HSPTL_ADMISSION_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > HSPTL_ADMISSION_DT AND
-             HSPTL_ADMISSION_DT IS NOT NULL;
-
-
-       ----3. ---AST_RESULT_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = AST_RESULT_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > AST_RESULT_DT AND
-             AST_RESULT_DT IS NOT NULL;
-
-
-       ----4.---ALT_RESULT_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = ALT_RESULT_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > ALT_RESULT_DT AND
-             ALT_RESULT_DT IS NOT NULL;
-
-
-       ----5.--- INV_START_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = INV_START_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > INV_START_DT AND
-             INV_START_DT IS NOT NULL;
-
-
-       ---6.  ---EARLIEST_RPT_TO_STATE_DT
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = EARLIEST_RPT_TO_STATE_DT
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > EARLIEST_RPT_TO_STATE_DT AND
-             EARLIEST_RPT_TO_STATE_DT IS NOT NULL;
-
-
-       ----7.----EARLIEST_RPT_TO_CNTY
-       UPDATE #TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = EARLIEST_RPT_TO_CNTY
-       WHERE EVENT_DATE IS NULL OR
-             EVENT_DATE > EARLIEST_RPT_TO_CNTY AND
-             EARLIEST_RPT_TO_CNTY IS NOT NULL;
-
-
-/*
-                                                                                           ----8---INV_RPT_DT
-                                                                                           UPDATE #TMP_HEPATITIS_CASE_BASE
-                                                                                           SET EVENT_DATE = INV_RPT_DT
-                                                                                           Where  EVENT_DATE iS NULL or
-                                                                                           EVENT_DATE > INV_RPT_DT AND  INV_RPT_DT IS NOT NULL
-                                                                                           */
-       ----8.----ILLNESS_ONSET_DT---
-       UPDATE TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = DIAGNOSIS_DT
-       WHERE DIAGNOSIS_DT IS NOT NULL;
-
-
-       ----9.----ILLNESS_ONSET_DT---
-       UPDATE TMP_HEPATITIS_CASE_BASE
-         SET EVENT_DATE = ILLNESS_ONSET_DT
-       WHERE ILLNESS_ONSET_DT IS NOT NULL;
-
-
-       ----10 If all Dates Are Null get the addTime from Investigation Table ---5-19-2021
-       UPDATE TMP_HEPATITIS_CASE_BASE
-        SET EVENT_DATE = ADD_TIME
-       FROM [dbo].[INVESTIGATION] I
-       WHERE Event_Date IS NULL AND
-             I.INV_LOCAL_ID = TMP_HEPATITIS_CASE_BASE.INV_LOCAL_ID AND
-             I.[INVESTIGATION_KEY] = TMP_HEPATITIS_CASE_BASE.INVESTIGATION_KEY;
-*/
-
-
-
-
-
-
-
----------------------------------------------------------------
-
-/*
-
-IF OBJECT_ID('DBO.TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL
-DROP TABLE DBO.TEMP_MIN_MAX_NOTIFICATION;
-
-SELECT DISTINCT MIN(CASE
-        WHEN VERSION_CTRL_NBR = 1
-            THEN RECORD_STATUS_CD
-        END) AS FIRSTNOTIFICATIONSTATUS
-
-
-,MIN(CASE
-        WHEN RECORD_STATUS_CD = 'COMPLETED'
-            THEN RPT_SENT_TIME
-        END) AS FIRSTNOTIFICATIONSENDDATE
-,PUBLIC_HEALTH_CASE_UID
-INTO DBO.TEMP_MIN_MAX_NOTIFICATION
-FROM DBO.TEMP_HEP_NOTIFICATION WITH (NOLOCK)
-GROUP BY PUBLIC_HEALTH_CASE_UID
-;
-*/
-
-------------------------------------------------------------------------------------------------------
-----HEP_D_TEST_IND  to appear as N,Y U or Null--added on 5-19-2021
-UPDATE #TMP_HEPATITIS_CASE_BASE ----5/20-2021
-SET HEP_D_TEST_IND = CASE
-    WHEN HEP_D_TEST_IND IS NULL THEN NULL
-    WHEN HEP_D_TEST_IND = 'Yes' THEN 'Y'
-    WHEN HEP_D_TEST_IND = 'No' THEN 'N'
-    ELSE 'U'
-    END;
-
-
----------------------------------------------------------Final Table 28 TMP_HEPATITIS_CASE_BASE------------------------------------------------------------------------------------------------
-BEGIN TRANSACTION;
-
-			SET @Proc_Step_name = 'Updating HEPATITIS_CASE_BASE';
-
-			SET @Proc_Step_no = 28;
-
-UPDATE [dbo].[HEPATITIS_DATAMART]
-SET INNC_NOTIFICATION_DT = H.[INNC_NOTIFICATION_DT], CASE_RPT_MMWR_WEEK = H.[CASE_RPT_MMWR_WEEK], CASE_RPT_MMWR_YEAR = H.[CASE_RPT_MMWR_YEAR], HEP_D_INFECTION_IND = H.[HEP_D_INFECTION_IND], HEP_MEDS_RECVD_IND = H.[HEP_MEDS_RECVD_IND], HEP_C_TOTAL_ANTIBODY = H.[HEP_C_TOTAL_ANTIBODY], DIAGNOSIS_DT = H.[DIAGNOSIS_DT], DIE_FRM_THIS_ILLNESS_IND = H.[DIE_FRM_THIS_ILLNESS_IND], DISEASE_IMPORTED_IND = H.[DISEASE_IMPORTED_IND], EARLIEST_RPT_TO_CNTY = H.[EARLIEST_RPT_TO_CNTY], EARLIEST_RPT_TO_STATE_DT = H.[EARLIEST_RPT_TO_STATE_DT], BINATIONAL_RPTNG_CRIT = H.[BINATIONAL_RPTNG_CRIT], CHILDCARE_CASE_IND = H.[CHILDCARE_CASE_IND], CNTRY_USUAL_RESIDENCE = H.[CNTRY_USUAL_RESIDENCE], CT_BABYSITTER_IND = H.[CT_BABYSITTER_IND], CT_CHILDCARE_IND = H.[CT_CHILDCARE_IND], CT_HOUSEHOLD_IND = H.[CT_HOUSEHOLD_IND], HEP_CONTACT_IND = H.[HEP_CONTACT_IND], HEP_CONTACT_EVER_IND = H.[HEP_CONTACT_EVER_IND], OTHER_CONTACT_IND = H.[OTHER_CONTACT_IND], COM_SRC_OUTBREAK_IND = H.[COM_SRC_OUTBREAK_IND], CONTACT_TYPE_OTH = H.[CONTACT_TYPE_OTH], CT_PLAYMATE_IND = H.[CT_PLAYMATE_IND], SEXUAL_PARTNER_IND = H.[SEXUAL_PARTNER_IND], DNP_HOUSEHOLD_CT_IND = H.[DNP_HOUSEHOLD_CT_IND], HEP_A_EPLINK_IND = H.[HEP_A_EPLINK_IND], FEMALE_SEX_PRTNR_NBR = H.[FEMALE_SEX_PRTNR_NBR], FOODHNDLR_PRIOR_IND = H.[FOODHNDLR_PRIOR_IND], DNP_EMPLOYEE_IND = H.[DNP_EMPLOYEE_IND], STREET_DRUG_INJECTED = H.[STREET_DRUG_INJECTED], MALE_SEX_PRTNR_NBR = H.[MALE_SEX_PRTNR_NBR], OUTBREAK_IND = H.[OUTBREAK_IND], OBRK_FOODHNDLR_IND = H.[OBRK_FOODHNDLR_IND], FOOD_OBRK_FOOD_ITEM = H.[FOOD_OBRK_FOOD_ITEM], OBRK_NOFOODHNDLR_IND = H.[OBRK_NOFOODHNDLR_IND], OBRK_UNIDENTIFIED_IND = H.[OBRK_UNIDENTIFIED_IND], OBRK_WATERBORNE_IND = H.[OBRK_WATERBORNE_IND], STREET_DRUG_USED = H.[STREET_DRUG_USED],
-    SEX_PREF = H.[SEX_PREF], HSPTL_ADMISSION_DT = H.[HSPTL_ADMISSION_DT], HSPTL_DISCHARGE_DT = H.[HSPTL_DISCHARGE_DT], HSPTL_DURATION_DAYS = H.[HSPTL_DURATION_DAYS], HSPTLIZD_IND = H.[HSPTLIZD_IND], ILLNESS_ONSET_DT = H.[ILLNESS_ONSET_DT], INV_CASE_STATUS = H.[INV_CASE_STATUS], INV_COMMENTS = H.[INV_COMMENTS], INV_LOCAL_ID = H.[INV_LOCAL_ID], INV_RPT_DT = H.[INV_RPT_DT], INV_START_DT = H.[INV_START_DT], INVESTIGATION_STATUS = H.[INVESTIGATION_STATUS], JURISDICTION_NM = H.[JURISDICTION_NM], ALT_SGPT_RESULT = H.[ALT_SGPT_RESULT], ANTI_HBS_POS_REAC_IND = H.[ANTI_HBS_POS_REAC_IND], AST_SGOT_RESULT = H.[AST_SGOT_RESULT], HEP_E_ANTIGEN = H.[HEP_E_ANTIGEN], HBE_AG_DT = H.[HBE_AG_DT], HEP_B_SURFACE_ANTIGEN = H.[HEP_B_SURFACE_ANTIGEN], HBS_AG_DT = H.[HBS_AG_DT], HBV_NAT_DT = H.[HBV_NAT_DT], HCV_RNA = H.[HCV_RNA],
-    HCV_RNA_DT = H.[HCV_RNA_DT], HEP_D_TEST_IND = H.[HEP_D_TEST_IND], HEP_A_IGM_ANTIBODY = H.[HEP_A_IGM_ANTIBODY], IGM_ANTI_HAV_DT = H.[IGM_ANTI_HAV_DT], HEP_B_IGM_ANTIBODY = H.[HEP_B_IGM_ANTIBODY], IGM_ANTI_HBC_DT = H.[IGM_ANTI_HBC_DT], PREV_NEG_HEP_TEST_IND = H.[PREV_NEG_HEP_TEST_IND], ANTIHCV_SIGCUT_RATIO = H.[ANTIHCV_SIGCUT_RATIO], ANTIHCV_SUPP_ASSAY = H.[ANTIHCV_SUPP_ASSAY], SUPP_ANTI_HCV_DT = H.[SUPP_ANTI_HCV_DT], ALT_RESULT_DT = H.[ALT_RESULT_DT], AST_RESULT_DT = H.[AST_RESULT_DT], ALT_SGPT_RSLT_UP_LMT = H.[ALT_SGPT_RSLT_UP_LMT], AST_SGOT_RSLT_UP_LMT = H.[AST_SGOT_RSLT_UP_LMT], HEP_A_TOTAL_ANTIBODY = H.[HEP_A_TOTAL_ANTIBODY], TOTAL_ANTI_HAV_DT = H.[TOTAL_ANTI_HAV_DT], HEP_B_TOTAL_ANTIBODY = H.[HEP_B_TOTAL_ANTIBODY], TOTAL_ANTI_HBC_DT = H.[TOTAL_ANTI_HBC_DT], TOTAL_ANTI_HCV_DT = H.[TOTAL_ANTI_HCV_DT],
-    HEP_D_TOTAL_ANTIBODY = H.[HEP_D_TOTAL_ANTIBODY], TOTAL_ANTI_HDV_DT = H.[TOTAL_ANTI_HDV_DT], HEP_E_TOTAL_ANTIBODY = H.[HEP_E_TOTAL_ANTIBODY], TOTAL_ANTI_HEV_DT = H.[TOTAL_ANTI_HEV_DT], VERIFIED_TEST_DT = H.[VERIFIED_TEST_DT], LEGACY_CASE_ID = H.[LEGACY_CASE_ID], DIABETES_IND = H.[DIABETES_IND], DIABETES_DX_DT = H.[DIABETES_DX_DT], PREGNANCY_DUE_DT = H.[PREGNANCY_DUE_DT], PAT_JUNDICED_IND = H.[PAT_JUNDICED_IND], PAT_PREV_AWARE_IND = H.[PAT_PREV_AWARE_IND], HEP_CARE_PROVIDER = H.[HEP_CARE_PROVIDER], TEST_REASON = H.[TEST_REASON], TEST_REASON_OTH = H.[TEST_REASON_OTH], SYMPTOMATIC_IND = H.[SYMPTOMATIC_IND], MTH_BORN_OUTSIDE_US = H.[MTH_BORN_OUTSIDE_US], MTH_ETHNICITY = H.[MTH_ETHNICITY], MTH_HBS_AG_PRIOR_POS = H.[MTH_HBS_AG_PRIOR_POS], MTH_POS_AFTER = H.[MTH_POS_AFTER], MTH_POS_TEST_DT = H.[MTH_POS_TEST_DT], MTH_RACE = H.[MTH_RACE], MTH_BIRTH_COUNTRY = H.[MTH_BIRTH_COUNTRY], NOT_SUBMIT_DT = H.[NOT_SUBMIT_DT], PAT_REPORTED_AGE = H.[PAT_REPORTED_AGE], PAT_REPORTED_AGE_UNIT = H.[PAT_REPORTED_AGE_UNIT], PAT_CITY = H.[PAT_CITY], PAT_COUNTRY = H.[PAT_COUNTRY], PAT_COUNTY = H.[PAT_COUNTY], PAT_CURR_GENDER = H.[PAT_CURR_GENDER], PAT_DOB = H.[PAT_DOB], PAT_ETHNICITY = H.[PAT_ETHNICITY], PAT_FIRST_NM = H.[PAT_FIRST_NM], PAT_LAST_NM = H.[PAT_LAST_NM], PAT_LOCAL_ID = H.[PAT_LOCAL_ID], PAT_MIDDLE_NM = H.[PAT_MIDDLE_NM], PAT_PREGNANT_IND = H.[PAT_PREGNANT_IND], PAT_RACE = H.[PAT_RACE], PAT_STATE = H.[PAT_STATE], PAT_STREET_ADDR_1 = H.[PAT_STREET_ADDR_1], PAT_STREET_ADDR_2 = H.[PAT_STREET_ADDR_2], PAT_ZIP_CODE = H.[PAT_ZIP_CODE], RPT_SRC_SOURCE_NM = H.[RPT_SRC_SOURCE_NM], RPT_SRC_STATE = H.[RPT_SRC_STATE], RPT_SRC_CD_DESC = H.[RPT_SRC_CD_DESC], BLD_EXPOSURE_IND = H.[BLD_EXPOSURE_IND], BLD_RECVD_IND = H.[BLD_RECVD_IND], BLD_RECVD_DT = H.[BLD_RECVD_DT], MED_DEN_BLD_CT_FRQ = H.[MED_DEN_BLD_CT_FRQ], MED_DEN_EMPLOYEE_IND = H.[MED_DEN_EMPLOYEE_IND], MED_DEN_EMP_EVER_IND = H.[MED_DEN_EMP_EVER_IND], CLOTFACTOR_PRIOR_1987 = H.[CLOTFACTOR_PRIOR_1987], BLD_CONTAM_IND = H.[BLD_CONTAM_IND], DEN_WORK_OR_SURG_IND = H.[DEN_WORK_OR_SURG_IND], HEMODIALYSIS_IND = H.[HEMODIALYSIS_IND], LT_HEMODIALYSIS_IND = H.[LT_HEMODIALYSIS_IND], HSPTL_PRIOR_ONSET_IND = H.[HSPTL_PRIOR_ONSET_IND], EVER_INJCT_NOPRSC_DRG = H.[EVER_INJCT_NOPRSC_DRG], INCAR_24PLUSHRS_IND = H.[INCAR_24PLUSHRS_IND], INCAR_6PLUS_MO_IND = H.[INCAR_6PLUS_MO_IND], EVER_INCAR_IND = H.[EVER_INCAR_IND], INCAR_TYPE_JAIL_IND = H.[INCAR_TYPE_JAIL_IND], INCAR_TYPE_PRISON_IND = H.[INCAR_TYPE_PRISON_IND],
-    INCAR_TYPE_JUV_IND = H.[INCAR_TYPE_JUV_IND], LAST6PLUSMO_INCAR_PER = H.[LAST6PLUSMO_INCAR_PER], LAST6PLUSMO_INCAR_YR = H.[LAST6PLUSMO_INCAR_YR], OUTPAT_IV_INF_IND = H.[OUTPAT_IV_INF_IND], LTCARE_RESIDENT_IND = H.[LTCARE_RESIDENT_IND], LIFE_SEX_PRTNR_NBR = H.[LIFE_SEX_PRTNR_NBR], BLD_EXPOSURE_OTH = H.[BLD_EXPOSURE_OTH], PIERC_PRIOR_ONSET_INd = H.[PIERC_PRIOR_ONSET_IND], PIERC_PERF_LOC_OTH = H.[PIERC_PERF_LOC_OTH], PIERC_PERF_LOC = H.[PIERC_PERF_LOC], PUB_SAFETY_BLD_CT_FRQ = H.[PUB_SAFETY_BLD_CT_FRQ], PUB_SAFETY_WORKER_IND = H.[PUB_SAFETY_WORKER_IND], STD_TREATED_IND = H.[STD_TREATED_IND], STD_LAST_TREATMENT_YR = H.[STD_LAST_TREATMENT_YR], NON_ORAL_SURGERY_IND = H.[NON_ORAL_SURGERY_IND], TATT_PRIOR_ONSET_IND = H.[TATT_PRIOR_ONSET_IND], TATTOO_PERF_LOC = H.[TATTOO_PERF_LOC], TATT_PRIOR_LOC_OTH = H.[TATT_PRIOR_LOC_OTH], BLD_TRANSF_PRIOR_1992 = H.[BLD_TRANSF_PRIOR_1992], ORGN_TRNSP_PRIOR_1992 = H.[ORGN_TRNSP_PRIOR_1992], TRANSMISSION_MODE = H.[TRANSMISSION_MODE], HOUSEHOLD_TRAVEL_IND = H.[HOUSEHOLD_TRAVEL_IND], TRAVEL_OUT_USACAN_IND = H.[TRAVEL_OUT_USACAN_IND], TRAVEL_OUT_USACAN_LOC = H.[TRAVEL_OUT_USACAN_LOC], HOUSEHOLD_TRAVEL_LOC = H.[HOUSEHOLD_TRAVEL_LOC], TRAVEL_REASON = H.[TRAVEL_REASON], IMM_GLOB_RECVD_IND = H.[IMM_GLOB_RECVD_IND], GLOB_LAST_RECVD_YR = H.[GLOB_LAST_RECVD_YR], VACC_RECVD_IND = H.[VACC_RECVD_IND], VACC_DOSE_NBR_1 = H.[VACC_DOSE_NBR_1], VACC_RECVD_DT_1 = H.[VACC_RECVD_DT_1], VACC_DOSE_NBR_2 = H.[VACC_DOSE_NBR_2], VACC_RECVD_DT_2 = H.[VACC_RECVD_DT_2], VACC_DOSE_NBR_3 = H.[VACC_DOSE_NBR_3], VACC_RECVD_DT_3 = H.[VACC_RECVD_DT_3], VACC_DOSE_NBR_4 = H.[VACC_DOSE_NBR_4], VACC_RECVD_DT_4 = H.[VACC_RECVD_DT_4], VACC_GT_4_IND = H.[VACC_GT_4_IND], VACC_DOSE_RECVD_NBR = H.[VACC_DOSE_RECVD_NBR], VACC_LAST_RECVD_YR = H.[VACC_LAST_RECVD_YR], ANTI_HBSAG_TESTED_IND = H.[ANTI_HBSAG_TESTED_IND], CONDITION_CD = H.[CONDITION_CD], EVENT_DATE = H.[EVENT_DATE], IMPORT_FROM_CITY = H.[IMPORT_FROM_CITY], IMPORT_FROM_COUNTRY = H.[IMPORT_FROM_COUNTRY], IMPORT_FROM_COUNTY = H.[IMPORT_FROM_COUNTY], IMPORT_FROM_STATE = H.[IMPORT_FROM_STATE], INVESTIGATION_KEY = H.[INVESTIGATION_KEY], INVESTIGATOR_NAME = H.[INVESTIGATOR_NAME], PAT_ELECTRONIC_IND = H.[PAT_ELECTRONIC_IND], PHYS_CITY = H.[PHYS_CITY], PHYS_COUNTY = H.[PHYS_COUNTY], PHYS_NAME = H.[PHYS_NAME], PHYS_STATE = H.[PHYS_STATE], PROGRAM_JURISDICTION_OID = H.[PROGRAM_JURISDICTION_OID], RPT_SRC_CITY = H.[RPT_SRC_CITY], RPT_SRC_COUNTY = H.[RPT_SRC_COUNTY], RPT_SRC_COUNTY_CD = H.[RPT_SRC_COUNTY_CD], PHYSICIAN_UID = H.[PHYSICIAN_UID], PATIENT_UID = H.[PATIENT_UID], CASE_UID = H.[CASE_UID], INVESTIGATOR_UID = H.[INVESTIGATOR_UID], REPORTING_SOURCE_UID = H.[REPORTING_SOURCE_UID], REFRESH_DATETIME = H.[REFRESH_DATETIME], PAT_BIRTH_COUNTRY = H.[PAT_BIRTH_COUNTRY]
-FROM #TMP_HEPATITIS_CASE_BASE H WITH(NOLOCK)
-WHERE H.[CASE_UID] = [dbo].[HEPATITIS_DATAMART].[CASE_UID] AND
-    H.[PATIENT_UID] = [dbo].[HEPATITIS_DATAMART].[PATIENT_UID] AND
-    H.[INVESTIGATION_KEY] = [dbo].[HEPATITIS_DATAMART].[INVESTIGATION_KEY];
-
-COMMIT TRANSACTION;
-
-
---------------------------------------29.-----Final ---Inserting into dbo.HEPATITIS_DATAMART----------------------------------------------
-BEGIN TRANSACTION;
-
-			SET @PROC_STEP_NO = 29;
-
-			SET @PROC_STEP_NAME = 'Inserting new entries dbo.HEPATITIS_DATAMART';
-
-INSERT INTO dbo.[HEPATITIS_DATAMART]( INNC_NOTIFICATION_DT, ---1
-                                      CASE_RPT_MMWR_WEEK, ---2
-                                      CASE_RPT_MMWR_YEAR, ----3
-                                      HEP_D_INFECTION_IND, ----4
-                                      HEP_MEDS_RECVD_IND, ----5
-                                      HEP_C_TOTAL_ANTIBODY, ----6
-                                      DIAGNOSIS_DT, ------------7
-                                      DIE_FRM_THIS_ILLNESS_IND, ----8
-                                      DISEASE_IMPORTED_IND, -----9
-                                      EARLIEST_RPT_TO_CNTY, ----10
-                                      EARLIEST_RPT_TO_STATE_DT, ---11
-                                      BINATIONAL_RPTNG_CRIT, ---12
-                                      CHILDCARE_CASE_IND, ---13
-                                      CNTRY_USUAL_RESIDENCE, ---14
-                                      CT_BABYSITTER_IND, ---15
-                                      CT_CHILDCARE_IND, ----16
-                                      CT_HOUSEHOLD_IND, ---17
-                                      HEP_CONTACT_IND, ----18
-                                      HEP_CONTACT_EVER_IND, ----19
-                                      OTHER_CONTACT_IND, ---20
-                                      COM_SRC_OUTBREAK_IND, ---21
-                                      CONTACT_TYPE_OTH, ----22
-                                      CT_PLAYMATE_IND, ----23
-                                      SEXUAL_PARTNER_IND, ----24
-                                      DNP_HOUSEHOLD_CT_IND, ---25
-                                      HEP_A_EPLINK_IND, ----25
-                                      FEMALE_SEX_PRTNR_NBR, ---27
-                                      FOODHNDLR_PRIOR_IND, ----28
-                                      DNP_EMPLOYEE_IND, -----29
-                                      STREET_DRUG_INJECTED, -----30
-                                      MALE_SEX_PRTNR_NBR, ----31
-                                      OUTBREAK_IND, -----32
-                                      OBRK_FOODHNDLR_IND, ----33
-                                      FOOD_OBRK_FOOD_ITEM, ----34
-                                      OBRK_NOFOODHNDLR_IND, ----35
-                                      OBRK_UNIDENTIFIED_IND, ----36
-                                      OBRK_WATERBORNE_IND, ----37
-                                      STREET_DRUG_USED, ---38
-                                      SEX_PREF, ----39
-                                      HSPTL_ADMISSION_DT, ----40
-                                      HSPTL_DISCHARGE_DT, ----41
-                                      HSPTL_DURATION_DAYS, ----42
-                                      HSPTLIZD_IND, ---43
-                                      ILLNESS_ONSET_DT, ----44
-                                      INV_CASE_STATUS, ----45
-                                      INV_COMMENTS, ----46
-                                      INV_LOCAL_ID, ---47
-                                      INV_RPT_DT, ---48
-                                      INV_START_DT, ---49
-                                      INVESTIGATION_STATUS, ---50
-                                      JURISDICTION_NM, ---51
-                                      ALT_SGPT_RESULT, ----52
-                                      ANTI_HBS_POS_REAC_IND, -----53
-                                      AST_SGOT_RESULT, ---54
-                                      HEP_E_ANTIGEN, ----55
-                                      HBE_AG_DT, ---56
-                                      HEP_B_SURFACE_ANTIGEN, ----57
-                                      HBS_AG_DT, ----58
-                                      HEP_B_DNA, -----59
-                                      HBV_NAT_DT, ----60
-                                      HCV_RNA, ----61
-                                      HCV_RNA_DT, ----62
-                                      HEP_D_TEST_IND, ----63
-                                      HEP_A_IGM_ANTIBODY, ----64
-                                      IGM_ANTI_HAV_DT, ----65
-                                      HEP_B_IGM_ANTIBODY, ----66
-                                      IGM_ANTI_HBC_DT, ----67
-                                      PREV_NEG_HEP_TEST_IND, ------68
-                                      ANTIHCV_SIGCUT_RATIO, ----69
-                                      ANTIHCV_SUPP_ASSAY, -----70
-                                      SUPP_ANTI_HCV_DT, -----71
-                                      ALT_RESULT_DT, ----72
-                                      AST_RESULT_DT, -----73
-                                      ALT_SGPT_RSLT_UP_LMT, ----74
-                                      AST_SGOT_RSLT_UP_LMT, ----75
-                                      HEP_A_TOTAL_ANTIBODY, ----76
-                                      TOTAL_ANTI_HAV_DT, ----77
-                                      HEP_B_TOTAL_ANTIBODY, ----78
-                                      TOTAL_ANTI_HBC_DT, ----79
-                                      TOTAL_ANTI_HCV_DT, ----80
-                                      HEP_D_TOTAL_ANTIBODY, ----81
-                                      TOTAL_ANTI_HDV_DT, ----82
-                                      HEP_E_TOTAL_ANTIBODY, ----83
-                                      TOTAL_ANTI_HEV_DT, ----84
-                                      VERIFIED_TEST_DT, ----85
-                                      LEGACY_CASE_ID, ---86
-                                      DIABETES_IND, ----87
-                                      DIABETES_DX_DT, ----88
-                                      PREGNANCY_DUE_DT, ----89
-                                      PAT_JUNDICED_IND, -----90
-                                      PAT_PREV_AWARE_IND, ----91
-                                      HEP_CARE_PROVIDER, ----92
-                                      TEST_REASON, ------93
-                                      TEST_REASON_OTH, -----94
-                                      SYMPTOMATIC_IND, -----95
-                                      MTH_BORN_OUTSIDE_US, ---96
-                                      MTH_ETHNICITY, ------97
-                                      MTH_HBS_AG_PRIOR_POS, ----98
-                                      MTH_POS_AFTER, ------99
-                                      MTH_POS_TEST_DT, ----100
-                                      MTH_RACE, -----101
-                                      MTH_BIRTH_COUNTRY, ----102
-                                      NOT_SUBMIT_DT, ----103
-                                      PAT_REPORTED_AGE, ----104
-                                      PAT_REPORTED_AGE_UNIT, ----105
-                                      PAT_CITY, ----106
-                                      PAT_COUNTRY, ----107
-                                      PAT_COUNTY, ----108
-                                      PAT_CURR_GENDER, ---109
-                                      PAT_DOB, ---110
-                                      PAT_ETHNICITY, ---111
-                                      PAT_FIRST_NM, ---112
-                                      PAT_LAST_NM, ---113
-                                      PAT_LOCAL_ID, ---114
-                                      PAT_MIDDLE_NM, ---115
-                                      PAT_PREGNANT_IND, ---116
-                                      PAT_RACE, ----117
-                                      PAT_STATE, ----118
-                                      PAT_STREET_ADDR_1, ---119
-                                      PAT_STREET_ADDR_2, ----120
-                                      PAT_ZIP_CODE, ----121
-                                      RPT_SRC_SOURCE_NM, ----122
-                                      RPT_SRC_STATE, ----123
-                                      RPT_SRC_CD_DESC, ---124
-                                      BLD_EXPOSURE_IND, ----125
-                                      BLD_RECVD_IND, ----126
-                                      BLD_RECVD_DT, ----127
-                                      MED_DEN_BLD_CT_FRQ, ----128
-                                      MED_DEN_EMP_EVER_IND, ----129
-                                      MED_DEN_EMPLOYEE_IND, ---130
-                                      CLOTFACTOR_PRIOR_1987, ----131
-                                      BLD_CONTAM_IND, ------132
-                                      DEN_WORK_OR_SURG_IND, ----133
-                                      HEMODIALYSIS_IND, ----134
-                                      LT_HEMODIALYSIS_IND, -----135
-                                      HSPTL_PRIOR_ONSET_IND, ----136
-                                      EVER_INJCT_NOPRSC_DRG, -----137
-                                      INCAR_24PLUSHRS_IND, ---138
-                                      INCAR_6PLUS_MO_IND, ---139
-                                      EVER_INCAR_IND, ----140
-                                      INCAR_TYPE_JAIL_IND, ----141
-                                      INCAR_TYPE_PRISON_IND, ----142
-                                      INCAR_TYPE_JUV_IND, ----143
-                                      LAST6PLUSMO_INCAR_PER, ----144
-                                      LAST6PLUSMO_INCAR_YR, ----145
-                                      OUTPAT_IV_INF_IND, ----146
-                                      LTCARE_RESIDENT_IND, ----147
-                                      LIFE_SEX_PRTNR_NBR, ----148
-                                      BLD_EXPOSURE_OTH, ----149
-                                      PIERC_PRIOR_ONSET_IND, ----150
-                                      PIERC_PERF_LOC_OTH, ----151
-                                      PIERC_PERF_LOC, -----152
-                                      PUB_SAFETY_BLD_CT_FRQ, ----153
-                                      PUB_SAFETY_WORKER_IND, ----154
-                                      STD_TREATED_IND, ----155
-                                      STD_LAST_TREATMENT_YR, ---156
-                                      NON_ORAL_SURGERY_IND, ---157
-                                      TATT_PRIOR_ONSET_IND, ---158
-                                      TATTOO_PERF_LOC, ----158
-                                      TATT_PRIOR_LOC_OTH, ----160
-                                      BLD_TRANSF_PRIOR_1992, ---161
-                                      ORGN_TRNSP_PRIOR_1992, ----162
-                                      TRANSMISSION_MODE, ----163
-                                      HOUSEHOLD_TRAVEL_IND, ----164
-                                      TRAVEL_OUT_USACAN_IND, ----165
-                                      TRAVEL_OUT_USACAN_LOC, -----166
-                                      HOUSEHOLD_TRAVEL_LOC, ----167
-                                      TRAVEL_REASON, -----168
-                                      IMM_GLOB_RECVD_IND, ----169
-                                      GLOB_LAST_RECVD_YR, ----170
-                                      VACC_RECVD_IND, ----171
-                                      VACC_DOSE_NBR_1, ----172
-                                      VACC_RECVD_DT_1, ----173
-                                      VACC_DOSE_NBR_2, ----174
-                                      VACC_RECVD_DT_2, ----175
-                                      VACC_DOSE_NBR_3, ----176
-                                      VACC_RECVD_DT_3, -----177
-                                      VACC_DOSE_NBR_4, -----178
-                                      VACC_RECVD_DT_4, ---179
-                                      VACC_GT_4_IND, -----180
-                                      VACC_DOSE_RECVD_NBR, ----181
-                                      VACC_LAST_RECVD_YR, -----182
-                                      ANTI_HBSAG_TESTED_IND, ----183
-                                      CONDITION_CD, -----184
-                                      EVENT_DATE, ----185
-                                      IMPORT_FROM_CITY, ----186
-                                      IMPORT_FROM_COUNTRY, ----187
-                                      IMPORT_FROM_COUNTY, ----188
-                                      IMPORT_FROM_STATE, ----189
-                                      INVESTIGATION_KEY, -----190
-                                      INVESTIGATOR_NAME, -----191
-                                      PAT_ELECTRONIC_IND, ----192
-                                      PHYS_CITY, ----193
-                                      PHYS_COUNTY, ----194
-                                      PHYS_NAME, ----195
-                                      PHYS_STATE, ----196
-                                      PROGRAM_JURISDICTION_OID, ----197
-                                      RPT_SRC_CITY, ---198
-                                      RPT_SRC_COUNTY, ----199
-                                      RPT_SRC_COUNTY_CD, ---200
-                                      PHYSICIAN_UID, ----201
-                                      PATIENT_UID, ----202
-                                      CASE_UID, ---203
-                                      INVESTIGATOR_UID, ---204
-                                      REPORTING_SOURCE_UID, ---205
-                                      REFRESH_DATETIME, ---206
-                                      PAT_BIRTH_COUNTRY ----207
-)
-SELECT  INNC_NOTIFICATION_DT,
-        CASE_RPT_MMWR_WEEK,
-        CASE_RPT_MMWR_YEAR,
-        cast(HEP_D_INFECTION_IND as varchar(300)),
-        cast(HEP_MEDS_RECVD_IND as varchar(300)),
-        cast(HEP_C_TOTAL_ANTIBODY as varchar(300)),
-        DIAGNOSIS_DT,
-        cast(DIE_FRM_THIS_ILLNESS_IND as varchar(300)),
-        cast(DISEASE_IMPORTED_IND as varchar(300)),
-        EARLIEST_RPT_TO_CNTY,
-        EARLIEST_RPT_TO_STATE_DT,
-        cast(BINATIONAL_RPTNG_CRIT as varchar(300)),
-        cast(CHILDCARE_CASE_IND as varchar(300)),
-        cast(CNTRY_USUAL_RESIDENCE as varchar(300)),
-        cast(CT_BABYSITTER_IND as varchar(300)),
-        cast(CT_CHILDCARE_IND as varchar(300)),
-        cast(CT_HOUSEHOLD_IND as varchar(300)),
-        cast(HEP_CONTACT_IND as varchar(300)),
-        cast(HEP_CONTACT_EVER_IND as varchar(300)),
-        cast(OTHER_CONTACT_IND as varchar(300)),
-        cast(COM_SRC_OUTBREAK_IND as varchar(300)),
-        cast(CONTACT_TYPE_OTH as varchar(100)),
-        cast(CT_PLAYMATE_IND as varchar(300)),
-        cast(SEXUAL_PARTNER_IND as varchar(300)),
-        cast(DNP_HOUSEHOLD_CT_IND as varchar(300)),
-        cast(HEP_A_EPLINK_IND as varchar(300)),
-        FEMALE_SEX_PRTNR_NBR,
-        cast(FOODHNDLR_PRIOR_IND as varchar(300)),
-        cast(DNP_EMPLOYEE_IND as varchar(300)),
-        cast(STREET_DRUG_INJECTED as varchar(300)),
-        MALE_SEX_PRTNR_NBR,
-        cast(OUTBREAK_IND as varchar(300)),
-        cast(OBRK_FOODHNDLR_IND as varchar(300)),
-        cast(FOOD_OBRK_FOOD_ITEM as varchar(100)),
-        cast(OBRK_NOFOODHNDLR_IND as varchar(300)),
-        cast(OBRK_UNIDENTIFIED_IND as varchar(300)),
-        cast(OBRK_WATERBORNE_IND as varchar(300)),
-        cast(STREET_DRUG_USED as varchar(300)),
-        cast(SEX_PREF as varchar(300)),
-        HSPTL_ADMISSION_DT,
-        HSPTL_DISCHARGE_DT,
-        HSPTL_DURATION_DAYS,
-        cast(HSPTLIZD_IND as varchar(300)),
-        ILLNESS_ONSET_DT,
-        cast(INV_CASE_STATUS as varchar(300)),
-        cast(INV_COMMENTS as varchar(2000)),
-        cast(INV_LOCAL_ID as varchar(25)),
-        INV_RPT_DT,
-        INV_START_DT,
-        cast(INVESTIGATION_STATUS as varchar(300)),
-        cast(JURISDICTION_NM as varchar(300)),
-        ALT_SGPT_RESULT,
-        cast(ANTI_HBS_POS_REAC_IND as varchar(300)),
-        AST_SGOT_RESULT,
-        cast(HEP_E_ANTIGEN as varchar(300)),
-        HBE_AG_DT,
-        cast(HEP_B_SURFACE_ANTIGEN as varchar(300)),
-        HBS_AG_DT,
-        cast(HEP_B_DNA as varchar(300)),
-        HBV_NAT_DT,
-        cast(HCV_RNA as varchar(300)),
-        HCV_RNA_DT,
-        cast(HEP_D_TEST_IND as varchar(300)),
-        cast(HEP_A_IGM_ANTIBODY as varchar(300)),
-        IGM_ANTI_HAV_DT,
-        cast(HEP_B_IGM_ANTIBODY as varchar(300)),
-        IGM_ANTI_HBC_DT,
-        cast(PREV_NEG_HEP_TEST_IND as varchar(300)),
-        cast(ANTIHCV_SIGCUT_RATIO as varchar(25)),
-        cast(ANTIHCV_SUPP_ASSAY as varchar(300)),
-        SUPP_ANTI_HCV_DT,
-        ALT_RESULT_DT,
-        AST_RESULT_DT,
-        ALT_SGPT_RSLT_UP_LMT,
-        AST_SGOT_RSLT_UP_LMT,
-        cast(HEP_A_TOTAL_ANTIBODY as varchar(300)),
-        TOTAL_ANTI_HAV_DT,
-        cast(HEP_B_TOTAL_ANTIBODY as varchar(300)),
-        TOTAL_ANTI_HBC_DT,
-        TOTAL_ANTI_HCV_DT,
-        cast(HEP_D_TOTAL_ANTIBODY as varchar(300)),
-        TOTAL_ANTI_HDV_DT,
-        cast(HEP_E_TOTAL_ANTIBODY as varchar(300)),
-        TOTAL_ANTI_HEV_DT,
-        VERIFIED_TEST_DT,
-        cast(LEGACY_CASE_ID as varchar(15)),
-        cast(DIABETES_IND as varchar(300)),
-        DIABETES_DX_DT,
-        PREGNANCY_DUE_DT,
-        cast(PAT_JUNDICED_IND as varchar(300)),
-        cast(PAT_PREV_AWARE_IND as varchar(300)),
-        cast(HEP_CARE_PROVIDER as varchar(300)),
-        cast(TEST_REASON as varchar(300)),
-        cast(TEST_REASON_OTH as varchar(150)),
-        cast(SYMPTOMATIC_IND as varchar(300)),
-        cast(MTH_BORN_OUTSIDE_US as varchar(300)),
-        cast(MTH_ETHNICITY as varchar(300)),
-        cast(MTH_HBS_AG_PRIOR_POS as varchar(300)),
-        cast(MTH_POS_AFTER as varchar(300)),
-        MTH_POS_TEST_DT,
-        cast(MTH_RACE as varchar(300)),
-        cast(MTH_BIRTH_COUNTRY as varchar(300)),
-        NOT_SUBMIT_DT,
-        PAT_REPORTED_AGE,
-        cast(PAT_REPORTED_AGE_UNIT as varchar(300)),
-        cast(PAT_CITY as varchar(50)),
-        cast(PAT_COUNTRY as varchar(300)),
-        cast(PAT_COUNTY as varchar(300)),
-        cast(PAT_CURR_GENDER as varchar(300)),
-        PAT_DOB,
-        cast(PAT_ETHNICITY as varchar(300)),
-        cast(PAT_FIRST_NM as varchar(50)),
-        cast(PAT_LAST_NM as varchar(50)),
-        cast(PAT_LOCAL_ID as varchar(25)),
-        cast(PAT_MIDDLE_NM as varchar(50)),
-        cast(PAT_PREGNANT_IND as varchar(300)),
-        cast(PAT_RACE as varchar(300)),
-        cast(PAT_STATE as varchar(300)),
-        cast(PAT_STREET_ADDR_1 as varchar(50)),
-        cast(PAT_STREET_ADDR_2 as varchar(50)),
-        cast(PAT_ZIP_CODE as varchar(10)),
-        cast(RPT_SRC_SOURCE_NM as varchar(300)),
-        cast(RPT_SRC_STATE as varchar(300)),
-        cast(RPT_SRC_CD_DESC as varchar(300)),
-        cast(BLD_EXPOSURE_IND as varchar(300)),
-        cast(BLD_RECVD_IND as varchar(300)),
-        BLD_RECVD_DT,
-        cast(MED_DEN_BLD_CT_FRQ as varchar(300)),
-        cast(MED_DEN_EMP_EVER_IND as varchar(300)),
-        cast(MED_DEN_EMPLOYEE_IND as varchar(300)),
-        cast(CLOTFACTOR_PRIOR_1987 as varchar(300)),
-        cast(BLD_CONTAM_IND as varchar(300)),
-        cast(DEN_WORK_OR_SURG_IND as varchar(300)),
-        cast(HEMODIALYSIS_IND as varchar(300)),
-        cast(LT_HEMODIALYSIS_IND as varchar(300)),
-        cast(HSPTL_PRIOR_ONSET_IND as varchar(300)),
-        cast(EVER_INJCT_NOPRSC_DRG as varchar(300)),
-        cast(INCAR_24PLUSHRS_IND as varchar(300)),
-        cast(INCAR_6PLUS_MO_IND as varchar(300)),
-        cast(EVER_INCAR_IND as varchar(300)),
-        cast(INCAR_TYPE_JAIL_IND as varchar(300)),
-        cast(INCAR_TYPE_PRISON_IND as varchar(300)),
-        cast(INCAR_TYPE_JUV_IND as varchar(300)),
-        LAST6PLUSMO_INCAR_PER,
-        LAST6PLUSMO_INCAR_YR,
-        cast(OUTPAT_IV_INF_IND as varchar(300)),
-        cast(LTCARE_RESIDENT_IND as varchar(300)),
-        LIFE_SEX_PRTNR_NBR,
-        cast(BLD_EXPOSURE_OTH as varchar(200)),
-        cast(PIERC_PRIOR_ONSET_IND as varchar(300)),
-        cast(PIERC_PERF_LOC_OTH as varchar(150)),
-        cast(PIERC_PERF_LOC as varchar(300)),
-        cast(PUB_SAFETY_BLD_CT_FRQ as varchar(300)),
-        cast(PUB_SAFETY_WORKER_IND as varchar(300)),
-        cast(STD_TREATED_IND as varchar(300)),
-        STD_LAST_TREATMENT_YR,
-        cast(NON_ORAL_SURGERY_IND as varchar(300)),
-        cast(TATT_PRIOR_ONSET_IND as varchar(300)),
-        cast(TATTOO_PERF_LOC as varchar(300)),
-        cast(TATT_PRIOR_LOC_OTH as varchar(150)),
-        cast(BLD_TRANSF_PRIOR_1992 as varchar(300)),
-        cast(ORGN_TRNSP_PRIOR_1992 as varchar(300)),
-        cast(TRANSMISSION_MODE as varchar(300)),
-        cast(HOUSEHOLD_TRAVEL_IND as varchar(300)),
-        cast(TRAVEL_OUT_USACAN_IND as varchar(300)),
-        cast(TRAVEL_OUT_USACAN_LOC as varchar(300)),
-        cast(HOUSEHOLD_TRAVEL_LOC as varchar(300)),
-        cast(TRAVEL_REASON as varchar(300)),
-        cast(IMM_GLOB_RECVD_IND as varchar(300)),
-        GLOB_LAST_RECVD_YR,
-        cast(cast(VACC_RECVD_IND as varchar(10)) as varchar(10)),
-        VACC_DOSE_NBR_1,
-        VACC_RECVD_DT_1,
-        VACC_DOSE_NBR_2,
-        VACC_RECVD_DT_2,
-        VACC_DOSE_NBR_3,
-        VACC_RECVD_DT_3,
-        VACC_DOSE_NBR_4,
-        VACC_RECVD_DT_4,
-        cast(VACC_GT_4_IND as varchar(300)),
-        VACC_DOSE_RECVD_NBR,
-        VACC_LAST_RECVD_YR,
-        cast(ANTI_HBSAG_TESTED_IND as varchar(300)),
-        cast(CONDITION_CD as varchar(300)),
-        EVENT_DATE,
-        cast(IMPORT_FROM_CITY as varchar(300)),
-        cast(IMPORT_FROM_COUNTRY as varchar(300)),
-        cast(IMPORT_FROM_COUNTY as varchar(300)),
-        cast(IMPORT_FROM_STATE as varchar(300)),
-        INVESTIGATION_KEY,
-        cast(INVESTIGATOR_NAME as varchar(300)),
-        cast(PAT_ELECTRONIC_IND as varchar(300)),
-        cast(PHYS_CITY as varchar(300)),
-        cast(PHYS_COUNTY as varchar(300)),
-        cast(PHYS_NAME as varchar(300)),
-        cast(PHYS_STATE as varchar(300)),
-        PROGRAM_JURISDICTION_OID,
-        cast(RPT_SRC_CITY as varchar(300)),
-        cast(RPT_SRC_COUNTY as varchar(300)),
-        cast(RPT_SRC_COUNTY_CD as varchar(300)),
-        PHYSICIAN_UID,
-        PATIENT_UID,
-        CASE_UID,
-        INVESTIGATOR_UID,
-        REPORTING_SOURCE_UID,
-        REFRESH_DATETIME,
-        cast(PAT_BIRTH_COUNTRY as varchar(50))
-FROM #TMP_HEPATITIS_CASE_BASE  TH WITH(NOLOCK)
-WHERE NOT EXISTS
-    (
-    SELECT *
-    FROM [dbo].[HEPATITIS_DATAMART] WITH(NOLOCK)
-    WHERE [CASE_UID] = TH.[CASE_UID] AND
-    [PATIENT_UID] = TH.[PATIENT_UID] AND
-    [INVESTIGATION_KEY] = TH.[INVESTIGATION_KEY]
-    )
-ORDER BY INVESTIGATION_KEY;
-
-if @debug = 'true'
-select * from  #TMP_HEPATITIS_CASE_BASE;
-
-SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-
-INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
-VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
-
-COMMIT TRANSACTION;
-
-
-/*
+            END;
+
+
+        /*
+                                                                                        DATA VAC_REPEAT_OUT_FINAL;
+
+                                                                                        MERGE  VAC_REPEAT_OUT_DATE(IN=in1) VAC_REPEAT_OUT_NUM(IN=in2);
+
+                                                                                        BY D_INVESTIGATION_REPEAT_KEY;
+
+                                                                                        */
+        SELECT DISTINCT
+            D.Page_Case_UId, D.D_INVESTIGATION_REPEAT_KEY, D.INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_RECVD_DT_1, VACC_DOSE_NBR_2, VACC_RECVD_DT_2, VACC_DOSE_NBR_3, VACC_RECVD_DT_3, VACC_DOSE_NBR_4, VACC_RECVD_DT_4, VAC_GT_4_IND, VAC_DOSE_4_IND, CAST(NULL  AS varchar(1000)) AS VACC_GT_4_IND   ---------FinalIndicator
+        INTO #TMP_VAC_REPEAT_OUT_FINAL1
+        FROM #TMP_VAC_REPEAT_OUT_Date_Final AS D
+                 INNER JOIN
+             #TMP_VAC_REPEAT_OUT_NUM_Final AS N
+             ON D.D_INVESTIGATION_REPEAT_KEY = N.D_INVESTIGATION_REPEAT_KEY
+        ORDER BY D.D_INVESTIGATION_REPEAT_KEY;
+
+        UPDATE #TMP_VAC_REPEAT_OUT_FINAL1
+        SET VACC_GT_4_IND = CASE
+            WHEN LEN(RTRIM(VAC_DOSE_4_IND)) > 0 OR
+                 LEN(RTRIM(VAC_GT_4_IND)) > 0 THEN 'True'
+            ELSE NULL
+            END;
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+        --------------------------------------------------26e. CREATE TABLE TMP_VAC_REPEAT_OUT_FINAL--------------------------------------------------------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating TMP_VAC_REPEAT_OUT_FINAL';
+
+        SET @Proc_Step_no = 26;
+
+        ----e
+        IF OBJECT_ID('#TMP_VAC_REPEAT_OUT_FINAL', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_VAC_REPEAT_OUT_FINAL;
+
+            END;
+
+        SELECT Page_Case_UId, D_INVESTIGATION_REPEAT_KEY, INVESTIGATION_KEY, VACC_DOSE_NBR_1, VACC_RECVD_DT_1, VACC_DOSE_NBR_2, VACC_RECVD_DT_2, VACC_DOSE_NBR_3, VACC_RECVD_DT_3, VACC_DOSE_NBR_4, VACC_RECVD_DT_4, VACC_GT_4_IND   ---------FinalIndicator
+        INTO #TMP_VAC_REPEAT_OUT_FINAL
+        FROM #TMP_VAC_REPEAT_OUT_FINAL1;
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+
+        ---------------------------------------------------------Final Table 27 TMP_HEPATITIS_CASE_BASE------------------------------------------------------------------------------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Generating TMP_HEPATITIS_CASE_BASE';
+
+        SET @Proc_Step_no = 27;
+
+        IF OBJECT_ID('#TMP_HEPATITIS_CASE_BASE', 'U') IS NOT NULL
+            BEGIN
+                DROP TABLE #TMP_HEPATITIS_CASE_BASE;
+
+            END;
+
+        SELECT DISTINCT
+            A.INNC_NOTIFICATION_DT, ---1
+            I.CASE_RPT_MMWR_WEEK, ---2
+            I.CASE_RPT_MMWR_YEAR, ----3
+            C.HEP_D_INFECTION_IND, ----4
+            C.HEP_MEDS_RECVD_IND, ----5
+            L.HEP_C_TOTAL_ANTIBODY, ----6
+            I.DIAGNOSIS_DT, ------------7
+            I.DIE_FRM_THIS_ILLNESS_IND, ----8
+            I.DISEASE_IMPORTED_IND, -----9
+            I.EARLIEST_RPT_TO_CNTY, ----10
+            I.EARLIEST_RPT_TO_STATE_DT, ---11
+            RTRIM(LTRIM(SUBSTRING(A.BINATIONAL_RPTNG_CRIT,1,300))) as BINATIONAL_RPTNG_CRIT, ---12
+            E.CHILDCARE_CASE_IND, ---13
+            E.CNTRY_USUAL_RESIDENCE, ---14
+            E.CT_BABYSITTER_IND, ---15
+            E.CT_CHILDCARE_IND, ----16
+            E.CT_HOUSEHOLD_IND, ---17
+            E.HEP_CONTACT_IND, ----18
+            R.HEP_CONTACT_EVER_IND, ----19
+            E.OTHER_CONTACT_IND, ---20
+            ISNULL(NULLIF(E.COM_SRC_OUTBREAK_IND, ''), NULL) AS COM_SRC_OUTBREAK_IND, ---21
+            E.CONTACT_TYPE_OTH, ----22
+            E.CT_PLAYMATE_IND, ----23
+            E.SEXUAL_PARTNER_IND, ----24
+            E.DNP_HOUSEHOLD_CT_IND, ---25
+            E.HEP_A_EPLINK_IND, ----25
+            E.FEMALE_SEX_PRTNR_NBR, ---27
+            E.FOODHNDLR_PRIOR_IND, ----28
+            ISNULL(NULLIF(E.DNP_EMPLOYEE_IND, ''), NULL) AS DNP_EMPLOYEE_IND, -----29
+            ISNULL(NULLIF(E.STREET_DRUG_INJECTED, ''), NULL) AS STREET_DRUG_INJECTED, -----30
+            ISNULL(NULLIF(E.MALE_SEX_PRTNR_NBR, ''), NULL) AS MALE_SEX_PRTNR_NBR, ----31
+            I.OUTBREAK_IND, -----32
+            ISNULL(NULLIF(E.OBRK_FOODHNDLR_IND, ''), NULL) AS OBRK_FOODHNDLR_IND, ----33
+            ISNULL(NULLIF(E.FOOD_OBRK_FOOD_ITEM, ''), NULL) AS FOOD_OBRK_FOOD_ITEM, ----34
+            ISNULL(NULLIF(E.OBRK_NOFOODHNDLR_IND, ''), NULL) AS OBRK_NOFOODHNDLR_IND, ----35
+            ISNULL(NULLIF(E.OBRK_UNIDENTIFIED_IND, ''), NULL) AS OBRK_UNIDENTIFIED_IND, ----36
+            ISNULL(NULLIF(E.OBRK_WATERBORNE_IND, ''), NULL) AS OBRK_WATERBORNE_IND, ----37
+            ISNULL(NULLIF(E.STREET_DRUG_USED, ''), NULL) AS STREET_DRUG_USED, ---38
+            PO.SEX_PREF, ----39
+            I.HSPTL_ADMISSION_DT, ----40
+            I.HSPTL_DISCHARGE_DT, ----41
+            I.HSPTL_DURATION_DAYS, ----42
+            I.HSPTLIZD_IND, ---43
+            I.ILLNESS_ONSET_DT, ----44
+            I.INV_CASE_STATUS, ----45
+            ----	ltrim(rtrim(I.INV_COMMENTS)) as INV_COMMENTS,----46--------7/21/2021
+            LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE([INV_COMMENTS], CHAR(10), CHAR(32)), CHAR(13), CHAR(32)), CHAR(160), CHAR(32)), CHAR(9), CHAR(32)))) AS INV_COMMENTS, ----46--------7/21/2021
+            I.INV_LOCAL_ID, ---47
+            I.INV_RPT_DT, ---48
+            I.INV_START_DT, ---49
+            I.INVESTIGATION_STATUS, ---50
+            I.JURISDICTION_NM, ---51
+            L.ALT_SGPT_RESULT, ----52
+            L.ANTI_HBS_POS_REAC_IND, -----53
+            L.AST_SGOT_RESULT, ---54
+            L.HEP_E_ANTIGEN, ----55
+            L.HBE_AG_DT, ---56
+            L.HEP_B_SURFACE_ANTIGEN, ----57
+            L.HBS_AG_DT, ----58
+            L.HEP_B_DNA, -----59
+            L.HBV_NAT_DT, ----60
+            L.HCV_RNA, ----61
+            L.HCV_RNA_DT, ----62
+            L.HEP_D_TEST_IND, ----63
+            L.HEP_A_IGM_ANTIBODY, ----64
+            L.IGM_ANTI_HAV_DT, ----65
+            L.HEP_B_IGM_ANTIBODY, ----66
+            L.IGM_ANTI_HBC_DT, ----67
+            L.PREV_NEG_HEP_TEST_IND, ------68
+            L.ANTIHCV_SIGCUT_RATIO, ----69
+            L.ANTIHCV_SUPP_ASSAY, -----70
+            L.SUPP_ANTI_HCV_DT, -----71
+            L.ALT_RESULT_DT, ----72
+            L.AST_RESULT_DT, -----73
+            L.ALT_SGPT_RSLT_UP_LMT, ----74
+            L.AST_SGOT_RSLT_UP_LMT, ----75
+            L.HEP_A_TOTAL_ANTIBODY, ----76
+            L.TOTAL_ANTI_HAV_DT, ----77
+            L.HEP_B_TOTAL_ANTIBODY, ----78
+            L.TOTAL_ANTI_HBC_DT, ----79
+            L.TOTAL_ANTI_HCV_DT, ----80
+            L.HEP_D_TOTAL_ANTIBODY, ----81
+            L.TOTAL_ANTI_HDV_DT, ----82
+            L.HEP_E_TOTAL_ANTIBODY, ----83
+            L.TOTAL_ANTI_HEV_DT, ----84
+            L.VERIFIED_TEST_DT, ----85
+            I.LEGACY_CASE_ID, ---86
+            MH.DIABETES_IND, ----87
+            MH.DIABETES_DX_DT, ----88
+            MH.PREGNANCY_DUE_DT, ----89
+            MH.PAT_JUNDICED_IND, -----90
+            MH.PAT_PREV_AWARE_IND, ----91
+            MH.HEP_CARE_PROVIDER, ----92
+            MH.TEST_REASON, ------93
+            RTRIM(LTRIM(SUBSTRING(MH.TEST_REASON_OTH,1,150))) as TEST_REASON_OTH, -----94----10/18/2021 added the trim since the dest has only 150 length
+            MH.SYMPTOMATIC_IND, -----95
+            M.MTH_BORN_OUTSIDE_US, ---96
+            M.MTH_ETHNICITY, ------97
+            M.MTH_HBS_AG_PRIOR_POS, ----98
+            M.MTH_POS_AFTER, ------99
+            M.MTH_POS_TEST_DT, ----100
+            M.MTH_RACE, -----101
+            M.MTH_BIRTH_COUNTRY, ----102
+            I.NOT_SUBMIT_DT, ----103
+            P.PAT_REPORTED_AGE, ----104
+            P.PAT_REPORTED_AGE_UNIT, ----105
+            P.PAT_CITY, ----106
+            P.PAT_COUNTRY, ----107
+            P.PAT_COUNTY, ----108
+            P.PAT_CURR_GENDER, ---109
+            P.PAT_DOB, ---110
+            LTRIM(RTRIM(P.PAT_ETHNICITY)) AS PAT_ETHNICITY, ---111
+            P.PAT_FIRST_NM, ---112
+            P.PAT_LAST_NM, ---113
+            P.PAT_LOCAL_ID, ---114
+            P.PAT_MIDDLE_NM, ---115
+            I.PAT_PREGNANT_IND, ---116
+            P.PAT_RACE, ----117
+            P.PAT_STATE, ----118
+            LTRIM(RTRIM(P.PAT_STREET_ADDR_1)) AS PAT_STREET_ADDR_1, ---119-------------------7/14/2021
+            P.PAT_STREET_ADDR_2, ----120
+            P.PAT_ZIP_CODE, ----121
+            HP.RPT_SRC_SOURCE_NM, ----122
+            HP.RPT_SRC_STATE, ----123
+            I.RPT_SRC_CD_DESC, ---124
+            R.BLD_EXPOSURE_IND, ----125
+            R.BLD_RECVD_IND, ----126
+            R.BLD_RECVD_DT, ----127
+            R.MED_DEN_BLD_CT_FRQ, ----128
+            R.MED_DEN_EMP_EVER_IND, ----129
+            R.MED_DEN_EMPLOYEE_IND, ---130
+            R.CLOTFACTOR_PRIOR_1987, ----131
+            R.BLD_CONTAM_IND, ------132
+            R.DEN_WORK_OR_SURG_IND, ----133
+            R.HEMODIALYSIS_IND, ----134
+            R.LT_HEMODIALYSIS_IND, -----135
+            R.HSPTL_PRIOR_ONSET_IND, ----136
+            R.EVER_INJCT_NOPRSC_DRG, -----137
+            R.INCAR_24PLUSHRS_IND, ---138
+            R.INCAR_6PLUS_MO_IND, ---139
+            R.EVER_INCAR_IND, ----140
+            R.INCAR_TYPE_JAIL_IND, ----141
+            R.INCAR_TYPE_PRISON_IND, ----142
+            R.INCAR_TYPE_JUV_IND, ----143
+            R.LAST6PLUSMO_INCAR_PER, ----144
+            R.LAST6PLUSMO_INCAR_YR, ----145
+            R.OUTPAT_IV_INF_IND, ----146
+            R.LTCARE_RESIDENT_IND, ----147
+            R.LIFE_SEX_PRTNR_NBR, ----148
+            R.BLD_EXPOSURE_OTH, ----149
+            R.PIERC_PRIOR_ONSET_IND, ----150
+            R.PIERC_PERF_LOC_OTH, ----151
+            R.PIERC_PERF_LOC, -----152
+            R.PUB_SAFETY_BLD_CT_FRQ, ----153
+            R.PUB_SAFETY_WORKER_IND, ----154
+            R.STD_TREATED_IND, ----155
+            R.STD_LAST_TREATMENT_YR, ---156
+            R.NON_ORAL_SURGERY_IND, ---157
+            R.TATT_PRIOR_ONSET_IND, ---158
+            R.TATTOO_PERF_LOC, ----158
+            R.TATT_PRIOR_LOC_OTH, ----160
+            R.BLD_TRANSF_PRIOR_1992, ---161
+            R.ORGN_TRNSP_PRIOR_1992, ----162
+            I.TRANSMISSION_MODE, ----163
+            T.HOUSEHOLD_TRAVEL_IND, ----164
+            T.TRAVEL_OUT_USACAN_IND, ----165
+            T.TRAVEL_OUT_USACAN_LOC, -----166
+            T.HOUSEHOLD_TRAVEL_LOC, ----167
+            T.TRAVEL_REASON, -----168
+            V.IMM_GLOB_RECVD_IND, ----169
+            V.GLOB_LAST_RECVD_YR, ----170
+            V.VACC_RECVD_IND, ----171-------Has to be 10 digits long
+            VAC.VACC_DOSE_NBR_1, ----172
+            VAC.VACC_RECVD_DT_1, ----173
+            VAC.VACC_DOSE_NBR_2, ----174
+            VAC.VACC_RECVD_DT_2, ----175
+            VAC.VACC_DOSE_NBR_3, ----176
+            VAC.VACC_RECVD_DT_3, -----177
+            VAC.VACC_DOSE_NBR_4, -----178
+            VAC.VACC_RECVD_DT_4, ---179
+            VAC.VACC_GT_4_IND, -----180
+            V.VACC_DOSE_RECVD_NBR, ----181
+            V.VACC_LAST_RECVD_YR, -----182
+            L.ANTI_HBSAG_TESTED_IND, ----183
+            I.CONDITION_CD, -----184
+            CAST(NULL AS datetime) AS EVENT_DATE, ----185
+            I.IMPORT_FROM_CITY, ----186
+            I.IMPORT_FROM_COUNTRY, ----187
+            I.IMPORT_FROM_COUNTY, ----188
+            I.IMPORT_FROM_STATE, ----189
+            I.INVESTIGATION_KEY, -----190
+            HP.INVESTIGATOR_NAME, -----191
+            P.PAT_ELECTRONIC_IND, ----192
+            HP.PHYS_CITY, ----193
+            HP.PHYS_COUNTY, ----194
+            HP.PHYS_NAME, ----195
+            HP.PHYS_STATE, ----196
+            I.PROGRAM_JURISDICTION_OID, ----197
+            HP.RPT_SRC_CITY, ---198
+            HP.RPT_SRC_COUNTY, ----199
+            HP.RPT_SRC_COUNTY_CD, ---200
+            HP.PHYSICIAN_UID, ----201
+            P.PATIENT_UID, ----202
+            I.CASE_UID, ---203
+            HP.INVESTIGATOR_UID, ---204
+            HP.REPORTING_SOURCE_UID, ---205
+            CAST(NULL AS datetime) AS REFRESH_DATETIME, ---206
+            P.PAT_BIRTH_COUNTRY,----207
+            CAST(NULL AS varchar(2000)) AS EVENT_DATE_TYPE
+        INTO #TMP_HEPATITIS_CASE_BASE
+        FROM #TMP_Investigation AS I WITH(NOLOCK)
+                 FULL OUTER JOIN  #TMP_D_INV_LAB_FINDING AS L WITH(NOLOCK)  ON I.INVESTIGATION_KEY = L.LAB_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_RISK_FACTOR AS R WITH(NOLOCK)  ON I.INVESTIGATION_KEY = R.RISK_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_EPIDEMIOLOGY AS E WITH(NOLOCK) ON I.INVESTIGATION_KEY = E.EPIDEMIOLOGY_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_Patient AS P WITH(NOLOCK)          ON I.INVESTIGATION_KEY = P.Patient_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_VACCINATION AS V WITH(NOLOCK)  ON I.INVESTIGATION_KEY = V.VACCINATION_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_TRAVEL AS T WITH(NOLOCK)  ON I.INVESTIGATION_KEY = T.Travel_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_MOTHER AS M WITH(NOLOCK)  ON I.INVESTIGATION_KEY = M.Mother_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_MEDICAL_HISTORY AS MH WITH(NOLOCK)  ON I.INVESTIGATION_KEY = MH.MEDHistory_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_ADMINISTRATIVE AS A WITH(NOLOCK)  ON I.INVESTIGATION_KEY = A.ADMIN_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_PATIENT_OBS AS PO WITH(NOLOCK)  ON I.INVESTIGATION_KEY = PO.PATIENT_OBS_INV_KEY
+                 FULL OUTER JOIN  #TMP_HEP_PAT_PROV AS HP WITH(NOLOCK)  ON I.INVESTIGATION_KEY = HP.HEP_PAT_PROV_INV_KEY
+                 FULL OUTER JOIN  #TMP_D_INV_CLINICAL AS C WITH(NOLOCK)  ON I.INVESTIGATION_KEY = C.CLINICAL_INV_KEY
+                 FULL OUTER JOIN  #TMP_VAC_REPEAT_OUT_FINAL AS VAC WITH(NOLOCK)  ON I.INVESTIGATION_KEY = VAC.INVESTIGATION_KEY
+        ;
+
+
+        if @debug = 'true' select * from #TMP_HEPATITIS_CASE_BASE;
+
+
+
+        ---7/14/2021(since getting error converting varchar to int)
+        UPDATE #TMP_HEPATITIS_CASE_BASE
+        SET LAST6PLUSMO_INCAR_PER = CASE
+            WHEN LAST6PLUSMO_INCAR_PER NOT LIKE N'%[^0-9.,-]%' AND
+                 LAST6PLUSMO_INCAR_PER NOT LIKE '.' AND
+                 ISNUMERIC(LAST6PLUSMO_INCAR_PER) = 1 THEN LAST6PLUSMO_INCAR_PER
+            ELSE 0
+            END
+        where LAST6PLUSMO_INCAR_PER is not null
+        ;
+
+
+        ------------  /*EXT_LAST6PLUSMO_INCAR_PER= INPUT(RSK_IncarcTimeMonths, comma20.)*/----20
+        UPDATE #TMP_HEPATITIS_CASE_BASE
+        SET LAST6PLUSMO_INCAR_YR = CASE
+            WHEN LAST6PLUSMO_INCAR_YR NOT LIKE N'%[^0-9.,-]%' AND
+                 LAST6PLUSMO_INCAR_YR NOT LIKE '.' AND
+                 ISNUMERIC(LAST6PLUSMO_INCAR_YR) = 1 THEN LAST6PLUSMO_INCAR_YR
+            ELSE 0
+            END
+        where LAST6PLUSMO_INCAR_YR is not null
+        ;
+
+        ------------  /*EXT_LAST6PLUSMO_INCAR_PER= INPUT(RSK_IncarcTimeMonths, comma20.)*/----20
+        UPDATE #TMP_HEPATITIS_CASE_BASE
+        SET VACC_GT_4_IND = CASE
+            WHEN LEN(ISNULL(RTRIM(LTRIM(VACC_GT_4_IND)), '')) < 1 THEN 'False'
+            ELSE VACC_GT_4_IND
+            END;
+
+
+        /*proc sql;
+
+                                                                                            DELETE from HEPATITIS_CASE_BASE where patient_uid is null;
+
+                                                                                            quit;
+
+        */
+        DELETE FROM #TMP_HEPATITIS_CASE_BASE
+        WHERE PATIENT_UID IS NULL;
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+        ------------------------------------------------------------------------------------------------------------------------------------------------------
+        UPDATE #TMP_HEPATITIS_CASE_BASE
+        SET REFRESH_DATETIME = GETDATE();
+
+        /*------------------
+               /* Note = FIRST_RPT_TO_CNTY_DT   is EARLIEST_RPT_TO_CNTY */
+               ----1.---HSPTL_DISCHARGE_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = HSPTL_DISCHARGE_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > HSPTL_DISCHARGE_DT AND
+                     HSPTL_DISCHARGE_DT IS NOT NULL;
+
+
+               ----2.---- HSPTL_ADMISSION_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = HSPTL_ADMISSION_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > HSPTL_ADMISSION_DT AND
+                     HSPTL_ADMISSION_DT IS NOT NULL;
+
+
+               ----3. ---AST_RESULT_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = AST_RESULT_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > AST_RESULT_DT AND
+                     AST_RESULT_DT IS NOT NULL;
+
+
+               ----4.---ALT_RESULT_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = ALT_RESULT_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > ALT_RESULT_DT AND
+                     ALT_RESULT_DT IS NOT NULL;
+
+
+               ----5.--- INV_START_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = INV_START_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > INV_START_DT AND
+                     INV_START_DT IS NOT NULL;
+
+
+               ---6.  ---EARLIEST_RPT_TO_STATE_DT
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = EARLIEST_RPT_TO_STATE_DT
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > EARLIEST_RPT_TO_STATE_DT AND
+                     EARLIEST_RPT_TO_STATE_DT IS NOT NULL;
+
+
+               ----7.----EARLIEST_RPT_TO_CNTY
+               UPDATE #TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = EARLIEST_RPT_TO_CNTY
+               WHERE EVENT_DATE IS NULL OR
+                     EVENT_DATE > EARLIEST_RPT_TO_CNTY AND
+                     EARLIEST_RPT_TO_CNTY IS NOT NULL;
+
+
+        /*
+                                                                                                   ----8---INV_RPT_DT
+                                                                                                   UPDATE #TMP_HEPATITIS_CASE_BASE
+                                     SET EVENT_DATE = INV_RPT_DT
+                                                                                                   Where  EVENT_DATE iS NULL or
+                                     EVENT_DATE > INV_RPT_DT AND  INV_RPT_DT IS NOT NULL
+                                                                                                   */
+               ----8.----ILLNESS_ONSET_DT---
+               UPDATE TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = DIAGNOSIS_DT
+               WHERE DIAGNOSIS_DT IS NOT NULL;
+
+
+               ----9.----ILLNESS_ONSET_DT---
+               UPDATE TMP_HEPATITIS_CASE_BASE
+                 SET EVENT_DATE = ILLNESS_ONSET_DT
+               WHERE ILLNESS_ONSET_DT IS NOT NULL;
+
+
+               ----10 If all Dates Are Null get the addTime from Investigation Table ---5-19-2021
+               UPDATE TMP_HEPATITIS_CASE_BASE
+                SET EVENT_DATE = ADD_TIME
+               FROM [dbo].[INVESTIGATION] I
+               WHERE Event_Date IS NULL AND
+                     I.INV_LOCAL_ID = TMP_HEPATITIS_CASE_BASE.INV_LOCAL_ID AND
+                     I.[INVESTIGATION_KEY] = TMP_HEPATITIS_CASE_BASE.INVESTIGATION_KEY;
+        */
+
+
+
+
+
+
+
+        ---------------------------------------------------------------
+
+        /*
+
+        IF OBJECT_ID('DBO.TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL
+        DROP TABLE DBO.TEMP_MIN_MAX_NOTIFICATION;
+
+        SELECT DISTINCT MIN(CASE
+                WHEN VERSION_CTRL_NBR = 1
+                    THEN RECORD_STATUS_CD
+                END) AS FIRSTNOTIFICATIONSTATUS
+
+
+        ,MIN(CASE
+                WHEN RECORD_STATUS_CD = 'COMPLETED'
+                    THEN RPT_SENT_TIME
+                END) AS FIRSTNOTIFICATIONSENDDATE
+        ,PUBLIC_HEALTH_CASE_UID
+        INTO DBO.TEMP_MIN_MAX_NOTIFICATION
+        FROM DBO.TEMP_HEP_NOTIFICATION WITH (NOLOCK)
+        GROUP BY PUBLIC_HEALTH_CASE_UID
+        ;
+        */
+
+        ------------------------------------------------------------------------------------------------------
+        ----HEP_D_TEST_IND  to appear as N,Y U or Null--added on 5-19-2021
+        UPDATE #TMP_HEPATITIS_CASE_BASE ----5/20-2021
+        SET HEP_D_TEST_IND = CASE
+            WHEN HEP_D_TEST_IND IS NULL THEN NULL
+            WHEN HEP_D_TEST_IND = 'Yes' THEN 'Y'
+            WHEN HEP_D_TEST_IND = 'No' THEN 'N'
+            ELSE 'U'
+            END;
+
+
+        ---------------------------------------------------------Final Table 28 TMP_HEPATITIS_CASE_BASE------------------------------------------------------------------------------------------------
+        BEGIN TRANSACTION;
+
+        SET @Proc_Step_name = 'Updating HEPATITIS_CASE_BASE';
+
+        SET @Proc_Step_no = 28;
+
+        UPDATE [dbo].[HEPATITIS_DATAMART]
+        SET INNC_NOTIFICATION_DT = H.[INNC_NOTIFICATION_DT], CASE_RPT_MMWR_WEEK = H.[CASE_RPT_MMWR_WEEK], CASE_RPT_MMWR_YEAR = H.[CASE_RPT_MMWR_YEAR], HEP_D_INFECTION_IND = H.[HEP_D_INFECTION_IND], HEP_MEDS_RECVD_IND = H.[HEP_MEDS_RECVD_IND], HEP_C_TOTAL_ANTIBODY = H.[HEP_C_TOTAL_ANTIBODY], DIAGNOSIS_DT = H.[DIAGNOSIS_DT], DIE_FRM_THIS_ILLNESS_IND = H.[DIE_FRM_THIS_ILLNESS_IND], DISEASE_IMPORTED_IND = H.[DISEASE_IMPORTED_IND], EARLIEST_RPT_TO_CNTY = H.[EARLIEST_RPT_TO_CNTY], EARLIEST_RPT_TO_STATE_DT = H.[EARLIEST_RPT_TO_STATE_DT], BINATIONAL_RPTNG_CRIT = H.[BINATIONAL_RPTNG_CRIT], CHILDCARE_CASE_IND = H.[CHILDCARE_CASE_IND], CNTRY_USUAL_RESIDENCE = H.[CNTRY_USUAL_RESIDENCE], CT_BABYSITTER_IND = H.[CT_BABYSITTER_IND], CT_CHILDCARE_IND = H.[CT_CHILDCARE_IND], CT_HOUSEHOLD_IND = H.[CT_HOUSEHOLD_IND], HEP_CONTACT_IND = H.[HEP_CONTACT_IND], HEP_CONTACT_EVER_IND = H.[HEP_CONTACT_EVER_IND], OTHER_CONTACT_IND = H.[OTHER_CONTACT_IND], COM_SRC_OUTBREAK_IND = H.[COM_SRC_OUTBREAK_IND], CONTACT_TYPE_OTH = H.[CONTACT_TYPE_OTH], CT_PLAYMATE_IND = H.[CT_PLAYMATE_IND], SEXUAL_PARTNER_IND = H.[SEXUAL_PARTNER_IND], DNP_HOUSEHOLD_CT_IND = H.[DNP_HOUSEHOLD_CT_IND], HEP_A_EPLINK_IND = H.[HEP_A_EPLINK_IND], FEMALE_SEX_PRTNR_NBR = H.[FEMALE_SEX_PRTNR_NBR], FOODHNDLR_PRIOR_IND = H.[FOODHNDLR_PRIOR_IND], DNP_EMPLOYEE_IND = H.[DNP_EMPLOYEE_IND], STREET_DRUG_INJECTED = H.[STREET_DRUG_INJECTED], MALE_SEX_PRTNR_NBR = H.[MALE_SEX_PRTNR_NBR], OUTBREAK_IND = H.[OUTBREAK_IND], OBRK_FOODHNDLR_IND = H.[OBRK_FOODHNDLR_IND], FOOD_OBRK_FOOD_ITEM = H.[FOOD_OBRK_FOOD_ITEM], OBRK_NOFOODHNDLR_IND = H.[OBRK_NOFOODHNDLR_IND], OBRK_UNIDENTIFIED_IND = H.[OBRK_UNIDENTIFIED_IND], OBRK_WATERBORNE_IND = H.[OBRK_WATERBORNE_IND], STREET_DRUG_USED = H.[STREET_DRUG_USED],
+            SEX_PREF = H.[SEX_PREF], HSPTL_ADMISSION_DT = H.[HSPTL_ADMISSION_DT], HSPTL_DISCHARGE_DT = H.[HSPTL_DISCHARGE_DT], HSPTL_DURATION_DAYS = H.[HSPTL_DURATION_DAYS], HSPTLIZD_IND = H.[HSPTLIZD_IND], ILLNESS_ONSET_DT = H.[ILLNESS_ONSET_DT], INV_CASE_STATUS = H.[INV_CASE_STATUS], INV_COMMENTS = H.[INV_COMMENTS], INV_LOCAL_ID = H.[INV_LOCAL_ID], INV_RPT_DT = H.[INV_RPT_DT], INV_START_DT = H.[INV_START_DT], INVESTIGATION_STATUS = H.[INVESTIGATION_STATUS], JURISDICTION_NM = H.[JURISDICTION_NM], ALT_SGPT_RESULT = H.[ALT_SGPT_RESULT], ANTI_HBS_POS_REAC_IND = H.[ANTI_HBS_POS_REAC_IND], AST_SGOT_RESULT = H.[AST_SGOT_RESULT], HEP_E_ANTIGEN = H.[HEP_E_ANTIGEN], HBE_AG_DT = H.[HBE_AG_DT], HEP_B_SURFACE_ANTIGEN = H.[HEP_B_SURFACE_ANTIGEN], HBS_AG_DT = H.[HBS_AG_DT], HBV_NAT_DT = H.[HBV_NAT_DT], HCV_RNA = H.[HCV_RNA],
+            HCV_RNA_DT = H.[HCV_RNA_DT], HEP_D_TEST_IND = H.[HEP_D_TEST_IND], HEP_A_IGM_ANTIBODY = H.[HEP_A_IGM_ANTIBODY], IGM_ANTI_HAV_DT = H.[IGM_ANTI_HAV_DT], HEP_B_IGM_ANTIBODY = H.[HEP_B_IGM_ANTIBODY], IGM_ANTI_HBC_DT = H.[IGM_ANTI_HBC_DT], PREV_NEG_HEP_TEST_IND = H.[PREV_NEG_HEP_TEST_IND], ANTIHCV_SIGCUT_RATIO = H.[ANTIHCV_SIGCUT_RATIO], ANTIHCV_SUPP_ASSAY = H.[ANTIHCV_SUPP_ASSAY], SUPP_ANTI_HCV_DT = H.[SUPP_ANTI_HCV_DT], ALT_RESULT_DT = H.[ALT_RESULT_DT], AST_RESULT_DT = H.[AST_RESULT_DT], ALT_SGPT_RSLT_UP_LMT = H.[ALT_SGPT_RSLT_UP_LMT], AST_SGOT_RSLT_UP_LMT = H.[AST_SGOT_RSLT_UP_LMT], HEP_A_TOTAL_ANTIBODY = H.[HEP_A_TOTAL_ANTIBODY], TOTAL_ANTI_HAV_DT = H.[TOTAL_ANTI_HAV_DT], HEP_B_TOTAL_ANTIBODY = H.[HEP_B_TOTAL_ANTIBODY], TOTAL_ANTI_HBC_DT = H.[TOTAL_ANTI_HBC_DT], TOTAL_ANTI_HCV_DT = H.[TOTAL_ANTI_HCV_DT],
+            HEP_D_TOTAL_ANTIBODY = H.[HEP_D_TOTAL_ANTIBODY], TOTAL_ANTI_HDV_DT = H.[TOTAL_ANTI_HDV_DT], HEP_E_TOTAL_ANTIBODY = H.[HEP_E_TOTAL_ANTIBODY], TOTAL_ANTI_HEV_DT = H.[TOTAL_ANTI_HEV_DT], VERIFIED_TEST_DT = H.[VERIFIED_TEST_DT], LEGACY_CASE_ID = H.[LEGACY_CASE_ID], DIABETES_IND = H.[DIABETES_IND], DIABETES_DX_DT = H.[DIABETES_DX_DT], PREGNANCY_DUE_DT = H.[PREGNANCY_DUE_DT], PAT_JUNDICED_IND = H.[PAT_JUNDICED_IND], PAT_PREV_AWARE_IND = H.[PAT_PREV_AWARE_IND], HEP_CARE_PROVIDER = H.[HEP_CARE_PROVIDER], TEST_REASON = H.[TEST_REASON], TEST_REASON_OTH = H.[TEST_REASON_OTH], SYMPTOMATIC_IND = H.[SYMPTOMATIC_IND], MTH_BORN_OUTSIDE_US = H.[MTH_BORN_OUTSIDE_US], MTH_ETHNICITY = H.[MTH_ETHNICITY], MTH_HBS_AG_PRIOR_POS = H.[MTH_HBS_AG_PRIOR_POS], MTH_POS_AFTER = H.[MTH_POS_AFTER], MTH_POS_TEST_DT = H.[MTH_POS_TEST_DT], MTH_RACE = H.[MTH_RACE], MTH_BIRTH_COUNTRY = H.[MTH_BIRTH_COUNTRY], NOT_SUBMIT_DT = H.[NOT_SUBMIT_DT], PAT_REPORTED_AGE = H.[PAT_REPORTED_AGE], PAT_REPORTED_AGE_UNIT = H.[PAT_REPORTED_AGE_UNIT], PAT_CITY = H.[PAT_CITY], PAT_COUNTRY = H.[PAT_COUNTRY], PAT_COUNTY = H.[PAT_COUNTY], PAT_CURR_GENDER = H.[PAT_CURR_GENDER], PAT_DOB = H.[PAT_DOB], PAT_ETHNICITY = H.[PAT_ETHNICITY], PAT_FIRST_NM = H.[PAT_FIRST_NM], PAT_LAST_NM = H.[PAT_LAST_NM], PAT_LOCAL_ID = H.[PAT_LOCAL_ID], PAT_MIDDLE_NM = H.[PAT_MIDDLE_NM], PAT_PREGNANT_IND = H.[PAT_PREGNANT_IND], PAT_RACE = H.[PAT_RACE], PAT_STATE = H.[PAT_STATE], PAT_STREET_ADDR_1 = H.[PAT_STREET_ADDR_1], PAT_STREET_ADDR_2 = H.[PAT_STREET_ADDR_2], PAT_ZIP_CODE = H.[PAT_ZIP_CODE], RPT_SRC_SOURCE_NM = H.[RPT_SRC_SOURCE_NM], RPT_SRC_STATE = H.[RPT_SRC_STATE], RPT_SRC_CD_DESC = H.[RPT_SRC_CD_DESC], BLD_EXPOSURE_IND = H.[BLD_EXPOSURE_IND], BLD_RECVD_IND = H.[BLD_RECVD_IND], BLD_RECVD_DT = H.[BLD_RECVD_DT], MED_DEN_BLD_CT_FRQ = H.[MED_DEN_BLD_CT_FRQ], MED_DEN_EMPLOYEE_IND = H.[MED_DEN_EMPLOYEE_IND], MED_DEN_EMP_EVER_IND = H.[MED_DEN_EMP_EVER_IND], CLOTFACTOR_PRIOR_1987 = H.[CLOTFACTOR_PRIOR_1987], BLD_CONTAM_IND = H.[BLD_CONTAM_IND], DEN_WORK_OR_SURG_IND = H.[DEN_WORK_OR_SURG_IND], HEMODIALYSIS_IND = H.[HEMODIALYSIS_IND], LT_HEMODIALYSIS_IND = H.[LT_HEMODIALYSIS_IND], HSPTL_PRIOR_ONSET_IND = H.[HSPTL_PRIOR_ONSET_IND], EVER_INJCT_NOPRSC_DRG = H.[EVER_INJCT_NOPRSC_DRG], INCAR_24PLUSHRS_IND = H.[INCAR_24PLUSHRS_IND], INCAR_6PLUS_MO_IND = H.[INCAR_6PLUS_MO_IND], EVER_INCAR_IND = H.[EVER_INCAR_IND], INCAR_TYPE_JAIL_IND = H.[INCAR_TYPE_JAIL_IND], INCAR_TYPE_PRISON_IND = H.[INCAR_TYPE_PRISON_IND],
+            INCAR_TYPE_JUV_IND = H.[INCAR_TYPE_JUV_IND], LAST6PLUSMO_INCAR_PER = H.[LAST6PLUSMO_INCAR_PER], LAST6PLUSMO_INCAR_YR = H.[LAST6PLUSMO_INCAR_YR], OUTPAT_IV_INF_IND = H.[OUTPAT_IV_INF_IND], LTCARE_RESIDENT_IND = H.[LTCARE_RESIDENT_IND], LIFE_SEX_PRTNR_NBR = H.[LIFE_SEX_PRTNR_NBR], BLD_EXPOSURE_OTH = H.[BLD_EXPOSURE_OTH], PIERC_PRIOR_ONSET_INd = H.[PIERC_PRIOR_ONSET_IND], PIERC_PERF_LOC_OTH = H.[PIERC_PERF_LOC_OTH], PIERC_PERF_LOC = H.[PIERC_PERF_LOC], PUB_SAFETY_BLD_CT_FRQ = H.[PUB_SAFETY_BLD_CT_FRQ], PUB_SAFETY_WORKER_IND = H.[PUB_SAFETY_WORKER_IND], STD_TREATED_IND = H.[STD_TREATED_IND], STD_LAST_TREATMENT_YR = H.[STD_LAST_TREATMENT_YR], NON_ORAL_SURGERY_IND = H.[NON_ORAL_SURGERY_IND], TATT_PRIOR_ONSET_IND = H.[TATT_PRIOR_ONSET_IND], TATTOO_PERF_LOC = H.[TATTOO_PERF_LOC], TATT_PRIOR_LOC_OTH = H.[TATT_PRIOR_LOC_OTH], BLD_TRANSF_PRIOR_1992 = H.[BLD_TRANSF_PRIOR_1992], ORGN_TRNSP_PRIOR_1992 = H.[ORGN_TRNSP_PRIOR_1992], TRANSMISSION_MODE = H.[TRANSMISSION_MODE], HOUSEHOLD_TRAVEL_IND = H.[HOUSEHOLD_TRAVEL_IND], TRAVEL_OUT_USACAN_IND = H.[TRAVEL_OUT_USACAN_IND], TRAVEL_OUT_USACAN_LOC = H.[TRAVEL_OUT_USACAN_LOC], HOUSEHOLD_TRAVEL_LOC = H.[HOUSEHOLD_TRAVEL_LOC], TRAVEL_REASON = H.[TRAVEL_REASON], IMM_GLOB_RECVD_IND = H.[IMM_GLOB_RECVD_IND], GLOB_LAST_RECVD_YR = H.[GLOB_LAST_RECVD_YR], VACC_RECVD_IND = H.[VACC_RECVD_IND], VACC_DOSE_NBR_1 = H.[VACC_DOSE_NBR_1], VACC_RECVD_DT_1 = H.[VACC_RECVD_DT_1], VACC_DOSE_NBR_2 = H.[VACC_DOSE_NBR_2], VACC_RECVD_DT_2 = H.[VACC_RECVD_DT_2], VACC_DOSE_NBR_3 = H.[VACC_DOSE_NBR_3], VACC_RECVD_DT_3 = H.[VACC_RECVD_DT_3], VACC_DOSE_NBR_4 = H.[VACC_DOSE_NBR_4], VACC_RECVD_DT_4 = H.[VACC_RECVD_DT_4], VACC_GT_4_IND = H.[VACC_GT_4_IND], VACC_DOSE_RECVD_NBR = H.[VACC_DOSE_RECVD_NBR], VACC_LAST_RECVD_YR = H.[VACC_LAST_RECVD_YR], ANTI_HBSAG_TESTED_IND = H.[ANTI_HBSAG_TESTED_IND], CONDITION_CD = H.[CONDITION_CD], EVENT_DATE = H.[EVENT_DATE], IMPORT_FROM_CITY = H.[IMPORT_FROM_CITY], IMPORT_FROM_COUNTRY = H.[IMPORT_FROM_COUNTRY], IMPORT_FROM_COUNTY = H.[IMPORT_FROM_COUNTY], IMPORT_FROM_STATE = H.[IMPORT_FROM_STATE], INVESTIGATION_KEY = H.[INVESTIGATION_KEY], INVESTIGATOR_NAME = H.[INVESTIGATOR_NAME], PAT_ELECTRONIC_IND = H.[PAT_ELECTRONIC_IND], PHYS_CITY = H.[PHYS_CITY], PHYS_COUNTY = H.[PHYS_COUNTY], PHYS_NAME = H.[PHYS_NAME], PHYS_STATE = H.[PHYS_STATE], PROGRAM_JURISDICTION_OID = H.[PROGRAM_JURISDICTION_OID], RPT_SRC_CITY = H.[RPT_SRC_CITY], RPT_SRC_COUNTY = H.[RPT_SRC_COUNTY], RPT_SRC_COUNTY_CD = H.[RPT_SRC_COUNTY_CD], PHYSICIAN_UID = H.[PHYSICIAN_UID], PATIENT_UID = H.[PATIENT_UID], CASE_UID = H.[CASE_UID], INVESTIGATOR_UID = H.[INVESTIGATOR_UID], REPORTING_SOURCE_UID = H.[REPORTING_SOURCE_UID], REFRESH_DATETIME = H.[REFRESH_DATETIME], PAT_BIRTH_COUNTRY = H.[PAT_BIRTH_COUNTRY]
+        FROM #TMP_HEPATITIS_CASE_BASE H WITH(NOLOCK)
+        WHERE H.[CASE_UID] = [dbo].[HEPATITIS_DATAMART].[CASE_UID] AND
+            H.[PATIENT_UID] = [dbo].[HEPATITIS_DATAMART].[PATIENT_UID] AND
+            H.[INVESTIGATION_KEY] = [dbo].[HEPATITIS_DATAMART].[INVESTIGATION_KEY];
+
+        COMMIT TRANSACTION;
+
+
+        --------------------------------------29.-----Final ---Inserting into dbo.HEPATITIS_DATAMART----------------------------------------------
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO = 29;
+
+        SET @PROC_STEP_NAME = 'Inserting new entries dbo.HEPATITIS_DATAMART';
+
+        INSERT INTO dbo.[HEPATITIS_DATAMART]( INNC_NOTIFICATION_DT, ---1
+                                              CASE_RPT_MMWR_WEEK, ---2
+                                              CASE_RPT_MMWR_YEAR, ----3
+                                              HEP_D_INFECTION_IND, ----4
+                                              HEP_MEDS_RECVD_IND, ----5
+                                              HEP_C_TOTAL_ANTIBODY, ----6
+                                              DIAGNOSIS_DT, ------------7
+                                              DIE_FRM_THIS_ILLNESS_IND, ----8
+                                              DISEASE_IMPORTED_IND, -----9
+                                              EARLIEST_RPT_TO_CNTY, ----10
+                                              EARLIEST_RPT_TO_STATE_DT, ---11
+                                              BINATIONAL_RPTNG_CRIT, ---12
+                                              CHILDCARE_CASE_IND, ---13
+                                              CNTRY_USUAL_RESIDENCE, ---14
+                                              CT_BABYSITTER_IND, ---15
+                                              CT_CHILDCARE_IND, ----16
+                                              CT_HOUSEHOLD_IND, ---17
+                                              HEP_CONTACT_IND, ----18
+                                              HEP_CONTACT_EVER_IND, ----19
+                                              OTHER_CONTACT_IND, ---20
+                                              COM_SRC_OUTBREAK_IND, ---21
+                                              CONTACT_TYPE_OTH, ----22
+                                              CT_PLAYMATE_IND, ----23
+                                              SEXUAL_PARTNER_IND, ----24
+                                              DNP_HOUSEHOLD_CT_IND, ---25
+                                              HEP_A_EPLINK_IND, ----25
+                                              FEMALE_SEX_PRTNR_NBR, ---27
+                                              FOODHNDLR_PRIOR_IND, ----28
+                                              DNP_EMPLOYEE_IND, -----29
+                                              STREET_DRUG_INJECTED, -----30
+                                              MALE_SEX_PRTNR_NBR, ----31
+                                              OUTBREAK_IND, -----32
+                                              OBRK_FOODHNDLR_IND, ----33
+                                              FOOD_OBRK_FOOD_ITEM, ----34
+                                              OBRK_NOFOODHNDLR_IND, ----35
+                                              OBRK_UNIDENTIFIED_IND, ----36
+                                              OBRK_WATERBORNE_IND, ----37
+                                              STREET_DRUG_USED, ---38
+                                              SEX_PREF, ----39
+                                              HSPTL_ADMISSION_DT, ----40
+                                              HSPTL_DISCHARGE_DT, ----41
+                                              HSPTL_DURATION_DAYS, ----42
+                                              HSPTLIZD_IND, ---43
+                                              ILLNESS_ONSET_DT, ----44
+                                              INV_CASE_STATUS, ----45
+                                              INV_COMMENTS, ----46
+                                              INV_LOCAL_ID, ---47
+                                              INV_RPT_DT, ---48
+                                              INV_START_DT, ---49
+                                              INVESTIGATION_STATUS, ---50
+                                              JURISDICTION_NM, ---51
+                                              ALT_SGPT_RESULT, ----52
+                                              ANTI_HBS_POS_REAC_IND, -----53
+                                              AST_SGOT_RESULT, ---54
+                                              HEP_E_ANTIGEN, ----55
+                                              HBE_AG_DT, ---56
+                                              HEP_B_SURFACE_ANTIGEN, ----57
+                                              HBS_AG_DT, ----58
+                                              HEP_B_DNA, -----59
+                                              HBV_NAT_DT, ----60
+                                              HCV_RNA, ----61
+                                              HCV_RNA_DT, ----62
+                                              HEP_D_TEST_IND, ----63
+                                              HEP_A_IGM_ANTIBODY, ----64
+                                              IGM_ANTI_HAV_DT, ----65
+                                              HEP_B_IGM_ANTIBODY, ----66
+                                              IGM_ANTI_HBC_DT, ----67
+                                              PREV_NEG_HEP_TEST_IND, ------68
+                                              ANTIHCV_SIGCUT_RATIO, ----69
+                                              ANTIHCV_SUPP_ASSAY, -----70
+                                              SUPP_ANTI_HCV_DT, -----71
+                                              ALT_RESULT_DT, ----72
+                                              AST_RESULT_DT, -----73
+                                              ALT_SGPT_RSLT_UP_LMT, ----74
+                                              AST_SGOT_RSLT_UP_LMT, ----75
+                                              HEP_A_TOTAL_ANTIBODY, ----76
+                                              TOTAL_ANTI_HAV_DT, ----77
+                                              HEP_B_TOTAL_ANTIBODY, ----78
+                                              TOTAL_ANTI_HBC_DT, ----79
+                                              TOTAL_ANTI_HCV_DT, ----80
+                                              HEP_D_TOTAL_ANTIBODY, ----81
+                                              TOTAL_ANTI_HDV_DT, ----82
+                                              HEP_E_TOTAL_ANTIBODY, ----83
+                                              TOTAL_ANTI_HEV_DT, ----84
+                                              VERIFIED_TEST_DT, ----85
+                                              LEGACY_CASE_ID, ---86
+                                              DIABETES_IND, ----87
+                                              DIABETES_DX_DT, ----88
+                                              PREGNANCY_DUE_DT, ----89
+                                              PAT_JUNDICED_IND, -----90
+                                              PAT_PREV_AWARE_IND, ----91
+                                              HEP_CARE_PROVIDER, ----92
+                                              TEST_REASON, ------93
+                                              TEST_REASON_OTH, -----94
+                                              SYMPTOMATIC_IND, -----95
+                                              MTH_BORN_OUTSIDE_US, ---96
+                                              MTH_ETHNICITY, ------97
+                                              MTH_HBS_AG_PRIOR_POS, ----98
+                                              MTH_POS_AFTER, ------99
+                                              MTH_POS_TEST_DT, ----100
+                                              MTH_RACE, -----101
+                                              MTH_BIRTH_COUNTRY, ----102
+                                              NOT_SUBMIT_DT, ----103
+                                              PAT_REPORTED_AGE, ----104
+                                              PAT_REPORTED_AGE_UNIT, ----105
+                                              PAT_CITY, ----106
+                                              PAT_COUNTRY, ----107
+                                              PAT_COUNTY, ----108
+                                              PAT_CURR_GENDER, ---109
+                                              PAT_DOB, ---110
+                                              PAT_ETHNICITY, ---111
+                                              PAT_FIRST_NM, ---112
+                                              PAT_LAST_NM, ---113
+                                              PAT_LOCAL_ID, ---114
+                                              PAT_MIDDLE_NM, ---115
+                                              PAT_PREGNANT_IND, ---116
+                                              PAT_RACE, ----117
+                                              PAT_STATE, ----118
+                                              PAT_STREET_ADDR_1, ---119
+                                              PAT_STREET_ADDR_2, ----120
+                                              PAT_ZIP_CODE, ----121
+                                              RPT_SRC_SOURCE_NM, ----122
+                                              RPT_SRC_STATE, ----123
+                                              RPT_SRC_CD_DESC, ---124
+                                              BLD_EXPOSURE_IND, ----125
+                                              BLD_RECVD_IND, ----126
+                                              BLD_RECVD_DT, ----127
+                                              MED_DEN_BLD_CT_FRQ, ----128
+                                              MED_DEN_EMP_EVER_IND, ----129
+                                              MED_DEN_EMPLOYEE_IND, ---130
+                                              CLOTFACTOR_PRIOR_1987, ----131
+                                              BLD_CONTAM_IND, ------132
+                                              DEN_WORK_OR_SURG_IND, ----133
+                                              HEMODIALYSIS_IND, ----134
+                                              LT_HEMODIALYSIS_IND, -----135
+                                              HSPTL_PRIOR_ONSET_IND, ----136
+                                              EVER_INJCT_NOPRSC_DRG, -----137
+                                              INCAR_24PLUSHRS_IND, ---138
+                                              INCAR_6PLUS_MO_IND, ---139
+                                              EVER_INCAR_IND, ----140
+                                              INCAR_TYPE_JAIL_IND, ----141
+                                              INCAR_TYPE_PRISON_IND, ----142
+                                              INCAR_TYPE_JUV_IND, ----143
+                                              LAST6PLUSMO_INCAR_PER, ----144
+                                              LAST6PLUSMO_INCAR_YR, ----145
+                                              OUTPAT_IV_INF_IND, ----146
+                                              LTCARE_RESIDENT_IND, ----147
+                                              LIFE_SEX_PRTNR_NBR, ----148
+                                              BLD_EXPOSURE_OTH, ----149
+                                              PIERC_PRIOR_ONSET_IND, ----150
+                                              PIERC_PERF_LOC_OTH, ----151
+                                              PIERC_PERF_LOC, -----152
+                                              PUB_SAFETY_BLD_CT_FRQ, ----153
+                                              PUB_SAFETY_WORKER_IND, ----154
+                                              STD_TREATED_IND, ----155
+                                              STD_LAST_TREATMENT_YR, ---156
+                                              NON_ORAL_SURGERY_IND, ---157
+                                              TATT_PRIOR_ONSET_IND, ---158
+                                              TATTOO_PERF_LOC, ----158
+                                              TATT_PRIOR_LOC_OTH, ----160
+                                              BLD_TRANSF_PRIOR_1992, ---161
+                                              ORGN_TRNSP_PRIOR_1992, ----162
+                                              TRANSMISSION_MODE, ----163
+                                              HOUSEHOLD_TRAVEL_IND, ----164
+                                              TRAVEL_OUT_USACAN_IND, ----165
+                                              TRAVEL_OUT_USACAN_LOC, -----166
+                                              HOUSEHOLD_TRAVEL_LOC, ----167
+                                              TRAVEL_REASON, -----168
+                                              IMM_GLOB_RECVD_IND, ----169
+                                              GLOB_LAST_RECVD_YR, ----170
+                                              VACC_RECVD_IND, ----171
+                                              VACC_DOSE_NBR_1, ----172
+                                              VACC_RECVD_DT_1, ----173
+                                              VACC_DOSE_NBR_2, ----174
+                                              VACC_RECVD_DT_2, ----175
+                                              VACC_DOSE_NBR_3, ----176
+                                              VACC_RECVD_DT_3, -----177
+                                              VACC_DOSE_NBR_4, -----178
+                                              VACC_RECVD_DT_4, ---179
+                                              VACC_GT_4_IND, -----180
+                                              VACC_DOSE_RECVD_NBR, ----181
+                                              VACC_LAST_RECVD_YR, -----182
+                                              ANTI_HBSAG_TESTED_IND, ----183
+                                              CONDITION_CD, -----184
+                                              EVENT_DATE, ----185
+                                              IMPORT_FROM_CITY, ----186
+                                              IMPORT_FROM_COUNTRY, ----187
+                                              IMPORT_FROM_COUNTY, ----188
+                                              IMPORT_FROM_STATE, ----189
+                                              INVESTIGATION_KEY, -----190
+                                              INVESTIGATOR_NAME, -----191
+                                              PAT_ELECTRONIC_IND, ----192
+                                              PHYS_CITY, ----193
+                                              PHYS_COUNTY, ----194
+                                              PHYS_NAME, ----195
+                                              PHYS_STATE, ----196
+                                              PROGRAM_JURISDICTION_OID, ----197
+                                              RPT_SRC_CITY, ---198
+                                              RPT_SRC_COUNTY, ----199
+                                              RPT_SRC_COUNTY_CD, ---200
+                                              PHYSICIAN_UID, ----201
+                                              PATIENT_UID, ----202
+                                              CASE_UID, ---203
+                                              INVESTIGATOR_UID, ---204
+                                              REPORTING_SOURCE_UID, ---205
+                                              REFRESH_DATETIME, ---206
+                                              PAT_BIRTH_COUNTRY ----207
+        )
+        SELECT  INNC_NOTIFICATION_DT,
+                CASE_RPT_MMWR_WEEK,
+                CASE_RPT_MMWR_YEAR,
+                cast(HEP_D_INFECTION_IND as varchar(300)),
+                cast(HEP_MEDS_RECVD_IND as varchar(300)),
+                cast(HEP_C_TOTAL_ANTIBODY as varchar(300)),
+                DIAGNOSIS_DT,
+                cast(DIE_FRM_THIS_ILLNESS_IND as varchar(300)),
+                cast(DISEASE_IMPORTED_IND as varchar(300)),
+                EARLIEST_RPT_TO_CNTY,
+                EARLIEST_RPT_TO_STATE_DT,
+                cast(BINATIONAL_RPTNG_CRIT as varchar(300)),
+                cast(CHILDCARE_CASE_IND as varchar(300)),
+                cast(CNTRY_USUAL_RESIDENCE as varchar(300)),
+                cast(CT_BABYSITTER_IND as varchar(300)),
+                cast(CT_CHILDCARE_IND as varchar(300)),
+                cast(CT_HOUSEHOLD_IND as varchar(300)),
+                cast(HEP_CONTACT_IND as varchar(300)),
+                cast(HEP_CONTACT_EVER_IND as varchar(300)),
+                cast(OTHER_CONTACT_IND as varchar(300)),
+                cast(COM_SRC_OUTBREAK_IND as varchar(300)),
+                cast(CONTACT_TYPE_OTH as varchar(100)),
+                cast(CT_PLAYMATE_IND as varchar(300)),
+                cast(SEXUAL_PARTNER_IND as varchar(300)),
+                cast(DNP_HOUSEHOLD_CT_IND as varchar(300)),
+                cast(HEP_A_EPLINK_IND as varchar(300)),
+                FEMALE_SEX_PRTNR_NBR,
+                cast(FOODHNDLR_PRIOR_IND as varchar(300)),
+                cast(DNP_EMPLOYEE_IND as varchar(300)),
+                cast(STREET_DRUG_INJECTED as varchar(300)),
+                MALE_SEX_PRTNR_NBR,
+                cast(OUTBREAK_IND as varchar(300)),
+                cast(OBRK_FOODHNDLR_IND as varchar(300)),
+                cast(FOOD_OBRK_FOOD_ITEM as varchar(100)),
+                cast(OBRK_NOFOODHNDLR_IND as varchar(300)),
+                cast(OBRK_UNIDENTIFIED_IND as varchar(300)),
+                cast(OBRK_WATERBORNE_IND as varchar(300)),
+                cast(STREET_DRUG_USED as varchar(300)),
+                cast(SEX_PREF as varchar(300)),
+                HSPTL_ADMISSION_DT,
+                HSPTL_DISCHARGE_DT,
+                HSPTL_DURATION_DAYS,
+                cast(HSPTLIZD_IND as varchar(300)),
+                ILLNESS_ONSET_DT,
+                cast(INV_CASE_STATUS as varchar(300)),
+                cast(INV_COMMENTS as varchar(2000)),
+                cast(INV_LOCAL_ID as varchar(25)),
+                INV_RPT_DT,
+                INV_START_DT,
+                cast(INVESTIGATION_STATUS as varchar(300)),
+                cast(JURISDICTION_NM as varchar(300)),
+                ALT_SGPT_RESULT,
+                cast(ANTI_HBS_POS_REAC_IND as varchar(300)),
+                AST_SGOT_RESULT,
+                cast(HEP_E_ANTIGEN as varchar(300)),
+                HBE_AG_DT,
+                cast(HEP_B_SURFACE_ANTIGEN as varchar(300)),
+                HBS_AG_DT,
+                cast(HEP_B_DNA as varchar(300)),
+                HBV_NAT_DT,
+                cast(HCV_RNA as varchar(300)),
+                HCV_RNA_DT,
+                cast(HEP_D_TEST_IND as varchar(300)),
+                cast(HEP_A_IGM_ANTIBODY as varchar(300)),
+                IGM_ANTI_HAV_DT,
+                cast(HEP_B_IGM_ANTIBODY as varchar(300)),
+                IGM_ANTI_HBC_DT,
+                cast(PREV_NEG_HEP_TEST_IND as varchar(300)),
+                cast(ANTIHCV_SIGCUT_RATIO as varchar(25)),
+                cast(ANTIHCV_SUPP_ASSAY as varchar(300)),
+                SUPP_ANTI_HCV_DT,
+                ALT_RESULT_DT,
+                AST_RESULT_DT,
+                ALT_SGPT_RSLT_UP_LMT,
+                AST_SGOT_RSLT_UP_LMT,
+                cast(HEP_A_TOTAL_ANTIBODY as varchar(300)),
+                TOTAL_ANTI_HAV_DT,
+                cast(HEP_B_TOTAL_ANTIBODY as varchar(300)),
+                TOTAL_ANTI_HBC_DT,
+                TOTAL_ANTI_HCV_DT,
+                cast(HEP_D_TOTAL_ANTIBODY as varchar(300)),
+                TOTAL_ANTI_HDV_DT,
+                cast(HEP_E_TOTAL_ANTIBODY as varchar(300)),
+                TOTAL_ANTI_HEV_DT,
+                VERIFIED_TEST_DT,
+                cast(LEGACY_CASE_ID as varchar(15)),
+                cast(DIABETES_IND as varchar(300)),
+                DIABETES_DX_DT,
+                PREGNANCY_DUE_DT,
+                cast(PAT_JUNDICED_IND as varchar(300)),
+                cast(PAT_PREV_AWARE_IND as varchar(300)),
+                cast(HEP_CARE_PROVIDER as varchar(300)),
+                cast(TEST_REASON as varchar(300)),
+                cast(TEST_REASON_OTH as varchar(150)),
+                cast(SYMPTOMATIC_IND as varchar(300)),
+                cast(MTH_BORN_OUTSIDE_US as varchar(300)),
+                cast(MTH_ETHNICITY as varchar(300)),
+                cast(MTH_HBS_AG_PRIOR_POS as varchar(300)),
+                cast(MTH_POS_AFTER as varchar(300)),
+                MTH_POS_TEST_DT,
+                cast(MTH_RACE as varchar(300)),
+                cast(MTH_BIRTH_COUNTRY as varchar(300)),
+                NOT_SUBMIT_DT,
+                PAT_REPORTED_AGE,
+                cast(PAT_REPORTED_AGE_UNIT as varchar(300)),
+                cast(PAT_CITY as varchar(50)),
+                cast(PAT_COUNTRY as varchar(300)),
+                cast(PAT_COUNTY as varchar(300)),
+                cast(PAT_CURR_GENDER as varchar(300)),
+                PAT_DOB,
+                cast(PAT_ETHNICITY as varchar(300)),
+                cast(PAT_FIRST_NM as varchar(50)),
+                cast(PAT_LAST_NM as varchar(50)),
+                cast(PAT_LOCAL_ID as varchar(25)),
+                cast(PAT_MIDDLE_NM as varchar(50)),
+                cast(PAT_PREGNANT_IND as varchar(300)),
+                cast(PAT_RACE as varchar(300)),
+                cast(PAT_STATE as varchar(300)),
+                cast(PAT_STREET_ADDR_1 as varchar(50)),
+                cast(PAT_STREET_ADDR_2 as varchar(50)),
+                cast(PAT_ZIP_CODE as varchar(10)),
+                cast(RPT_SRC_SOURCE_NM as varchar(300)),
+                cast(RPT_SRC_STATE as varchar(300)),
+                cast(RPT_SRC_CD_DESC as varchar(300)),
+                cast(BLD_EXPOSURE_IND as varchar(300)),
+                cast(BLD_RECVD_IND as varchar(300)),
+                BLD_RECVD_DT,
+                cast(MED_DEN_BLD_CT_FRQ as varchar(300)),
+                cast(MED_DEN_EMP_EVER_IND as varchar(300)),
+                cast(MED_DEN_EMPLOYEE_IND as varchar(300)),
+                cast(CLOTFACTOR_PRIOR_1987 as varchar(300)),
+                cast(BLD_CONTAM_IND as varchar(300)),
+                cast(DEN_WORK_OR_SURG_IND as varchar(300)),
+                cast(HEMODIALYSIS_IND as varchar(300)),
+                cast(LT_HEMODIALYSIS_IND as varchar(300)),
+                cast(HSPTL_PRIOR_ONSET_IND as varchar(300)),
+                cast(EVER_INJCT_NOPRSC_DRG as varchar(300)),
+                cast(INCAR_24PLUSHRS_IND as varchar(300)),
+                cast(INCAR_6PLUS_MO_IND as varchar(300)),
+                cast(EVER_INCAR_IND as varchar(300)),
+                cast(INCAR_TYPE_JAIL_IND as varchar(300)),
+                cast(INCAR_TYPE_PRISON_IND as varchar(300)),
+                cast(INCAR_TYPE_JUV_IND as varchar(300)),
+                LAST6PLUSMO_INCAR_PER,
+                LAST6PLUSMO_INCAR_YR,
+                cast(OUTPAT_IV_INF_IND as varchar(300)),
+                cast(LTCARE_RESIDENT_IND as varchar(300)),
+                LIFE_SEX_PRTNR_NBR,
+                cast(BLD_EXPOSURE_OTH as varchar(200)),
+                cast(PIERC_PRIOR_ONSET_IND as varchar(300)),
+                cast(PIERC_PERF_LOC_OTH as varchar(150)),
+                cast(PIERC_PERF_LOC as varchar(300)),
+                cast(PUB_SAFETY_BLD_CT_FRQ as varchar(300)),
+                cast(PUB_SAFETY_WORKER_IND as varchar(300)),
+                cast(STD_TREATED_IND as varchar(300)),
+                STD_LAST_TREATMENT_YR,
+                cast(NON_ORAL_SURGERY_IND as varchar(300)),
+                cast(TATT_PRIOR_ONSET_IND as varchar(300)),
+                cast(TATTOO_PERF_LOC as varchar(300)),
+                cast(TATT_PRIOR_LOC_OTH as varchar(150)),
+                cast(BLD_TRANSF_PRIOR_1992 as varchar(300)),
+                cast(ORGN_TRNSP_PRIOR_1992 as varchar(300)),
+                cast(TRANSMISSION_MODE as varchar(300)),
+                cast(HOUSEHOLD_TRAVEL_IND as varchar(300)),
+                cast(TRAVEL_OUT_USACAN_IND as varchar(300)),
+                cast(TRAVEL_OUT_USACAN_LOC as varchar(300)),
+                cast(HOUSEHOLD_TRAVEL_LOC as varchar(300)),
+                cast(TRAVEL_REASON as varchar(300)),
+                cast(IMM_GLOB_RECVD_IND as varchar(300)),
+                GLOB_LAST_RECVD_YR,
+                cast(cast(VACC_RECVD_IND as varchar(10)) as varchar(10)),
+                VACC_DOSE_NBR_1,
+                VACC_RECVD_DT_1,
+                VACC_DOSE_NBR_2,
+                VACC_RECVD_DT_2,
+                VACC_DOSE_NBR_3,
+                VACC_RECVD_DT_3,
+                VACC_DOSE_NBR_4,
+                VACC_RECVD_DT_4,
+                cast(VACC_GT_4_IND as varchar(300)),
+                VACC_DOSE_RECVD_NBR,
+                VACC_LAST_RECVD_YR,
+                cast(ANTI_HBSAG_TESTED_IND as varchar(300)),
+                cast(CONDITION_CD as varchar(300)),
+                EVENT_DATE,
+                cast(IMPORT_FROM_CITY as varchar(300)),
+                cast(IMPORT_FROM_COUNTRY as varchar(300)),
+                cast(IMPORT_FROM_COUNTY as varchar(300)),
+                cast(IMPORT_FROM_STATE as varchar(300)),
+                INVESTIGATION_KEY,
+                cast(INVESTIGATOR_NAME as varchar(300)),
+                cast(PAT_ELECTRONIC_IND as varchar(300)),
+                cast(PHYS_CITY as varchar(300)),
+                cast(PHYS_COUNTY as varchar(300)),
+                cast(PHYS_NAME as varchar(300)),
+                cast(PHYS_STATE as varchar(300)),
+                PROGRAM_JURISDICTION_OID,
+                cast(RPT_SRC_CITY as varchar(300)),
+                cast(RPT_SRC_COUNTY as varchar(300)),
+                cast(RPT_SRC_COUNTY_CD as varchar(300)),
+                PHYSICIAN_UID,
+                PATIENT_UID,
+                CASE_UID,
+                INVESTIGATOR_UID,
+                REPORTING_SOURCE_UID,
+                REFRESH_DATETIME,
+                cast(PAT_BIRTH_COUNTRY as varchar(50))
+        FROM #TMP_HEPATITIS_CASE_BASE  TH WITH(NOLOCK)
+        WHERE NOT EXISTS
+                  (
+                      SELECT *
+                      FROM [dbo].[HEPATITIS_DATAMART] WITH(NOLOCK)
+                      WHERE [CASE_UID] = TH.[CASE_UID] AND
+                          [PATIENT_UID] = TH.[PATIENT_UID] AND
+                          [INVESTIGATION_KEY] = TH.[INVESTIGATION_KEY]
+                  )
+        ORDER BY INVESTIGATION_KEY;
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]( BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT] )
+        VALUES( @BATCH_ID, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO );
+
+        COMMIT TRANSACTION;
+
+        if @debug = 'true' select * from  #TMP_HEPATITIS_CASE_BASE;
+
+
+        /*
 
            BEGIN TRANSACTION;
 
@@ -3538,86 +2617,88 @@ COMMIT TRANSACTION;
                (BATCH_ID,[DATAFLOW_NAME],[PACKAGE_NAME] ,[STATUS_TYPE],[STEP_NUMBER],[STEP_NAME],[ROW_COUNT])
                VALUES(@BATCH_ID,'HEPATITIS_DATAMART','Hepatitis_Case_DATAMART','START',@PROC_STEP_NO,@PROC_STEP_NAME,@ROWCOUNT_NO);
 
-           COMMIT TRANSACTION;
+      COMMIT TRANSACTION;
+ */
+
+        /*
 
 
+               BEGIN TRANSACTION;
 
-           BEGIN TRANSACTION;
+                 SET @Proc_Step_no =  31  ;
 
-             SET @Proc_Step_no =  31  ;
+                 SET @PROC_STEP_NAME = 'Updating INIT_NND_NOTF_DT in HEPATITIS_DATAMART';
 
-             SET @PROC_STEP_NAME = 'Updating INIT_NND_NOTF_DT in HEPATITIS_DATAMART';
+                    MIN(ADD_TIME) AS FIRSTNOTIFICATIONDATE
 
+                   update ISD
+                                 set ISD.INIT_NND_NOT_DT = NND.FIRSTNOTIFICATIONSENDDATE
+                           FROM dbo.[HEPATITIS_DATAMART] ISD
+                                            JOIN #TMP_inv_sum_nnd_info NND with (nolock) ON ISD.INVESTIGATION_KEY=NND.INVESTIGATION_KEY
+                                           ;
 
+                  SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-               update ISD
-                             set ISD.INIT_NND_NOT_DT = NND.FIRSTNOTIFICATIONSENDDATE
-                       FROM dbo.[HEPATITIS_DATAMART] ISD
-                                        JOIN #TMP_inv_sum_nnd_info NND with (nolock) ON ISD.INVESTIGATION_KEY=NND.INVESTIGATION_KEY
-                                       ;
+                   INSERT INTO [DBO].[JOB_FLOW_LOG]
+                   (BATCH_ID,[DATAFLOW_NAME],[PACKAGE_NAME] ,[STATUS_TYPE],[STEP_NUMBER],[STEP_NAME],[ROW_COUNT])
+                   VALUES(@BATCH_ID,'HEPATITIS_DATAMART','Hepatitis_Case_DATAMART','START',@PROC_STEP_NO,@PROC_STEP_NAME,@ROWCOUNT_NO);
 
-              SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+               COMMIT TRANSACTION;
 
-               INSERT INTO [DBO].[JOB_FLOW_LOG]
-               (BATCH_ID,[DATAFLOW_NAME],[PACKAGE_NAME] ,[STATUS_TYPE],[STEP_NUMBER],[STEP_NAME],[ROW_COUNT])
-               VALUES(@BATCH_ID,'HEPATITIS_DATAMART','Hepatitis_Case_DATAMART','START',@PROC_STEP_NO,@PROC_STEP_NAME,@ROWCOUNT_NO);
+    */
 
-           COMMIT TRANSACTION;
-
-
-           */
 ---------------------------------------------------------------------------Dropping All TMP Tables------------------------------------------------------------
 
-select 'Transaction_count',@@TRANCOUNT
-;
+        select 'Transaction_count',@@TRANCOUNT
+        ;
 
-IF @@TRANCOUNT > 0
-BEGIN
-select 'COMMIT 1';
+        IF @@TRANCOUNT > 0
+            BEGIN
+                select 'COMMIT 1';
 
-COMMIT TRANSACTION;
-END;
+                COMMIT TRANSACTION;
+            END;
 
-			-------------------------------------------------------------------------------------------------------------------------
-BEGIN TRANSACTION;
+        -------------------------------------------------------------------------------------------------------------------------
+        BEGIN TRANSACTION;
 
-			SET @Proc_Step_no = 32;
+        SET @Proc_Step_no = 32;
 
-			SET @Proc_Step_Name = 'SP_COMPLETE';
+        SET @Proc_Step_Name = 'SP_COMPLETE';
 
-INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count] )
-VALUES( @batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'COMPLETE', @Proc_Step_no, @Proc_Step_name, @RowCount_no );
-
-
-
-COMMIT TRANSACTION;
+        INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count] )
+        VALUES( @batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'COMPLETE', @Proc_Step_no, @Proc_Step_name, @RowCount_no );
 
 
 
-END TRY
-BEGIN CATCH
-IF @@TRANCOUNT > 0
-BEGIN
-ROLLBACK TRANSACTION;
+        COMMIT TRANSACTION;
 
-END;
 
-		DECLARE @ErrorNumber int= ERROR_NUMBER();
 
-		DECLARE @ErrorLine int= ERROR_LINE();
+    END TRY
+    BEGIN CATCH
+        IF @@TRANCOUNT > 0
+            BEGIN
+                ROLLBACK TRANSACTION;
 
-		DECLARE @ErrorMessage nvarchar(4000)= ERROR_MESSAGE();
+            END;
 
-		DECLARE @ErrorSeverity int= ERROR_SEVERITY();
+        DECLARE @ErrorNumber int= ERROR_NUMBER();
 
-		DECLARE @ErrorState int= ERROR_STATE();
+        DECLARE @ErrorLine int= ERROR_LINE();
 
-INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [Error_Description], [row_count] )
-VALUES( @Batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'ERROR', @Proc_Step_no, 'ERROR - ' + @Proc_Step_name, 'Step -' + CAST(@Proc_Step_no AS varchar(3)) + ' -' + CAST(@ErrorMessage AS varchar(500)), 0 );
+        DECLARE @ErrorMessage nvarchar(4000)= ERROR_MESSAGE();
 
-RETURN -1;
+        DECLARE @ErrorSeverity int= ERROR_SEVERITY();
 
-END CATCH;
+        DECLARE @ErrorState int= ERROR_STATE();
+
+        INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [Error_Description], [row_count] )
+        VALUES( @Batch_id, 'HEPATITIS_DATAMART', 'Hepatitis_Case_DATAMART', 'ERROR', @Proc_Step_no, 'ERROR - ' + @Proc_Step_name, 'Step -' + CAST(@Proc_Step_no AS varchar(3)) + ' -' + CAST(@ErrorMessage AS varchar(500)), 0 );
+
+        RETURN -1;
+
+    END CATCH;
 
 END;
 

--- a/liquibase-service/src/main/resources/db/rdb/032-create_nrt_datamart_metadata-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb/032-create_nrt_datamart_metadata-001.sql
@@ -1,14 +1,27 @@
-USE RDB_MODERN;
 IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_datamart_metadata' and xtype = 'U')
-CREATE TABLE dbo.nrt_datamart_metadata (
-                                           condition_cd varchar(20) NOT NULL,
-                                           condition_desc_txt varchar(300) NULL,
-                                           Datamart varchar(18) NOT NULL,
-                                           Stored_Procedure varchar(36) NOT NULL
-                                       );
-INSERT INTO dbo.nrt_datamart_metadata
-(condition_cd, condition_desc_txt, Datamart, Stored_Procedure)
-SELECT condition_cd, condition_desc_txt, 'Hepatitis_Datamart',
-       'sp_hepatitis_datamart_postprocessing'
-FROM NBS_SRTE.[dbo].[Condition_code] WITH(NOLOCK)
-WHERE CONDITION_CD  IN( '10110', '10104', '10100', '10106', '10101', '10102', '10103', '10105', '10481', '50248', '999999' );
+CREATE TABLE dbo.nrt_datamart_metadata
+    (
+        condition_cd       varchar(20) NOT NULL,
+        condition_desc_txt varchar(300) NULL,
+        Datamart           varchar(18) NOT NULL,
+        Stored_Procedure   varchar(36) NOT NULL
+    );
+    INSERT INTO dbo.nrt_datamart_metadata
+        (condition_cd,condition_desc_txt,Datamart,Stored_Procedure)
+    SELECT condition_cd,
+           condition_desc_txt,
+           'Hepatitis_Datamart',
+           'sp_hepatitis_datamart_postprocessing'
+    FROM NBS_SRTE.[dbo].[Condition_code]
+    WITH (NOLOCK)
+    WHERE CONDITION_CD IN ( '10110'
+        , '10104'
+        , '10100'
+        , '10106'
+        , '10101'
+        , '10102'
+        , '10103'
+        , '10105'
+        , '10481'
+        , '50248'
+        , '999999' );


### PR DESCRIPTION
Updates to stored procedures:
+ Including bug fix versions for ODSE pre-processing sprocs- trim/substring handling for address fields.
+ Updates hepatitis stored procedure to pull page builder inv dimensions columns that were being missed.
+ Addition of `with (nolock)` to table joins for multiple/heavy transaction handling. 
+ Correct sproc for investigation pre-processing.