### PR TITLE
CNDIT-1554: Send message to DLQ for empty or not existed database objects

### DIFF
--- a/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/NoDataException.java
+++ b/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/NoDataException.java
@@ -1,0 +1,7 @@
+package gov.cdc.etldatapipeline.commonutil;
+
+public class NoDataException extends RuntimeException {
+    public NoDataException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Description
Implement and throw a custom exception when the requested database object is unavailable on the database side (sp returns empty data for the specified uid). Send incoming message to DLT if empty data is returned from database.

- **NoDataException.java**: custom exception class;
- **Investigation**, **Observation**, **Organization**, **Person** services now throw the NoDataException in the `processMessage` listeners;
- Same logic is to be implemented in the context of upcoming **PostProcessing** and **LDF** services enhancement.

## JIRA
[CNDIT-1554](https://cdc-nbs.atlassian.net/browse/CNDIT-1554)