### PR TITLE
CNDIT-1364: LDF post-processing service integration

### DIFF
--- a/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/model/dto/LdfDataKey.java
+++ b/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/model/dto/LdfDataKey.java
@@ -11,7 +11,4 @@ public class LdfDataKey {
     @NonNull
     @JsonProperty("ldf_uid")
     private Long ldfUid;
-
-    @JsonProperty("business_object_uid")
-    private Long businessObjectUid;
 }

--- a/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataService.java
+++ b/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataService.java
@@ -92,7 +92,6 @@ public class LdfDataService {
                 Optional<LdfData> ldfData = ldfDataRepository.computeLdfData(busObjNm, ldfUid, busObjUid);
                 if (ldfData.isPresent()) {
                     ldfDataKey.setLdfUid(Long.valueOf(ldfUid));
-                    ldfDataKey.setBusinessObjectUid(Long.valueOf(busObjUid));
                     pushKeyValuePairToKafka(ldfDataKey, ldfData.get(), ldfDataTopicReporting);
                     return objectMapper.writeValueAsString(ldfData.get());
                 }

--- a/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataServiceTest.java
+++ b/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataServiceTest.java
@@ -5,6 +5,7 @@ import gov.cdc.etldatapipeline.commonutil.json.CustomJsonGeneratorImpl;
 import gov.cdc.etldatapipeline.ldfdata.repository.LdfDataRepository;
 import gov.cdc.etldatapipeline.ldfdata.model.dto.LdfData;
 import gov.cdc.etldatapipeline.ldfdata.model.dto.LdfDataKey;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,11 +36,17 @@ class LdfDataServiceTest {
     @Captor
     private ArgumentCaptor<String> messageCaptor;
 
+    private AutoCloseable closeable;
     private final CustomJsonGeneratorImpl jsonGenerator = new CustomJsonGeneratorImpl();
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        closeable=MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test
@@ -100,7 +107,6 @@ class LdfDataServiceTest {
 
         LdfDataKey ldfDataKey = new LdfDataKey();
         ldfDataKey.setLdfUid(ldfData.getLdfUid());
-        ldfDataKey.setBusinessObjectUid(ldfData.getBusinessObjectUid());
 
         String expectedKey = jsonGenerator.generateStringJson(ldfDataKey);
         String expectedValue = jsonGenerator.generateStringJson(ldfData);
@@ -110,7 +116,6 @@ class LdfDataServiceTest {
         assertEquals(expectedKey, keyCaptor.getValue());
         assertEquals(expectedValue, messageCaptor.getValue());
         assertTrue(keyCaptor.getValue().contains(String.valueOf(ldfDataKey.getLdfUid())));
-        assertTrue(keyCaptor.getValue().contains(String.valueOf(ldfDataKey.getBusinessObjectUid())));
     }
 
     private LdfDataService getInvestigationService(String inputTopicName, String outputTopicName) {

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PostProcRepository.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PostProcRepository.java
@@ -19,4 +19,7 @@ public interface PostProcRepository extends JpaRepository<PostProcSp, Long> {
 
     @Procedure("sp_nrt_notification_postprocessing")
     void executeStoredProcForNotificationIds(@Param("notificationUids") String notificationUids);
+
+    @Procedure("sp_nrt_ldf_postprocessing")
+    void executeStoredProcForLdfIds(@Param("ldf_uids") String ldfUids);
 }

--- a/post-processing-service/src/main/resources/application.yaml
+++ b/post-processing-service/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ spring:
       patient: nrt_patient
       provider: nrt_provider
       notification: nrt_notifications
+      ldf_data: nrt_ldf_data
       datamart: nbs_Datamart
     dlq:
       retry-suffix: -retry

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -72,6 +72,7 @@ class PostProcessingServiceTest {
     })
     void testExtractIdFromMessage(String topic, String messageKey, Long expectedId) {
         Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
+        assertNotNull(extractedId);
         assertEquals(expectedId, extractedId);
     }
 
@@ -81,6 +82,8 @@ class PostProcessingServiceTest {
         String key = "{\"payload\":{\"patient_uid\":123}}";
 
         postProcessingServiceMock.postProcessMessage(topic, key, key);
+        assertEquals(postProcessingServiceMock.idCache.get(topic).get(0), 123L);
+
         postProcessingServiceMock.processCachedIds();
 
         String expectedPatientIdsString = "123";
@@ -141,6 +144,7 @@ class PostProcessingServiceTest {
 
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(5, logs.size());
+        assertTrue(logs.get(1).getFormattedMessage().contains(PostProcessingService.Entity.INVESTIGATION.getStoredProcedure()));
         assertTrue(logs.get(4).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
@@ -158,6 +162,7 @@ class PostProcessingServiceTest {
 
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(3, logs.size());
+        assertTrue(logs.get(1).getFormattedMessage().contains(PostProcessingService.Entity.NOTIFICATIONS.getStoredProcedure()));
         assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
@@ -183,6 +188,24 @@ class PostProcessingServiceTest {
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(7, logs.size());
         assertTrue(logs.get(6).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+    }
+
+    @Test
+    void testPostProcessLdfData() {
+        String topic = "dummy_ldf_data";
+        String key = "{\"payload\":{\"ldf_uid\":123}}";
+
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
+        postProcessingServiceMock.processCachedIds();
+
+        String expectedLdfIdsString = "123";
+        verify(postProcRepositoryMock).executeStoredProcForLdfIds(expectedLdfIdsString);
+        assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
+
+        List<ILoggingEvent> logs = listAppender.list;
+        assertEquals(3, logs.size());
+        assertTrue(logs.get(1).getFormattedMessage().contains(PostProcessingService.Entity.LDF_DATA.getStoredProcedure()));
+        assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -225,31 +248,34 @@ class PostProcessingServiceTest {
         String patientKey = "{\"payload\":{\"patient_uid\":125}}";
         String investigationKey = "{\"payload\":{\"public_health_case_uid\":126}}";
         String notificationKey = "{\"payload\":{\"notification_uid\":127}}";
+        String ldfKey = "{\"payload\":{\"ldf_uid\":127}}";
 
         String orgTopic = "dummy_organization";
         String providerTopic = "dummy_provider";
         String patientTopic = "dummy_patient";
         String invTopic = "dummy_investigation";
-        String notfTopic = "dummy_notifications";
+        String ntfTopic = "dummy_notifications";
+        String ldfTopic = "dummy_ldf_data";
 
         postProcessingServiceMock.postProcessMessage(invTopic, investigationKey, investigationKey);
         postProcessingServiceMock.postProcessMessage(providerTopic, providerKey, providerKey);
         postProcessingServiceMock.postProcessMessage(patientTopic, patientKey, patientKey);
-        postProcessingServiceMock.postProcessMessage(notfTopic, notificationKey, notificationKey);
+        postProcessingServiceMock.postProcessMessage(ntfTopic, notificationKey, notificationKey);
         postProcessingServiceMock.postProcessMessage(orgTopic, orgKey, orgKey);
+        postProcessingServiceMock.postProcessMessage(ldfTopic, ldfKey, ldfKey);
         postProcessingServiceMock.processCachedIds();
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(17, logs.size());
 
-        List<String> topicLogList = logs.stream().map(ILoggingEvent::getFormattedMessage).filter(m -> m.contains(
-                "message topic")).toList();
+        List<String> topicLogList = logs.stream().map(ILoggingEvent::getFormattedMessage).filter(m -> m.matches(
+                "Processing .+ for topic: .*")).toList();
         assertTrue(topicLogList.get(0).contains(orgTopic));
         assertTrue(topicLogList.get(1).contains(providerTopic));
         assertTrue(topicLogList.get(2).contains(patientTopic));
         assertTrue(topicLogList.get(3).contains(invTopic));
         assertTrue(topicLogList.get(4).contains(invTopic));
-        assertTrue(topicLogList.get(5).contains(notfTopic));
+        assertTrue(topicLogList.get(5).contains(ntfTopic));
+        assertTrue(topicLogList.get(6).contains(ldfTopic));
     }
 
     @Test

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -82,7 +82,7 @@ class PostProcessingServiceTest {
         String key = "{\"payload\":{\"patient_uid\":123}}";
 
         postProcessingServiceMock.postProcessMessage(topic, key, key);
-        assertEquals(postProcessingServiceMock.idCache.get(topic).get(0), 123L);
+        assertEquals(123L, postProcessingServiceMock.idCache.get(topic).get(0));
 
         postProcessingServiceMock.processCachedIds();
 


### PR DESCRIPTION
## Description
Implements LDF service integration in RTR post-processing service to call `sp_nrt_ldf_postprocessing` and update LDF dimensions.

- `LdfDataKey.java`: removed `business_object_uid` field from the message key
- `PostProcRepository.java`: added method to execute `sp_nrt_ldf_postprocessing`
- `PostProcessingService.java`: added `nrt_ldf_data` topic processing, minor improvements
- Adjusted unit tests

## JIRA
[CNDIT-1364](https://cdc-nbs.atlassian.net/browse/CNDIT-1364)