### PR TITLE
RTR investigation service - add PHC datamart feature flag

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -45,6 +45,9 @@ public class InvestigationService {
     @Value("${spring.kafka.output.topic-name-reporting}")
     public String investigationTopicReporting;
 
+    @Value("${service.phc-datamart-enable}")
+    public boolean phcDatamartEnable;
+
     private final InvestigationRepository investigationRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ProcessInvestigationDataUtil processDataUtil;
@@ -90,7 +93,9 @@ public class InvestigationService {
                 publicHealthCaseUid = payloadNode.get("public_health_case_uid").asText();
                 investigationKey.setPublicHealthCaseUid(Long.valueOf(publicHealthCaseUid));
 
-                processPhcFactDatamart(publicHealthCaseUid);
+                if (phcDatamartEnable) {
+                    processPhcFactDatamart(publicHealthCaseUid);
+                }
 
                 logger.debug(topicDebugLog, publicHealthCaseUid, investigationTopic);
                 Optional<Investigation> investigationData = investigationRepository.computeInvestigations(publicHealthCaseUid);

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -38,5 +38,7 @@ logging:
   file:
     name: InvestigationService.log
     path: ${DA_LOG_PATH:logs}
+service:
+  phc-datamart-enable: ${PHC_DM_ENABLE:false}
 server:
   port: '8093'

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -109,7 +109,6 @@ public class PostProcessingService {
             @Header(KafkaHeaders.RECEIVED_KEY) String key,
             @Payload String payload) {
         Long id = extractIdFromMessage(topic, key, payload);
-        logger.info("Adding id to cache: {} for topic: {}", id, topic);
         if (id != null) {
             idCache.computeIfAbsent(topic, k -> new CopyOnWriteArrayList<>()).add(id);
         }
@@ -172,10 +171,9 @@ public class PostProcessingService {
                 List<Long> ids = entry.getValue();
                 idCache.put(keyTopic, new ArrayList<>());
 
-                logger.info("Processing {} ids from topic: {}", ids.size(), keyTopic);
+                logger.info("Processing {} id(s) from topic: {}", ids.size(), keyTopic);
 
                 Entity entity = getEntityByTopic(keyTopic);
-                logger.info("{} data is about to be processed...", entity.getName());
                 switch (entity) {
                     case ORGANIZATION:
                         processTopic(keyTopic, entity, ids,
@@ -277,7 +275,7 @@ public class PostProcessingService {
     private Entity getEntityByTopic(String topic) {
         return Arrays.stream(Entity.values())
                 .filter(entity -> entity.getPriority() > 0)
-                .filter(entity -> topic.contains(entity.getName()))
+                .filter(entity -> topic.endsWith(entity.getName()))
                 .findFirst()
                 .orElse(Entity.UNKNOWN);
     }

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -91,8 +91,8 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
-        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(4, logs.size());
+        assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -108,8 +108,8 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
-        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(4, logs.size());
+        assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -125,8 +125,8 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
-        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(4, logs.size());
+        assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -143,9 +143,9 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(8, logs.size());
-        assertTrue(logs.get(4).getFormattedMessage().contains(PostProcessingService.Entity.INVESTIGATION.getStoredProcedure()));
-        assertTrue(logs.get(7).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(6, logs.size());
+        assertTrue(logs.get(2).getFormattedMessage().contains(PostProcessingService.Entity.INVESTIGATION.getStoredProcedure()));
+        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -161,9 +161,9 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
-        assertTrue(logs.get(4).getFormattedMessage().contains(PostProcessingService.Entity.NOTIFICATION.getStoredProcedure()));
-        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(4, logs.size());
+        assertTrue(logs.get(2).getFormattedMessage().contains(PostProcessingService.Entity.NOTIFICATION.getStoredProcedure()));
+        assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -186,8 +186,8 @@ class PostProcessingServiceTest {
                 expectedRdbTableNames);
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(10, logs.size());
-        assertTrue(logs.get(9).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(8, logs.size());
+        assertTrue(logs.get(7).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -203,9 +203,9 @@ class PostProcessingServiceTest {
         assertTrue(postProcessingServiceMock.idCache.containsKey(topic));
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
-        assertTrue(logs.get(4).getFormattedMessage().contains(PostProcessingService.Entity.LDF_DATA.getStoredProcedure()));
-        assertTrue(logs.get(5).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertEquals(4, logs.size());
+        assertTrue(logs.get(2).getFormattedMessage().contains(PostProcessingService.Entity.LDF_DATA.getStoredProcedure()));
+        assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
@@ -338,7 +338,7 @@ class PostProcessingServiceTest {
 
         verify(investigationRepositoryMock, never()).executeStoredProcForPageBuilder(anyLong(), anyString());
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(8, logs.size());
+        assertEquals(6, logs.size());
     }
 
     @Test


### PR DESCRIPTION
## Description

- Add a feature flag to the investigation service for PHC datamart processing. Can be enabled/disabled by by setting the `PHC_DM_ENABLE` environment variable. If the variable is not set, the default value is `false` and feature will be turned off.
- Fix investigation update sp for the investigations without notifications
