### PR TITLE
CNDIT-1777 Fix ObservationNumeric data type for Kafka schema

### DIFF
--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationNumeric.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationNumeric.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
-import java.math.BigDecimal;
-
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -18,9 +16,9 @@ public class ObservationNumeric {
     @JsonProperty("ovn_comparator_cd_1")
     private String ovnComparatorCd1;
     @JsonProperty("ovn_numeric_value_1")
-    private BigDecimal ovnNumericValue1;
+    private String ovnNumericValue1;
     @JsonProperty("ovn_numeric_value_2")
-    private BigDecimal ovnNumericValue2;
+    private String ovnNumericValue2;
     private String ovnNumericUnitCd;
     private String ovnSeparatorCd;
 }

--- a/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationDataProcessTests.java
+++ b/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationDataProcessTests.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -258,8 +257,8 @@ class ObservationDataProcessTests {
         numeric.setOvnComparatorCd1("100");
         numeric.setOvnLowRange("10-100");
         numeric.setOvnHighRange("100-1000");
-        numeric.setOvnNumericValue1(new BigDecimal("1"));
-        numeric.setOvnNumericValue2(new BigDecimal("1"));
+        numeric.setOvnNumericValue1("1.0");
+        numeric.setOvnNumericValue2("1.0");
         numeric.setOvnNumericUnitCd("mL");
         numeric.setOvnSeparatorCd(":");
 


### PR DESCRIPTION
## Notes

Fixed Java type for `ovn_numeric_value_1` and `ovn_numeric_value_2` to avoid Kafka sink DataException

## JIRA

- **Related story**: [CNDE-1777](https://cdc-nbs.atlassian.net/browse/CNDE-1777)

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change