### PR TITLE
CNDE-1834: Fix persistence for multivalued observation payloads

### DIFF
--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationCodedKey.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationCodedKey.java
@@ -1,0 +1,14 @@
+package gov.cdc.etldatapipeline.observation.repository.model.reporting;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ObservationCodedKey {
+    private Long observationUid;
+    private String ovcCode;
+}

--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationReasonKey.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationReasonKey.java
@@ -1,0 +1,14 @@
+package gov.cdc.etldatapipeline.observation.repository.model.reporting;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ObservationReasonKey {
+    private Long observationUid;
+    private String reasonCd;
+}

--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationTxtKey.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/repository/model/reporting/ObservationTxtKey.java
@@ -1,0 +1,14 @@
+package gov.cdc.etldatapipeline.observation.repository.model.reporting;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ObservationTxtKey {
+    private Long observationUid;
+    private Integer ovtSeq;
+}

--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/util/ProcessObservationDataUtil.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/util/ProcessObservationDataUtil.java
@@ -323,10 +323,12 @@ public class ProcessObservationDataUtil {
         try {
             JsonNode observationCodedJsonArray = parseJsonArray(observationCoded);
 
+            ObservationCodedKey codedKey = new ObservationCodedKey();
             for (JsonNode jsonNode : observationCodedJsonArray) {
                 ObservationCoded coded = objectMapper.treeToValue(jsonNode, ObservationCoded.class);
-                observationKey.setObservationUid(coded.getObservationUid());
-                sendToKafka(observationKey, coded, codedTopicName, coded.getObservationUid(), "Observation Coded data (uid={}) sent to {}");
+                codedKey.setObservationUid(coded.getObservationUid());
+                codedKey.setOvcCode(coded.getOvcCode());
+                sendToKafka(codedKey, coded, codedTopicName, coded.getObservationUid(), "Observation Coded data (uid={}) sent to {}");
             }
         } catch (IllegalArgumentException ex) {
             logger.info(ex.getMessage(), "ObservationCoded");
@@ -388,10 +390,12 @@ public class ProcessObservationDataUtil {
         try {
             JsonNode observationReasonsJsonArray = parseJsonArray(observationReasons);
 
+            ObservationReasonKey reasonKey = new ObservationReasonKey();
             for (JsonNode jsonNode : observationReasonsJsonArray) {
                 ObservationReason reason = objectMapper.treeToValue(jsonNode, ObservationReason.class);
-                observationKey.setObservationUid(reason.getObservationUid());
-                sendToKafka(observationKey, reason, reasonTopicName, reason.getObservationUid(), "Observation Reason data (uid={}) sent to {}");
+                reasonKey.setObservationUid(reason.getObservationUid());
+                reasonKey.setReasonCd(reason.getReasonCd());
+                sendToKafka(reasonKey, reason, reasonTopicName, reason.getObservationUid(), "Observation Reason data (uid={}) sent to {}");
             }
         } catch (IllegalArgumentException ex) {
             logger.info(ex.getMessage(), "ObservationReasons");
@@ -404,10 +408,12 @@ public class ProcessObservationDataUtil {
         try {
             JsonNode observationTxtJsonArray = parseJsonArray(observationTxt);
 
+            ObservationTxtKey txtKey = new ObservationTxtKey();
             for (JsonNode jsonNode : observationTxtJsonArray) {
                 ObservationTxt txt = objectMapper.treeToValue(jsonNode, ObservationTxt.class);
-                observationKey.setObservationUid(txt.getObservationUid());
-                sendToKafka(observationKey, txt, txtTopicName, txt.getObservationUid(), "Observation Txt data (uid={}) sent to {}");
+                txtKey.setObservationUid(txt.getObservationUid());
+                txtKey.setOvtSeq(txt.getOvtSeq());
+                sendToKafka(txtKey, txt, txtTopicName, txt.getObservationUid(), "Observation Txt data (uid={}) sent to {}");
             }
         } catch (IllegalArgumentException ex) {
             logger.info(ex.getMessage(), "ObservationTxt");


### PR DESCRIPTION
## Notes

Fixed the issue with persistence of multivalued data for `nrt_observation_coded`, `nrt_observation_reason` and `nrt_observation_txt`.

## JIRA

- **Related story**: [CNDE-1834](https://cdc-nbs.atlassian.net/browse/CNDE-1834)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?