### PR TITLE
CNDE-1802: RTR remove redundant fields from the Investigation

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/Investigation.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/Investigation.java
@@ -274,18 +274,6 @@ public class Investigation {
     @Column(name = "program_area_description")
     private String programAreaDescription;
 
-    @Column(name = "notification_local_id")
-    private String notificationLocalId;
-
-    @Column(name = "notification_add_time")
-    private String notificationAddTime;
-
-    @Column(name = "notification_record_status_cd")
-    private String notificationRecordStatusCd;
-
-    @Column(name = "notification_last_chg_time")
-    private String notificationLastChgTime;
-
     @Column(name = "case_management_uid")
     private Long caseManagementUid;
 

--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/InvestigationReporting.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/InvestigationReporting.java
@@ -88,10 +88,6 @@ public class InvestigationReporting {
     private String coinfectionId;
     private String contactInvTxt;
     private String programAreaDescription;
-    private String notificationLocalId;
-    private String notificationAddTime;
-    private String notificationRecordStatusCd;
-    private String notificationLastChgTime;
     private Long caseManagementUid;
     private Long nacPageCaseUid;
     private String nacLastChgTime;

--- a/liquibase-service/src/main/resources/db/changelog/db.odse.changelog-16.1.yaml
+++ b/liquibase-service/src/main/resources/db/changelog/db.odse.changelog-16.1.yaml
@@ -9,6 +9,7 @@ databaseChangeLog:
   - changeSet:
       id: 1
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 001-fn_get_value_by_cd_ques-001.sql
@@ -16,6 +17,7 @@ databaseChangeLog:
   - changeSet:
       id: 2
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 002-fn_get_value_by_cvg-001.sql
@@ -23,6 +25,7 @@ databaseChangeLog:
   - changeSet:
       id: 3
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 003-fn-get_user_name-001.sql
@@ -30,6 +33,7 @@ databaseChangeLog:
   - changeSet:
       id: 4
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 004-fn_get_value_by_cd_codeset-001.sql
@@ -37,6 +41,7 @@ databaseChangeLog:
   - changeSet:
       id: 5
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 005-sp_organization_event-001.sql
@@ -44,6 +49,7 @@ databaseChangeLog:
   - changeSet:
       id: 6
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 006-sp_provider_event-001.sql
@@ -51,6 +57,7 @@ databaseChangeLog:
   - changeSet:
       id: 7
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 007-sp_patient_race_event-001.sql
@@ -58,6 +65,7 @@ databaseChangeLog:
   - changeSet:
       id: 8
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 008-sp_patient_event-001.sql
@@ -65,6 +73,7 @@ databaseChangeLog:
   - changeSet:
       id: 9
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 009-sp_observation_event-001.sql
@@ -72,6 +81,7 @@ databaseChangeLog:
   - changeSet:
       id: 10
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 010-sp_investigation_event-001.sql
@@ -79,6 +89,7 @@ databaseChangeLog:
   - changeSet:
       id: 11
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 011-sp_ldf_provider_event-001.sql
@@ -86,6 +97,7 @@ databaseChangeLog:
   - changeSet:
       id: 12
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 012-sp_ldf_organization_event-001.sql
@@ -93,6 +105,7 @@ databaseChangeLog:
   - changeSet:
       id: 13
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 013-sp_ldf_patient_event-001.sql
@@ -100,6 +113,7 @@ databaseChangeLog:
   - changeSet:
       id: 14
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 014-sp_ldf_observation_event-001.sql
@@ -107,6 +121,7 @@ databaseChangeLog:
   - changeSet:
       id: 15
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 015-sp_ldf_phc_event-001.sql
@@ -114,6 +129,7 @@ databaseChangeLog:
   - changeSet:
       id: 16
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 016-sp_ldf_intervention_event-001.sql
@@ -121,6 +137,7 @@ databaseChangeLog:
   - changeSet:
       id: 17
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 017-sp_ldf_data_event-001.sql
@@ -128,6 +145,7 @@ databaseChangeLog:
   - changeSet:
       id: 18
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 018-sp_public_health_case_fact_datamart_event-001.sql
@@ -135,6 +153,7 @@ databaseChangeLog:
   - changeSet:
       id: 19
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 001-v_inv_form_code_data-001.sql
@@ -142,6 +161,7 @@ databaseChangeLog:
   - changeSet:
       id: 20
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 001-fn_get_record_status-001.sql
@@ -149,6 +169,7 @@ databaseChangeLog:
   - changeSet:
       id: 21
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 020-sp_notification_event-001.sql
@@ -156,6 +177,7 @@ databaseChangeLog:
   - changeSet:
       id: 22
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 020-sp_notification_event-002.sql
@@ -163,6 +185,7 @@ databaseChangeLog:
   - changeSet:
       id: 23
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 010-sp_investigation_event-002.sql
@@ -170,6 +193,7 @@ databaseChangeLog:
   - changeSet:
       id: 24
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 009-sp_observation_event-002.sql
@@ -177,6 +201,7 @@ databaseChangeLog:
   - changeSet:
       id: 25
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 009-sp_observation_event-003.sql
@@ -184,6 +209,7 @@ databaseChangeLog:
   - changeSet:
       id: 26
       author: liquibase
+      runOnChange: true
       changes:
         - sqlFile:
             path: 008-sp_patient_event-002.sql

--- a/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
+++ b/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
@@ -440,3 +440,10 @@ databaseChangeLog:
         - sqlFile:
             path: 020-sp_lab101_datamart_postprocessing-001.sql
             splitStatements: false
+  - changeSet:
+      id: 59
+      author: liquibase
+      changes:
+        - sqlFile:
+            path: 007-create_nrt_investigation-001.sql
+            splitStatements: false

--- a/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
+++ b/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
@@ -445,5 +445,5 @@ databaseChangeLog:
       author: liquibase
       changes:
         - sqlFile:
-            path: 007-create_nrt_investigation-001.sql
+            path: 007-create_nrt_investigation-002.sql
             splitStatements: false

--- a/liquibase-service/src/main/resources/db/odse/routines/010-sp_investigation_event-002.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/010-sp_investigation_event-002.sql
@@ -44,7 +44,7 @@ BEGIN
                results.jurisdiction_cd,
                results.pregnant_ind_cd,
                results.pregnant_ind,
-               results.local_id                    local_id,
+               results.local_id,
                results.rpt_form_cmplt_time,
                results.activity_to_time,
                results.activity_from_time,
@@ -123,11 +123,6 @@ BEGIN
                results.coinfection_id,
                results.contact_inv_txt,
                pac.prog_area_desc_txt              program_area_description,
-               notification.notification_uid,
-               notification.notification_local_id,
-               notification.notification_add_time,
-               notification.notification_record_status_cd,
-               notification.notification_last_chg_time,
                cm.case_management_uid,
                investigation_act_entity.nac_page_case_uid,
                investigation_act_entity.nac_last_chg_time,
@@ -633,19 +628,6 @@ BEGIN
               WHERE
                   phc.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_id_list
                   , ','))) AS results
-                 LEFT JOIN
-             (SELECT DISTINCT act_rel.target_act_uid,
-                              notification.notification_uid,
-                              notification.local_id               notification_local_id,
-                              notification.add_time               notification_add_time,
-                              notification.record_status_cd       notification_record_status_cd,
-                              notification.last_chg_time          notification_last_chg_time
-              from act_relationship act_rel WITH (NOLOCK)
-                               INNER JOIN notification WITH (NOLOCK) on  act_rel.source_act_uid = notification.notification_uid  AND act_rel.source_class_cd = 'NOTF'
-              where act_rel.target_class_cd = 'CASE'
-              group by target_act_uid,notification_uid, local_id, notification.add_time, notification.record_status_cd,notification.last_chg_time
-             ) as notification
-             on notification.target_act_uid = results.public_health_case_uid
                  LEFT JOIN nbs_srte.dbo.jurisdiction_code jc WITH (NOLOCK) ON results.jurisdiction_cd = jc.code
             LEFT JOIN act WITH (NOLOCK) ON act.act_uid = results.public_health_case_uid
             LEFT JOIN nbs_srte.dbo.program_area_code pac WITH (NOLOCK) on results.prog_area_cd = pac.prog_area_cd
@@ -700,7 +682,7 @@ BEGIN
 
     IF @@TRANCOUNT > 0   ROLLBACK TRANSACTION;
 
-            DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
+    DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
     INSERT INTO [rdb_modern].[dbo].[job_flow_log]
     (      batch_id
         , [Dataflow_Name]

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/007-create_nrt_investigation-002.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/007-create_nrt_investigation-002.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_investigation' and xtype = 'U')
+    BEGIN
+
+        IF EXISTS(SELECT 1 FROM sys.columns WHERE name = N'notification_local_id' AND Object_ID = Object_ID(N'nrt_investigation'))
+            BEGIN
+                ALTER TABLE dbo.nrt_investigation DROP COLUMN notification_local_id;
+            END;
+
+        IF EXISTS(SELECT 1 FROM sys.columns WHERE name = N'notification_add_time' AND Object_ID = Object_ID(N'nrt_investigation'))
+            BEGIN
+                ALTER TABLE dbo.nrt_investigation DROP COLUMN notification_add_time;
+            END;
+
+        IF EXISTS(SELECT 1 FROM sys.columns WHERE name = N'notification_record_status_cd' AND Object_ID = Object_ID(N'nrt_investigation'))
+            BEGIN
+                ALTER TABLE dbo.nrt_investigation DROP COLUMN notification_record_status_cd;
+            END;
+
+        IF EXISTS(SELECT 1 FROM sys.columns WHERE Name = N'notification_last_chg_time' AND Object_ID = Object_ID(N'nrt_investigation'))
+            BEGIN
+                ALTER TABLE dbo.nrt_investigation DROP COLUMN notification_last_chg_time;
+            END;
+
+    END;


### PR DESCRIPTION
## Notes

Removing redundant notification fields from the Investigation DTOs `nrt_investigation` and `sp_investigation_event`.

- `notification_uid` (sp only)
- `notification_local_id`
- `notification_add_time`
- `notification_record_status_cd`
- `notification_last_chg_time`

## JIRA

- **Related story**: [CNDE-1802](https://cdc-nbs.atlassian.net/browse/CNDE-1802)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [x] Is the `gradle build` logs attached?