### PR TITLE
CNDE-1861: Fix multivalued data for coded, reason and txt

### DIFF
--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/util/ProcessObservationDataUtil.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/util/ProcessObservationDataUtil.java
@@ -65,6 +65,7 @@ public class ProcessObservationDataUtil {
         observationTransformed.setObservationUid(observation.getObservationUid());
         observationTransformed.setReportObservationUid(observation.getObservationUid());
 
+        observationKey.setObservationUid(observation.getObservationUid());
         String obsDomainCdSt1 = observation.getObsDomainCdSt1();
 
         transformPersonParticipations(observation.getPersonParticipations(), obsDomainCdSt1, observationTransformed);
@@ -320,6 +321,9 @@ public class ProcessObservationDataUtil {
     }
 
     private void transformObservationCoded(String observationCoded) {
+        // Tombstone message to delete previous observation coded data for specified uid
+        sendToKafka(observationKey, null, codedTopicName, observationKey.getObservationUid(), null);
+
         try {
             JsonNode observationCodedJsonArray = parseJsonArray(observationCoded);
 
@@ -342,9 +346,8 @@ public class ProcessObservationDataUtil {
             JsonNode observationDateJsonArray = parseJsonArray(observationDate);
 
             for (JsonNode jsonNode : observationDateJsonArray) {
-                ObservationDate coded = objectMapper.treeToValue(jsonNode, ObservationDate.class);
-                observationKey.setObservationUid(coded.getObservationUid());
-                sendToKafka(observationKey, coded, dateTopicName, coded.getObservationUid(), "Observation Date data (uid={}) sent to {}");
+                ObservationDate obsDate = objectMapper.treeToValue(jsonNode, ObservationDate.class);
+                sendToKafka(observationKey, obsDate, dateTopicName, obsDate.getObservationUid(), "Observation Date data (uid={}) sent to {}");
             }
         } catch (IllegalArgumentException ex) {
             logger.info(ex.getMessage(), "ObservationDate");
@@ -376,7 +379,6 @@ public class ProcessObservationDataUtil {
 
             for (JsonNode jsonNode : observationNumericJsonArray) {
                 ObservationNumeric numeric = objectMapper.treeToValue(jsonNode, ObservationNumeric.class);
-                observationKey.setObservationUid(numeric.getObservationUid());
                 sendToKafka(observationKey, numeric, numericTopicName, numeric.getObservationUid(), "Observation Numeric data (uid={}) sent to {}");
             }
         } catch (IllegalArgumentException ex) {
@@ -388,6 +390,9 @@ public class ProcessObservationDataUtil {
 
     private void transformObservationReasons(String observationReasons) {
         try {
+            // Tombstone message to delete previous observation coded data for specified uid
+            sendToKafka(observationKey, null, reasonTopicName, observationKey.getObservationUid(), null);
+
             JsonNode observationReasonsJsonArray = parseJsonArray(observationReasons);
 
             ObservationReasonKey reasonKey = new ObservationReasonKey();
@@ -405,6 +410,9 @@ public class ProcessObservationDataUtil {
     }
 
     private void transformObservationTxt(String observationTxt) {
+        // Tombstone message to delete previous observation coded data for specified uid
+        sendToKafka(observationKey, null, txtTopicName, observationKey.getObservationUid(), null);
+
         try {
             JsonNode observationTxtJsonArray = parseJsonArray(observationTxt);
 
@@ -424,9 +432,13 @@ public class ProcessObservationDataUtil {
 
     private void sendToKafka(Object key, Object value, String topicName, Long uid, String message) {
         String jsonKey = jsonGenerator.generateStringJson(key);
-        String jsonValue = jsonGenerator.generateStringJson(value);
+        String jsonValue = Optional.ofNullable(value).map(jsonGenerator::generateStringJson).orElse(null);
         kafkaTemplate.send(topicName, jsonKey, jsonValue)
-                .whenComplete((res, e) -> logger.info(message, uid, topicName));
+                .whenComplete((res, e) -> {
+                    if (message != null) {
+                        logger.info(message, uid, topicName);
+                    }
+                });
     }
 
     private JsonNode parseJsonArray(String jsonString) throws JsonProcessingException, IllegalArgumentException {

--- a/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/ObservationServiceTest.java
+++ b/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/ObservationServiceTest.java
@@ -57,6 +57,9 @@ class ObservationServiceTest {
         observationService = new ObservationService(observationRepository, kafkaTemplate, transformer);
         observationService.setObservationTopic(inputTopicName);
         observationService.setObservationTopicOutputReporting(outputTopicName);
+        transformer.setCodedTopicName("ObservationCoded");
+        transformer.setReasonTopicName("ObservationReason");
+        transformer.setTxtTopicName("ObservationTxt");
     }
 
     @AfterEach
@@ -74,6 +77,7 @@ class ObservationServiceTest {
         Observation observation = constructObservation(observationUid, obsDomainCdSt);
         when(observationRepository.computeObservations(String.valueOf(observationUid))).thenReturn(Optional.of(observation));
         when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenReturn(CompletableFuture.completedFuture(null));
+        when(kafkaTemplate.send(anyString(), anyString(), isNull())).thenReturn(CompletableFuture.completedFuture(null));
 
         validateData(payload, observation);
 
@@ -105,7 +109,7 @@ class ObservationServiceTest {
 
         var reportingModel = constructObservationReporting(observation.getObservationUid(), observation.getObsDomainCdSt1());
 
-        verify(kafkaTemplate, times(2)).send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
+        verify(kafkaTemplate, times(5)).send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
         String actualTopic = topicCaptor.getValue();
         String actualKey = keyCaptor.getValue();
         String actualValue = messageCaptor.getValue();


### PR DESCRIPTION
## Notes

Implements tombstone messages sending to clear our previous choice for multivalued data related to

- nrt_observation_coded
- nrt_observation_reason
- nrt_observation_txt

## JIRA

- **Related story**: [CNDE-1861](https://cdc-nbs.atlassian.net/browse/CNDE-1861)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?