### PR TITLE
CNDE-1942: LAB100 Result Comment Hydration

### DIFF
--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
@@ -1191,7 +1191,7 @@ BEGIN
         SET @PROC_STEP_NAME = 'DELETE LAB_RESULT_COMMENT ';
 
         DELETE lrc
-        FROM LAB_RESULT_COMMENT lrc
+        FROM dbo.LAB_RESULT_COMMENT lrc
             INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = lrc.lab_test_uid
             LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = lrc.lab_test_uid
         WHERE tcg.lab_test_uid IS NULL
@@ -1211,7 +1211,7 @@ BEGIN
         SET @PROC_STEP_NAME = 'DELETE RESULT_COMMENT_GROUP ';
 
         DELETE rcg
-        FROM RESULT_COMMENT_GROUP rcg
+        FROM dbo.RESULT_COMMENT_GROUP rcg
             INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = rcg.lab_test_uid
             LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = rcg.lab_test_uid
         WHERE tcg.lab_test_uid IS NULL

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
@@ -1194,7 +1194,7 @@ BEGIN
         FROM dbo.LAB_RESULT_COMMENT lrc
             INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = lrc.lab_test_uid
             LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = lrc.lab_test_uid
-        WHERE tcg.lab_test_uid IS NULL
+        WHERE tcg.lab_test_uid IS NULL;
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
@@ -1214,7 +1214,7 @@ BEGIN
         FROM dbo.RESULT_COMMENT_GROUP rcg
             INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = rcg.lab_test_uid
             LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = rcg.lab_test_uid
-        WHERE tcg.lab_test_uid IS NULL
+        WHERE tcg.lab_test_uid IS NULL;
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
@@ -711,14 +711,14 @@ BEGIN
         WHERE rtrim(Test_Result_Val_Cd ) = '';
 
 
-       UPDATE #TMP_Lab_Result_Val
+        UPDATE #TMP_Lab_Result_Val
         SET Test_Result_Val_Cd_Desc  = NULL
         WHERE rtrim(Test_Result_Val_Cd_Desc  ) = '';
 
 
         UPDATE #TMP_Lab_Result_Val
         SET Result_Units  = NULL
-    WHERE rtrim(Result_Units  ) = '';
+        WHERE rtrim(Result_Units  ) = '';
 
 
         UPDATE #TMP_Lab_Result_Val
@@ -1184,11 +1184,51 @@ BEGIN
 
         COMMIT TRANSACTION;
 
+
         BEGIN TRANSACTION;
 
+        SET @PROC_STEP_NO =  @PROC_STEP_NO + 1 ;
+        SET @PROC_STEP_NAME = 'DELETE LAB_RESULT_COMMENT ';
+
+        DELETE LRC
+        FROM LAB_RESULT_COMMENT lrc
+            INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = lrc.lab_test_uid
+            LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = lrc.lab_test_uid
+        WHERE tcg.lab_test_uid IS NULL
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]
+        (BATCH_ID,[DATAFLOW_NAME],[PACKAGE_NAME] ,[STATUS_TYPE],[STEP_NUMBER],[STEP_NAME],[ROW_COUNT])
+        VALUES(@BATCH_ID,'D_LABTEST_RESULTS','D_LABTEST_RESULTS','START',  @PROC_STEP_NO,@PROC_STEP_NAME,@ROWCOUNT_NO);
+
+        COMMIT TRANSACTION;
+
+
+        BEGIN TRANSACTION;
 
         SET @PROC_STEP_NO =  @PROC_STEP_NO + 1 ;
-        SET @PROC_STEP_NAME = 'UPDATE Lab_Result_Comment ';
+        SET @PROC_STEP_NAME = 'DELETE RESULT_COMMENT_GROUP ';
+
+        DELETE rcg
+        FROM RESULT_COMMENT_GROUP rcg
+                 INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = rcg.lab_test_uid
+                 LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = rcg.lab_test_uid
+        WHERE tcg.lab_test_uid IS NULL
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+
+        INSERT INTO [DBO].[JOB_FLOW_LOG]
+        (BATCH_ID,[DATAFLOW_NAME],[PACKAGE_NAME] ,[STATUS_TYPE],[STEP_NUMBER],[STEP_NAME],[ROW_COUNT])
+        VALUES(@BATCH_ID,'D_LABTEST_RESULTS','D_LABTEST_RESULTS','START',  @PROC_STEP_NO,@PROC_STEP_NAME,@ROWCOUNT_NO);
+
+        COMMIT TRANSACTION;
+
+
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO =  @PROC_STEP_NO + 1 ;
+        SET @PROC_STEP_NAME = 'UPDATE LAB_RESULT_COMMENT ';
 
 
         UPDATE dbo.Lab_Result_Comment
@@ -1216,7 +1256,7 @@ BEGIN
 
 
         SET @PROC_STEP_NO =  @PROC_STEP_NO + 1 ;
-        SET @PROC_STEP_NAME = 'INSERTING INTO Lab_Result_Comment ';
+        SET @PROC_STEP_NAME = 'INSERTING INTO LAB_RESULT_COMMENT ';
 
 
         INSERT INTO dbo.Lab_Result_Comment
@@ -1268,8 +1308,6 @@ BEGIN
 
         UPDATE dbo.LAB_TEST_RESULT
         SET
-            [LAB_TEST_KEY]	 =	tmp.[LAB_TEST_KEY],
-            [LAB_TEST_UID]	 =	tmp.[LAB_TEST_UID],
             [RESULT_COMMENT_GRP_KEY]	 =	tmp.[RESULT_COMMENT_GRP_KEY],
             [TEST_RESULT_GRP_KEY]	 =	tmp.[TEST_RESULT_GRP_KEY],
             [PERFORMING_LAB_KEY]	 =	tmp.[PERFORMING_LAB_KEY],
@@ -1288,9 +1326,8 @@ BEGIN
             [RECORD_STATUS_CD]	 =	SUBSTRING(tmp.RECORD_STATUS_CD ,1,8),
             [RDB_LAST_REFRESH_TIME]	 =	GETDATE()
         FROM #TMP_LAB_TEST_RESULT tmp
-                 INNER JOIN dbo.LAB_TEST_RESULT val with (nolock) ON val.LAB_TEST_UID = tmp.LAB_TEST_UID
-            AND val.RESULT_COMMENT_GRP_KEY = tmp.RESULT_COMMENT_GRP_KEY
-            AND val.TEST_RESULT_GRP_KEY = tmp.TEST_RESULT_GRP_KEY;
+            INNER JOIN dbo.LAB_TEST_RESULT val with (nolock) ON val.LAB_TEST_UID = tmp.LAB_TEST_UID
+                AND val.LAB_TEST_KEY = tmp.LAB_TEST_KEY;
 
 
         IF @pDebug = 'true' SELECT 'TMP_LAB_TEST_RESULT', * FROM #TMP_LAB_TEST_RESULT;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/017-sp_d_labtest_result_postprocessing-002.sql
@@ -1190,7 +1190,7 @@ BEGIN
         SET @PROC_STEP_NO =  @PROC_STEP_NO + 1 ;
         SET @PROC_STEP_NAME = 'DELETE LAB_RESULT_COMMENT ';
 
-        DELETE LRC
+        DELETE lrc
         FROM LAB_RESULT_COMMENT lrc
             INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = lrc.lab_test_uid
             LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = lrc.lab_test_uid
@@ -1212,8 +1212,8 @@ BEGIN
 
         DELETE rcg
         FROM RESULT_COMMENT_GROUP rcg
-                 INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = rcg.lab_test_uid
-                 LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = rcg.lab_test_uid
+            INNER JOIN #TMP_LAB_TEST_RESULT ltr ON ltr.lab_test_uid = rcg.lab_test_uid
+            LEFT JOIN #TMP_RESULT_COMMENT_GROUP tcg ON tcg.lab_test_uid = rcg.lab_test_uid
         WHERE tcg.lab_test_uid IS NULL
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;


### PR DESCRIPTION
## Notes

Fix for `LAB100` datamart - lab test result comment update/delete.

- `UPDATE LAB_TEST_RESULT` query fixed
- `LAB_RESULT_COMMENT` and `RESULT_COMMENT_GROUP` records deleted if comment is deleted

## JIRA

- **Related story**: [CNDE-1942](https://cdc-nbs.atlassian.net/browse/CNDE-1942)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?