### PR TITLE
CNDE-1951: Re-order Hepatitis datamart post-processing

### DIFF
--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -40,6 +40,7 @@ public class ProcessDatamartData {
                     String jsonMessage = jsonGenerator.generateStringJson(dmart);
 
                     kafkaTemplate.send(datamartTopic, jsonKey, jsonMessage);
+                    logger.info("Datamart data: PHC uid={}, condition_cd={} sent to {} topic", dmart.getPublicHealthCaseUid(), dmart.getConditionCd(), datamartTopic);
                 }
             } catch (Exception e) {
                 logger.error("Error processing Datamart JSON array from investigation result data: {}", e.getMessage());


### PR DESCRIPTION
## Notes

Move Hepatitis Datamart Post-Processing to end of chain.

- Relocated the post-processing method for generating the Hepatitis datamart topic to the end of the post-processing chain.
- Ensures all dependent data (patient, investigation, notification, lab) is processed before scheduling the datamart run.

## JIRA

- **Related story**: [CNDE-1951](https://cdc-nbs.atlassian.net/browse/CNDE-1951)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?