### PR TITLE
CNDE-2043

### DIFF
--- a/db/upgrade/rdb_modern/routines/022-sp_d_interview_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/022-sp_d_interview_postprocessing.sql
@@ -243,8 +243,6 @@ BEGIN
         ' WHERE
         ix.D_INTERVIEW_KEY IS NOT NULL;';
 
-        SELECT @Update_sql;
-
         exec sp_executesql @Update_sql;
 
 

--- a/db/upgrade/rdb_modern/tables/022-create_nrt_interview_key.sql
+++ b/db/upgrade/rdb_modern/tables/022-create_nrt_interview_key.sql
@@ -1,13 +1,17 @@
-DROP TABLE IF EXISTS dbo.nrt_interview_key;
+-- table is not dropped and recreated, as D_INTERVIEW_KEY does not retain the key-uid relationship
 
-CREATE TABLE dbo.nrt_interview_key (
-	d_interview_key bigint IDENTITY(1,1) NOT NULL,
-	interview_uid bigint NULL
-);
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_key' and xtype = 'U')
+    BEGIN
 
-declare @max bigint;
-select @max=max(D_INTERVIEW_KEY)+1 from dbo.D_INTERVIEW;
-select @max;
-if @max IS NULL   --check when max is returned as null
-  SET @max = 1;
-DBCC CHECKIDENT ('dbo.nrt_interview_key', RESEED, @max);
+        CREATE TABLE dbo.nrt_interview_key (
+            d_interview_key bigint IDENTITY (1,1) NOT NULL,
+            interview_uid   bigint                NULL
+        );
+        declare @max bigint;
+        select @max=max(d_interview_key)+1 from dbo.D_INTERVIEW ;
+        select @max;
+        if @max IS NULL   --check when max is returned as null
+            SET @max = 2; -- default to 2, as default record with key = 1 is not stored in D_INTERVIEW
+        DBCC CHECKIDENT ('dbo.nrt_interview_key', RESEED, @max);
+
+    END

--- a/db/upgrade/rdb_modern/tables/022-create_nrt_interview_note_key.sql
+++ b/db/upgrade/rdb_modern/tables/022-create_nrt_interview_note_key.sql
@@ -1,14 +1,18 @@
-DROP TABLE IF EXISTS dbo.nrt_interview_note_key;
+-- table is not dropped and recreated so as to stay consistent with the design of nrt_interview_key
 
-CREATE TABLE dbo.nrt_interview_note_key (
-	d_interview_note_key bigint IDENTITY(1,1) NOT NULL,
-    d_interview_key bigint NOT NULL,
-	nbs_answer_uid bigint NULL
-);
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_note_key' and xtype = 'U')
+    BEGIN
 
-declare @max bigint;
-select @max=max(D_INTERVIEW_NOTE_KEY)+1 from dbo.D_INTERVIEW_NOTE;
-select @max;
-if @max IS NULL   --check when max is returned as null
-  SET @max = 1;
-DBCC CHECKIDENT ('dbo.nrt_interview_note_key', RESEED, @max);
+        CREATE TABLE dbo.nrt_interview_note_key (
+          d_interview_note_key bigint IDENTITY(1,1) NOT NULL,
+          d_interview_key bigint NOT NULL,
+          nbs_answer_uid bigint NULL
+        );
+        declare @max bigint;
+        select @max=max(d_interview_note_key)+1 from dbo.D_INTERVIEW_NOTE ;
+        select @max;
+        if @max IS NULL   --check when max is returned as null
+            SET @max = 2; -- default to 2, as default record with key = 1 is not stored in D_INTERVIEW_NOTE
+        DBCC CHECKIDENT ('dbo.nrt_interview_note_key', RESEED, @max);
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/023-sp_d_interview_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/023-sp_d_interview_postprocessing-001.sql
@@ -243,8 +243,6 @@ BEGIN
         ' WHERE
         ix.D_INTERVIEW_KEY IS NOT NULL;';
 
-        SELECT @Update_sql;
-
         exec sp_executesql @Update_sql;
 
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_key-001.sql
@@ -1,3 +1,5 @@
+-- table is not dropped and recreated, as D_INTERVIEW_KEY does not retain the key-uid relationship
+
 IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_key' and xtype = 'U')
     BEGIN
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_key-001.sql
@@ -1,13 +1,15 @@
-DROP TABLE IF EXISTS dbo.nrt_interview_key;
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_key' and xtype = 'U')
+    BEGIN
 
-CREATE TABLE dbo.nrt_interview_key (
-	d_interview_key bigint IDENTITY(1,1) NOT NULL,
-	interview_uid bigint NULL
-);
+        CREATE TABLE dbo.nrt_interview_key (
+            d_interview_key bigint IDENTITY (1,1) NOT NULL,
+            interview_uid   bigint                NULL
+        );
+        declare @max bigint;
+        select @max=max(d_interview_key)+1 from dbo.D_INTERVIEW ;
+        select @max;
+        if @max IS NULL   --check when max is returned as null
+            SET @max = 2; -- default to 2, as default record with key = 1 is not stored in D_INTERVIEW
+        DBCC CHECKIDENT ('dbo.nrt_interview_key', RESEED, @max);
 
-declare @max bigint;
-select @max=max(D_INTERVIEW_KEY)+1 from dbo.D_INTERVIEW;
-select @max;
-if @max IS NULL   --check when max is returned as null
-  SET @max = 1;
-DBCC CHECKIDENT ('dbo.nrt_interview_key', RESEED, @max);
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_note_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_note_key-001.sql
@@ -1,3 +1,5 @@
+-- table is not dropped and recreated so as to stay consistent with the design of nrt_interview_key
+
 IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_note_key' and xtype = 'U')
     BEGIN
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_note_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/022-create_nrt_interview_note_key-001.sql
@@ -1,14 +1,16 @@
-DROP TABLE IF EXISTS dbo.nrt_interview_note_key;
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_interview_note_key' and xtype = 'U')
+    BEGIN
 
-CREATE TABLE dbo.nrt_interview_note_key (
-	d_interview_note_key bigint IDENTITY(1,1) NOT NULL,
-    d_interview_key bigint NOT NULL,
-	nbs_answer_uid bigint NULL
-);
+        CREATE TABLE dbo.nrt_interview_note_key (
+          d_interview_note_key bigint IDENTITY(1,1) NOT NULL,
+          d_interview_key bigint NOT NULL,
+          nbs_answer_uid bigint NULL
+        );
+        declare @max bigint;
+        select @max=max(d_interview_note_key)+1 from dbo.D_INTERVIEW_NOTE ;
+        select @max;
+        if @max IS NULL   --check when max is returned as null
+            SET @max = 2; -- default to 2, as default record with key = 1 is not stored in D_INTERVIEW_NOTE
+        DBCC CHECKIDENT ('dbo.nrt_interview_note_key', RESEED, @max);
 
-declare @max bigint;
-select @max=max(D_INTERVIEW_NOTE_KEY)+1 from dbo.D_INTERVIEW_NOTE;
-select @max;
-if @max IS NULL   --check when max is returned as null
-  SET @max = 1;
-DBCC CHECKIDENT ('dbo.nrt_interview_note_key', RESEED, @max);
+    END


### PR DESCRIPTION
## Notes

nrt_interview_key and nrt_interview_note_key tables are being truncated on updates through liquibase. This needs to be fixed as the target tables do not maintain the key-uid relationship.

As part of this PR, I also removed a SELECT statement from sp_d_interview_postprocessing that caused the stored procedure to return data when it did not actually need to.

## JIRA

- **Related story**: [CNDE-2043](https://cdc-nbs.atlassian.net/browse/CNDE-2043)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?