### PR TITLE
CNDE-2215: Legacy Case Mart Bugfix (improper filtering)

### DIFF
--- a/db/upgrade/rdb_modern/routines/029-sp_generic_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/029-sp_generic_case_datamart_postprocessing.sql
@@ -77,7 +77,7 @@ BEGIN TRY
             INV_ASSIGNED_DT_KEY,
             LDF_GROUP_KEY,
             GEOCODING_LOCATION_KEY,
-            effective_duration_amt as ILLNESS_DURATION,
+            NULLIF(effective_duration_amt, '') as ILLNESS_DURATION,
             effective_duration_unit_cd as ILLNESS_DURATION_UNIT,
             pat_age_at_onset as PATIENT_AGE_AT_ONSET,
             pat_age_at_onset_unit_cd as PATIENT_AGE_AT_ONSET_UNIT,
@@ -126,7 +126,7 @@ BEGIN TRY
              on UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
              and UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'code')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
         ;
 
         if
@@ -164,7 +164,7 @@ BEGIN TRY
                 on UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 and UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'from_time')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
          and  unique_cd != 'INV110';
 
         if
@@ -209,7 +209,7 @@ BEGIN TRY
             ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
             AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'numeric_value_1')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
         ;
 
         if

--- a/db/upgrade/rdb_modern/routines/030-sp_rubella_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/030-sp_rubella_case_datamart_postprocessing.sql
@@ -121,13 +121,14 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
-
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
                 select @Proc_Step_Name as step, *
                 from #OBS_CODED_Rubella_Case;
+
+
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
@@ -162,7 +163,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -202,7 +203,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(col_nm)
             WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'from_time' or unique_cd in ('INV132','INV133'))
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -248,7 +249,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -264,6 +265,7 @@ BEGIN
                     @RowCount_no);
 
         COMMIT TRANSACTION;
+
 
             SET
                 @PROC_STEP_NO = @PROC_STEP_NO + 1;

--- a/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
@@ -140,7 +140,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm) 
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
 
             if
@@ -180,7 +180,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -220,7 +220,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'from_time'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
             --AND unique_cd != 'CRS013'
             
             /*
@@ -273,7 +273,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
             -- WHERE ((RDB_TABLE = 'CRS_Case' and db_field = 'numeric_value_1') or unique_cd = 'CRS013')
             --   and public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ','));
 

--- a/db/upgrade/rdb_modern/routines/032-sp_measles_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/032-sp_measles_case_datamart_postprocessing.sql
@@ -121,7 +121,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
 
             if
@@ -161,7 +161,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -201,7 +201,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'from_time'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -246,7 +246,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
@@ -77,7 +77,7 @@ BEGIN TRY
             INV_ASSIGNED_DT_KEY,
             LDF_GROUP_KEY,
             GEOCODING_LOCATION_KEY,
-            effective_duration_amt as ILLNESS_DURATION,
+            NULLIF(effective_duration_amt, '') as ILLNESS_DURATION,
             effective_duration_unit_cd as ILLNESS_DURATION_UNIT,
             pat_age_at_onset as PATIENT_AGE_AT_ONSET,
             pat_age_at_onset_unit_cd as PATIENT_AGE_AT_ONSET_UNIT,
@@ -126,7 +126,7 @@ BEGIN TRY
              on UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
              and UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'code')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
         ;
 
         if
@@ -164,7 +164,7 @@ BEGIN TRY
                 on UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 and UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'from_time')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
          and  unique_cd != 'INV110';
 
         if
@@ -209,7 +209,7 @@ BEGIN TRY
             ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
             AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
         WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'numeric_value_1')
-          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) or isc.column_name IS NOT NULL)
+          and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_ids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL))
         ;
 
         if

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/031-sp_rubella_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/031-sp_rubella_case_datamart_postprocessing-001.sql
@@ -121,13 +121,14 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
-
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
                 select @Proc_Step_Name as step, *
                 from #OBS_CODED_Rubella_Case;
+
+
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
@@ -162,7 +163,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -202,7 +203,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(col_nm)
             WHERE (RDB_TABLE = @tgt_table_nm and db_field = 'from_time' or unique_cd in ('INV132','INV133'))
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -248,7 +249,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -264,6 +265,7 @@ BEGIN
                     @RowCount_no);
 
         COMMIT TRANSACTION;
+
 
             SET
                 @PROC_STEP_NO = @PROC_STEP_NO + 1;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/032-sp_crs_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/032-sp_crs_case_datamart_postprocessing-001.sql
@@ -140,7 +140,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm) 
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
 
             if
@@ -180,7 +180,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -220,7 +220,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'from_time'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
             --AND unique_cd != 'CRS013'
             
             /*
@@ -273,7 +273,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
             -- WHERE ((RDB_TABLE = 'CRS_Case' and db_field = 'numeric_value_1') or unique_cd = 'CRS013')
             --   and public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ','));
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/033-sp_measles_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/033-sp_measles_case_datamart_postprocessing-001.sql
@@ -121,7 +121,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'code'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
 
             if
@@ -161,7 +161,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'value_txt'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -201,7 +201,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE RDB_TABLE = @tgt_table_nm and db_field = 'from_time'
-              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+              and (public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'
@@ -246,7 +246,7 @@ BEGIN
                 ON UPPER(isc.TABLE_NAME) = UPPER(rom.RDB_table)
                 AND UPPER(isc.COLUMN_NAME) = UPPER(rom.col_nm)
             WHERE rom.RDB_TABLE = @tgt_table_nm and rom.db_field = 'numeric_value_1'
-            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR isc.column_name IS NOT NULL);
+            and (rom.public_health_case_uid in (SELECT value FROM STRING_SPLIT(@phc_uids, ',')) OR (public_health_case_uid IS NULL and isc.column_name IS NOT NULL));
 
             if
                 @debug = 'true'


### PR DESCRIPTION
## Notes

In QA testing it was found that there were some date values not populating properly. The cause of this was most likely a result of an issue where information from other investigations were being improperly brought in by the stored procedure. This PR fixes that issue, as well as another issue found incidentally when testing the Generic_Case flow where some values needed to be set to `NULL` if they were an empty string.

## JIRA

- **Related story**: [CNDE-2215](https://cdc-nbs.atlassian.net/browse/CNDE-2215)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?