### PR TITLE
CNDE-2220: Add label column to coded temp table (Bugfix)

### DIFF
--- a/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
@@ -131,6 +131,7 @@ BEGIN
                    cd,
                    DB_field,
                    rdb_table,
+                   label,
                    col_nm,
                    response
             INTO #OBS_CODED_CRS_Case


### PR DESCRIPTION
## Notes

The column label is missing from #OBS_CODED_CRS_Case. This is causing the datamart modification proc to fail within CRS_Case. 

Fix: The column is already in the CTE used to create the temp table, but needs to be referenced in the actual select statement as well.

## JIRA

- **Related story**: [CNDE-2220](https://cdc-nbs.atlassian.net/browse/CNDE-2220)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?