### PR TITLE
CNDE-2253: Add feature flags for BMIRD, Contact Record and Event Metric

### DIFF
--- a/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
+++ b/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
@@ -37,6 +37,11 @@ public class UtilHelper {
         }
     }
 
+    public static String extractValue(String message, String fieldName) throws Exception {
+        JsonNode jsonNode = objectMapper.readTree(message);
+        return jsonNode.get("payload").path("after").path(fieldName).asText();
+    }
+
     public static String errorMessage(String entityName, String ids, Exception e) {
         return "Error processing " + entityName + " data" +
                 (!ids.isEmpty() ? " with ids '" + ids + "': " : ": " + e.getMessage());

--- a/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
+++ b/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
@@ -27,7 +27,7 @@ public class UtilHelper {
         return null;
     }
 
-    public static String extractUid(String value, String uidName) throws Exception {
+    public static String extractUid(String value, String uidName) throws JsonProcessingException {
         JsonNode jsonNode = objectMapper.readTree(value);
         JsonNode payloadNode = jsonNode.get("payload").path("after");
         if (!payloadNode.isMissingNode() && payloadNode.has(uidName)) {
@@ -37,7 +37,7 @@ public class UtilHelper {
         }
     }
 
-    public static String extractValue(String message, String fieldName) throws Exception {
+    public static String extractValue(String message, String fieldName) throws JsonProcessingException {
         JsonNode jsonNode = objectMapper.readTree(message);
         return jsonNode.get("payload").path("after").path(fieldName).asText();
     }

--- a/db/upgrade/rdb_modern/tables/019-create_nrt_datamart_metadata.sql
+++ b/db/upgrade/rdb_modern/tables/019-create_nrt_datamart_metadata.sql
@@ -150,15 +150,14 @@ IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_datamart_metadata' and xty
                 INSERT INTO dbo.nrt_datamart_metadata
                 VALUES ('', '', 'Case_Lab_Datamart', 'sp_case_lab_datamart_postprocessing')
             END;
-    END;
 
-    /*BMIRD_Case Datamart condition code addition script.*/
+        /*BMIRD_Case Datamart condition code addition script.*/
         IF NOT EXISTS (SELECT 1 FROM dbo.nrt_datamart_metadata ndm WHERE ndm.Datamart = 'Bmird_Case_Datamart')
             BEGIN
                 INSERT INTO dbo.nrt_datamart_metadata
                 SELECT condition_cd,
                        condition_desc_txt,
-                       'Bmird_Case_Datamart',
+                       'BMIRD_Case',
                        'sp_bmird_case_datamart_postprocessing'
                 FROM
                     (SELECT distinct cc.condition_cd, cc.condition_desc_txt
@@ -170,3 +169,4 @@ IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_datamart_metadata' and xty
                            FROM dbo.nrt_datamart_metadata ndm
                            WHERE ndm.condition_cd = bmird_codes.condition_cd);
             END;
+    END;

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -43,7 +43,9 @@ spring:
       url: ${DB_RDB_URL:jdbc:sqlserver://localhost:1433;databaseName=:RDB;encrypt=true;trustServerCertificate=true;}
   liquibase:
     change-log: db/changelog/db.changelog-master.yaml
-service:
-  phc-datamart-enable: ${PHC_DM_ENABLE:false}
+featureFlag:
+  phc-datamart-enable: ${FF_PHC_DM_ENABLE:false}
+  bmird-case-enable: ${FF_BMIRD_CASE_ENABLE:false}
+  contact-record-enable: ${FF_CONTACT_RECORD_ENABLE:false}
 server:
   port: '8093'

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/019-create_nrt_datamart_metadata-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/019-create_nrt_datamart_metadata-001.sql
@@ -150,23 +150,23 @@ IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_datamart_metadata' and xty
                 INSERT INTO dbo.nrt_datamart_metadata
                 VALUES ('', '', 'Case_Lab_Datamart', 'sp_case_lab_datamart_postprocessing')
             END;
-    END;
 
-    /*BMIRD_Case Datamart condition code addition script.*/
-    IF NOT EXISTS (SELECT 1 FROM dbo.nrt_datamart_metadata ndm WHERE ndm.Datamart = 'Bmird_Case_Datamart')
-        BEGIN
-            INSERT INTO dbo.nrt_datamart_metadata
-            SELECT condition_cd,
-                   condition_desc_txt,
-                   'Bmird_Case_Datamart',
-                   'sp_bmird_case_datamart_postprocessing'
-            FROM
-                (SELECT distinct cc.condition_cd, cc.condition_desc_txt
-                 FROM NBS_SRTE.dbo.Condition_code cc
-                 WHERE (cc.investigation_form_cd IS NOT NULL and cc.investigation_form_cd LIKE 'INV_FORM_BMD%')
-                ) bmird_codes
-            WHERE NOT EXISTS
-                      (SELECT 1
-                       FROM dbo.nrt_datamart_metadata ndm
-                       WHERE ndm.condition_cd = bmird_codes.condition_cd);
-        END;
+        /*BMIRD_Case Datamart condition code addition script.*/
+        IF NOT EXISTS (SELECT 1 FROM dbo.nrt_datamart_metadata ndm WHERE ndm.Datamart = 'Bmird_Case_Datamart')
+            BEGIN
+                INSERT INTO dbo.nrt_datamart_metadata
+                SELECT condition_cd,
+                       condition_desc_txt,
+                       'BMIRD_Case',
+                       'sp_bmird_case_datamart_postprocessing'
+                FROM
+                    (SELECT distinct cc.condition_cd, cc.condition_desc_txt
+                     FROM NBS_SRTE.dbo.Condition_code cc
+                     WHERE (cc.investigation_form_cd IS NOT NULL and cc.investigation_form_cd LIKE 'INV_FORM_BMD%')
+                    ) bmird_codes
+                WHERE NOT EXISTS
+                          (SELECT 1
+                           FROM dbo.nrt_datamart_metadata ndm
+                           WHERE ndm.condition_cd = bmird_codes.condition_cd);
+            END;
+    END;

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/Entity.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/Entity.java
@@ -27,7 +27,7 @@ enum Entity {
     RUBELLA_CASE(0, "Rubella_Case", Constants.PHC_UID, "sp_rubella_case_datamart_postprocessing"),
     MEASLES_CASE(0, "Measles_Case", Constants.PHC_UID, "sp_measles_case_datamart_postprocessing"),
     CASE_LAB_DATAMART(0, "Case_Lab_Datamart", Constants.PHC_UID, "sp_case_lab_datamart_postprocessing"),
-    BMIRD_CASE_DATAMART(0, "Bmird_Case_Datamart", Constants.PHC_UID, "sp_bmird_case_datamart_postprocessing"),
+    BMIRD_CASE(0, "BMIRD_Case", Constants.PHC_UID, "sp_bmird_case_datamart_postprocessing"),
     UNKNOWN(-1, "unknown", "unknown_uid", "sp_nrt_unknown_postprocessing");
 
     private final int priority;

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -8,9 +8,11 @@ import gov.cdc.etldatapipeline.postprocessingservice.repository.model.DatamartDa
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.dto.Datamart;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.kafka.common.errors.SerializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.retrytopic.DltStrategy;
@@ -39,6 +41,7 @@ import static gov.cdc.etldatapipeline.postprocessingservice.service.Entity.*;
 
 @Service
 @RequiredArgsConstructor
+@Setter
 @EnableScheduling
 public class PostProcessingService {
     private static final Logger logger = LoggerFactory.getLogger(PostProcessingService.class);
@@ -61,6 +64,9 @@ public class PostProcessingService {
 
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
     private final Object cacheLock = new Object();
+
+    @Value("${featureFlag.event-metric-enable}")
+    private boolean eventMetricEnabled;
 
     @RetryableTopic(
             attempts = "${spring.kafka.consumer.max-retry}",
@@ -252,7 +258,9 @@ public class PostProcessingService {
             }
             datamartProcessor.process(dmData);
 
-            processEventMetricDatamart(investigationUids, observationUids, notificationUids, contactRecordUids);
+            if (eventMetricEnabled) {
+                processEventMetricDatamart(investigationUids, observationUids, notificationUids, contactRecordUids);
+            }
         } else {
             logger.info("No ids to process from the topics.");
         }
@@ -359,10 +367,10 @@ public class PostProcessingService {
                         investigationRepository.executeStoredProcForCaseLabDatamart(cases);
                         completeLog(CASE_LAB_DATAMART.getStoredProcedure());
                         break;
-                    case BMIRD_CASE_DATAMART:
-                        logger.info(PROCESSING_MESSAGE_TOPIC_LOG_MSG, dmType, BMIRD_CASE_DATAMART.getStoredProcedure(), cases);
+                    case BMIRD_CASE:
+                        logger.info(PROCESSING_MESSAGE_TOPIC_LOG_MSG, dmType, BMIRD_CASE.getStoredProcedure(), cases);
                         investigationRepository.executeStoredProcForBmirdCaseDatamart(cases);
-                        completeLog(BMIRD_CASE_DATAMART.getStoredProcedure());
+                        completeLog(BMIRD_CASE.getStoredProcedure());
                         break;
                     default:
                         logger.info("No associated datamart processing logic found for the key: {} ",dmType);

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -66,7 +66,7 @@ public class PostProcessingService {
     private final Object cacheLock = new Object();
 
     @Value("${featureFlag.event-metric-enable}")
-    private boolean eventMetricEnabled;
+    private boolean eventMetricEnable;
 
     @RetryableTopic(
             attempts = "${spring.kafka.consumer.max-retry}",
@@ -258,7 +258,7 @@ public class PostProcessingService {
             }
             datamartProcessor.process(dmData);
 
-            if (eventMetricEnabled) {
+            if (eventMetricEnable) {
                 processEventMetricDatamart(investigationUids, observationUids, notificationUids, contactRecordUids);
             }
         } else {
@@ -437,7 +437,7 @@ public class PostProcessingService {
     /**
      * Gets the Entity by using the string passed to this function
      * E.g: if dummy_contact_record is passed, it will return the entity CONTACT_RECORD
-     * @param topic
+     * @param topic Incoming Kafka topic
      * @return Entity
      */
     private Entity getEntityByTopic(String topic) {

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -56,10 +56,12 @@ public class ProcessDatamartData {
     private List<DatamartData> reduce(List<DatamartData> dmData) {
         List<Long> hepUidsAlreadyInDmData =
                 dmData.stream()
+                        .filter(Objects::nonNull)
                         .filter(d -> HEPATITIS_DATAMART.getEntityName().equals(d.getDatamart()))
                         .map(DatamartData::getPublicHealthCaseUid).toList();
 
         return dmData.stream()
+                .filter(Objects::nonNull)
                 .filter(d -> {
                     boolean isCaseLab = CASE_LAB_DATAMART.getEntityName().equals(d.getDatamart());
                     boolean hasHepAlready = hepUidsAlreadyInDmData.contains(d.getPublicHealthCaseUid());

--- a/post-processing-service/src/main/resources/application.yaml
+++ b/post-processing-service/src/main/resources/application.yaml
@@ -35,6 +35,8 @@ spring:
   jpa:
     properties:
       javax.persistence.query.timeout: -1
+featureFlag:
+  event-metric-enable: ${FF_EVENT_METRIC_ENABLE:false}
 service:
   fixed-delay:
     cached-ids: ${FIXED_DELAY_ID:20000}

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
@@ -94,7 +94,7 @@ class DatamartProcessingTest {
                 Arguments.of("10200", RUBELLA_CASE.getEntityName(), RUBELLA_CASE.getStoredProcedure(), "RubellaCaseDatamart.json"),
                 Arguments.of("10140", MEASLES_CASE.getEntityName(), MEASLES_CASE.getStoredProcedure(), "MeaslesCaseDatamart.json"),
                 Arguments.of(null, CASE_LAB_DATAMART.getEntityName(), CASE_LAB_DATAMART.getStoredProcedure(), "CaseLabDatamart.json"),
-                Arguments.of("10160", BMIRD_CASE_DATAMART.getEntityName(), BMIRD_CASE_DATAMART.getStoredProcedure(), "BMIRDCaseDatamart.json")
+                Arguments.of("10160", BMIRD_CASE.getEntityName(), BMIRD_CASE.getStoredProcedure(), "BMIRDCaseDatamart.json")
         );
     }
 

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -55,6 +55,7 @@ class PostProcessingServiceTest {
         datamartProcessor = new ProcessDatamartData(kafkaTemplate);
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
+        postProcessingServiceMock.setEventMetricEnabled(true);
         Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
         listAppender.start();
         logger.addAppender(listAppender);
@@ -515,9 +516,9 @@ class PostProcessingServiceTest {
                     (repo, uid) -> verify(repo).executeStoredProcForCaseLabDatamart(uid)),
                 new DatamartTestCase(
                         "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10160\"," +
-                                "\"datamart\":\"Bmird_Case_Datamart\",\"stored_procedure\":\"sp_bmird_case_datamart_postprocessing\"}}",
-                        BMIRD_CASE_DATAMART.getEntityName(),
-                        BMIRD_CASE_DATAMART.getStoredProcedure(),
+                                "\"datamart\":\"BMIRD_Case\",\"stored_procedure\":\"sp_bmird_case_datamart_postprocessing\"}}",
+                        BMIRD_CASE.getEntityName(),
+                        BMIRD_CASE.getStoredProcedure(),
                         3,
                         (repo, uid) -> verify(repo).executeStoredProcForBmirdCaseDatamart(uid))
         );
@@ -579,8 +580,6 @@ class PostProcessingServiceTest {
 
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals("No updates to EVENT_METRIC Datamart", logs.getLast().getFormattedMessage());
-
-
     }
 
     @Test
@@ -606,7 +605,6 @@ class PostProcessingServiceTest {
         postProcessingServiceMock.processCachedIds();
 
         verify(postProcRepositoryMock).executeStoredProcForEventMetric("126,235", "130", "127", "123");
-
     }
 
     @Test

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -55,7 +55,7 @@ class PostProcessingServiceTest {
         datamartProcessor = new ProcessDatamartData(kafkaTemplate);
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
-        postProcessingServiceMock.setEventMetricEnabled(true);
+        postProcessingServiceMock.setEventMetricEnable(true);
         Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
         listAppender.start();
         logger.addAppender(listAppender);
@@ -605,6 +605,18 @@ class PostProcessingServiceTest {
         postProcessingServiceMock.processCachedIds();
 
         verify(postProcRepositoryMock).executeStoredProcForEventMetric("126,235", "130", "127", "123");
+    }
+
+    @Test
+    void testPostProcessEventMetricWhenDisabled() {
+
+        String investigationKey1 = "{\"payload\":{\"public_health_case_uid\":126}}";
+        String invTopic = "dummy_investigation";
+        postProcessingServiceMock.setEventMetricEnable(false);
+        postProcessingServiceMock.postProcessMessage(invTopic, investigationKey1, investigationKey1);
+        postProcessingServiceMock.processCachedIds();
+
+        verify(postProcRepositoryMock, never()).executeStoredProcForEventMetric(anyString(), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/post-processing-service/src/test/resources/rawDataFiles/BMIRDCaseDatamart.json
+++ b/post-processing-service/src/test/resources/rawDataFiles/BMIRDCaseDatamart.json
@@ -33,7 +33,7 @@
     "public_health_case_uid": 123,
     "patient_uid": 456,
     "condition_cd": "10160",
-    "datamart": "Bmird_Case_Datamart",
+    "datamart": "BMIRD_Case",
     "stored_procedure": "sp_bmird_case_datamart_postprocessing"
   }
 }


### PR DESCRIPTION
## Notes

Adds feature flags for enabling `BMIRD`, `Contact Record` in pre-processing and for `Event Metric` in the post-processing service. Default value is `OFF`. Helm charts will manage the actual flag values for each environment.
A feature flag for `Treatment` will be added when its implementation begins.

## JIRA

- **Related story**: [CNDE-2253](https://cdc-nbs.atlassian.net/browse/CNDE-2253)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?