### PR TITLE
CNDE-2278: fix return statements in postprocessing

### DIFF
--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/002-sp_nrt_organization_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/002-sp_nrt_organization_postprocessing-001.sql
@@ -373,7 +373,7 @@ BEGIN
             ,LEFT(@id_list,500)
             );
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/003-sp_nrt_provider_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/003-sp_nrt_provider_postprocessing-001.sql
@@ -338,7 +338,7 @@ BEGIN
             , LEFT (@id_list, 500)
             );
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/004-sp_nrt_patient_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/004-sp_nrt_patient_postprocessing-001.sql
@@ -556,7 +556,7 @@ BEGIN
             ,LEFT(@id_list,500)
             );
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/005-sp_nrt_investigation_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/005-sp_nrt_investigation_postprocessing-001.sql
@@ -856,7 +856,7 @@ BEGIN
                ,LEFT(@id_list, 500));
 
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/006-sp_nrt_notification_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/006-sp_nrt_notification_postprocessing-001.sql
@@ -363,7 +363,7 @@ BEGIN
             );
 
 
-        RETURN @ErrorMessage;
+        RETURN -1;
 
     END CATCH
 END;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
@@ -501,7 +501,7 @@ BEGIN
             );
 
 
-        RETURN @ErrorMessage;
+        RETURN -1;
 
 
     END CATCH

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
@@ -465,7 +465,7 @@ BEGIN
                ,0
                ,LEFT(@id_list, 500));
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/028-sp_nrt_place_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/028-sp_nrt_place_postprocessing-001.sql
@@ -653,7 +653,7 @@ BEGIN
                , LEFT(@id_list, 500));
 
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/034-sp_case_lab_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/034-sp_case_lab_datamart_postprocessing-001.sql
@@ -1241,7 +1241,6 @@ WHERE EVENT_DATE is null;';
 
         COMMIT TRANSACTION;
 
-        RETURN 0;
 
     END TRY
     BEGIN CATCH

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/035-sp_repeated_place_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/035-sp_repeated_place_postprocessing-001.sql
@@ -630,7 +630,7 @@ BEGIN
                );
 
 
-        return @ErrorMessage;
+        return -1;
 
     END CATCH
 


### PR DESCRIPTION
## Notes

Some post processing stored procedures were incorrectly returning the `@ErrorMessage` variable upon error, when they should have been returning `-1`. This PR contains the fix for that.

## JIRA

- **Related story**: [CNDE-2278](https://cdc-nbs.atlassian.net/browse/CNDE-2278)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?