### PR TITLE
Fix for deadlock due to competing threads on #TEMP_MIN_MAX_NOTIFICATI…

### DIFF
--- a/db/upgrade/rdb_modern/routines/043-sp_inv_summary_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/043-sp_inv_summary_datamart_postprocessing.sql
@@ -1272,10 +1272,13 @@ BEGIN
                       , notification_date               AS NOTIFICATIONDATE
                       , PUBLIC_HEALTH_CASE_UID
         INTO #TEMP_MIN_MAX_NOTIFICATION
-        FROM dbo.nrt_investigation_notification WITH (NOLOCK)
-        WHERE notification_uid IN (SELECT value FROM STRING_SPLIT(@notif_uids, ','))
-           OR PUBLIC_HEALTH_CASE_UID IN (SELECT CASE_UID FROM #TMP_CASE_LAB_DATAMART_MODIFIED_output)
-        OPTION (MAXDOP 1);
+        FROM dbo.nrt_investigation_notification n WITH (NOLOCK)
+        LEFT JOIN (
+            SELECT value FROM STRING_SPLIT(@notif_uids, ',')
+        ) nu ON n.notification_uid = nu.value
+        LEFT JOIN
+            #TMP_CASE_LAB_DATAMART_MODIFIED_output pc ON n.PUBLIC_HEALTH_CASE_UID = pc.CASE_UID
+        WHERE nu.value is not null or pc.CASE_UID is not null;
 
         if @debug = 'true' select @Proc_Step_Name as step, * from #TEMP_MIN_MAX_NOTIFICATION;
 

--- a/db/upgrade/rdb_modern/tables/039-alter_table_add_index.sql
+++ b/db/upgrade/rdb_modern/tables/039-alter_table_add_index.sql
@@ -205,7 +205,10 @@ BEGIN
 CREATE INDEX idx_nrt_obs_coded_obs_uid_code ON dbo.nrt_observation_coded (observation_uid, ovc_code);
 END
 
-
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'idx_nrt_inv_notf_notf_uid' AND object_id = OBJECT_ID('dbo.nrt_investigation_notification'))
+BEGIN
+CREATE INDEX idx_nrt_inv_notf_notf_uid ON dbo.nrt_investigation_notification (notification_uid);
+END
 
 
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/045-sp_inv_summary_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/045-sp_inv_summary_datamart_postprocessing-001.sql
@@ -1272,10 +1272,13 @@ BEGIN
                       , notification_date               AS NOTIFICATIONDATE
                       , PUBLIC_HEALTH_CASE_UID
         INTO #TEMP_MIN_MAX_NOTIFICATION
-        FROM dbo.nrt_investigation_notification WITH (NOLOCK)
-        WHERE notification_uid IN (SELECT value FROM STRING_SPLIT(@notif_uids, ','))
-           OR PUBLIC_HEALTH_CASE_UID IN (SELECT CASE_UID FROM #TMP_CASE_LAB_DATAMART_MODIFIED_output)
-        OPTION (MAXDOP 1);
+        FROM dbo.nrt_investigation_notification n WITH (NOLOCK)
+        LEFT JOIN (
+            SELECT value FROM STRING_SPLIT(@notif_uids, ',')
+        ) nu ON n.notification_uid = nu.value
+        LEFT JOIN
+            #TMP_CASE_LAB_DATAMART_MODIFIED_output pc ON n.PUBLIC_HEALTH_CASE_UID = pc.CASE_UID
+        WHERE nu.value is not null or pc.CASE_UID is not null;
 
         if @debug = 'true' select @Proc_Step_Name as step, * from #TEMP_MIN_MAX_NOTIFICATION;
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/039-alter_table_add_index-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/039-alter_table_add_index-001.sql
@@ -205,7 +205,10 @@ BEGIN
 CREATE INDEX idx_nrt_obs_coded_obs_uid_code ON dbo.nrt_observation_coded (observation_uid, ovc_code);
 END
 
-
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'idx_nrt_inv_notf_notf_uid' AND object_id = OBJECT_ID('dbo.nrt_investigation_notification'))
+BEGIN
+CREATE INDEX idx_nrt_inv_notf_notf_uid ON dbo.nrt_investigation_notification (notification_uid);
+END
 
 
 


### PR DESCRIPTION
## Notes

Fix for deadlock due to competing threads on a step in INV_SUMMARY proc

## JIRA

- **Related story**: CNDE-2152

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?