### PR TITLE
CNDE-2334 hotfix for setting nbsRdbMetadataUid to null

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/PageCaseAnswer.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/PageCaseAnswer.java
@@ -13,7 +13,7 @@ public class PageCaseAnswer {
     private @NonNull Long actUid;
     private @NonNull Long nbsCaseAnswerUid;
     private @NonNull Long nbsUiMetadataUid;
-    private @NonNull Long nbsRdbMetadataUid;
+    private Long nbsRdbMetadataUid;
     private @NonNull Long nbsQuestionUid;
 
     private String rdbTableNm;


### PR DESCRIPTION
## Notes

Hotfix to set nbsRdbMetadataUid to null for Page case answers to accommodate INV data.

## JIRA

- **Related story**: [CNDE-2334](https://cdc-nbs.atlassian.net/browse/CNDE-2334)

## Checklist

- [X] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [X] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [X] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?