### PR TITLE
CNDE-2472: Fix the CVE vulnerability by upgrading SpringBoot version from 3.2.4 to 3.4.4 which will upgrade the embedded tomcat version to `10.1.39`

### DIFF
--- a/common-util/build.gradle
+++ b/common-util/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/investigation-service/build.gradle
+++ b/investigation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/ldfdata-service/build.gradle
+++ b/ldfdata-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.4'
+	id 'org.springframework.boot' version '3.4.4'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'jacoco'
 	id 'org.sonarqube' version '4.2.1.3168'

--- a/liquibase-service/build.gradle
+++ b/liquibase-service/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.liquibase.gradle' version '2.2.2'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/observation-service/build.gradle
+++ b/observation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/organization-service/build.gradle
+++ b/organization-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/person-service/build.gradle
+++ b/person-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/post-processing-service/build.gradle
+++ b/post-processing-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/status-service/build.gradle
+++ b/status-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 


### PR DESCRIPTION
CNDE-2472: Fix the CVE vulnerability by upgrading SpringBoot version from 3.2.4 to 3.4.4 which will upgrade the embedded tomcat version to `10.1.39`