### PR TITLE
CNDE-2381: Replace SRTE db references within stored procedures to nrt_srte

### DIFF
--- a/db/upgrade/rdb_modern/routines/006-sp_s_pagebuilder_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/006-sp_s_pagebuilder_postprocessing.sql
@@ -93,7 +93,7 @@ BEGIN
         INTO #text_data_INV
         FROM #NRT_PAGE AS nrt_page
             INNER JOIN
-            NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+            dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
             ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
             AND (nrt_page.RDB_TABLE_NM = @rdb_table_name AND nrt_page.QUESTION_GROUP_SEQ_NBR IS NULL AND UPPER(nrt_page.DATA_TYPE) = 'TEXT')
@@ -213,7 +213,7 @@ BEGIN
         INTO #CODED_TABLE_INV
         FROM #CASE_ANSWER_PHC_UIDS AS PA WITH(NOLOCK)
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(PA.DATA_TYPE)
         WHERE CVG.CODE_SET_NM = 'NBS_DATA_TYPE'
           AND UPPER(data_type) = 'CODED'
@@ -389,7 +389,7 @@ BEGIN
         WHERE CODED.CODE_SET_GROUP_ID IN
               (
                   SELECT code_set_group_id
-                  FROM nbs_srte..codeset
+                  FROM dbo.nrt_srte_Codeset
                   WHERE CLASS_CD = 'V_State_county_code_value'
               )
         ORDER BY NBS_CASE_ANSWER_UID, RDB_COLUMN_NM;
@@ -423,7 +423,7 @@ BEGIN
         INTO #CODED_TABLE_SNTEMP_INV
         FROM #NRT_PAGE AS nrt_page WITH(NOLOCK) --3
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -481,8 +481,8 @@ BEGIN
                      dbo.nrt_investigation inv
                      on #CODED_TABLE_SNTEMP_INV.page_case_uid = inv.public_health_case_uid
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                          INNER JOIN
                      #NRT_PAGE nrt_page
                      ON nrt_page.act_uid = inv.public_health_case_uid
@@ -687,10 +687,10 @@ BEGIN
         INTO #CODED_COUNTY_TABLE_INV
         FROM #CODED_TABLE_INV AS CODED WITH(NOLOCK) LEFT
                                                         JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                         JOIN
-             NBS_SRTE.dbo.V_STATE_COUNTY_CODE_VALUE AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_State_county_code_value AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT
         WHERE METADATA.CODE_SET_NM = 'COUNTY_CCD';
@@ -793,7 +793,7 @@ BEGIN
         INTO #DATE_DATA_INV
         FROM #NRT_PAGE AS nrt_page
                  LEFT OUTER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -816,15 +816,15 @@ BEGIN
                      dbo.nrt_investigation inv
                      ON nrt_page.ACT_UID = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                 WHERE
                     DATA_TYPE IN ( 'Date/Time', 'Date', 'DATETIME', 'DATE' ) AND
                     (ISDATE(ANSWER_TXT) != 1) AND
                     UPPER(nrt_page.DATA_LOCATION) = 'NBS_CASE_ANSWER.ANSWER_TXT' AND
                     ANSWER_TXT IS NOT NULL AND
                     nrt_page.rdb_table_nm = @rdb_table_name
-                  AND CONDITION_CODE.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD
+                  AND cc.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD
             );
 
 
@@ -954,7 +954,7 @@ BEGIN
         INTO #NUMERIC_BASE_DATA_INV_CAT
         FROM #NRT_PAGE AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -1047,10 +1047,10 @@ BEGIN
         INTO #NUMERIC_DATA_TRANS_INV_CAT
         FROM #NUMERIC_DATA_MERGED_INV_CAT AS CODED WITH(NOLOCK) LEFT
                                                                     JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                                     JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM
         WHERE CVG.CODE = CODED.ANSWER_CODED OR
             ANSWER_CODED IS NULL
@@ -1296,15 +1296,15 @@ BEGIN
                      dbo.nrt_investigation inv
                      ON numeric_inv.page_case_uid = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                          INNER JOIN
                      #NRT_PAGE nrt_page
                      ON nrt_page.act_uid = inv.public_health_case_uid
                 WHERE
                     (isNumeric(numeric_inv.ANSWER_TXT) != 1) AND
                     numeric_inv.ANSWER_TXT IS NOT NULL AND
-                    CONDITION_CODE.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD);
+                    cc.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD);
 
         SELECT @RowCount_no = @@ROWCOUNT;
         INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count] )

--- a/db/upgrade/rdb_modern/routines/009-sp_sld_investigation_repeat_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/009-sp_sld_investigation_repeat_postprocessing.sql
@@ -170,7 +170,7 @@ BEGIN
         INTO #TEXT_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NOT NULL
           AND CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -238,7 +238,7 @@ BEGIN
         INTO #CODED_TABLE_TEMP_REPT
         FROM #NBS_CASE_ANSWER_REPT AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NOT NULL AND
             CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -277,10 +277,10 @@ BEGIN
         INTO #CODED_TABLE_REPT
         FROM #CODED_TABLE_TEMP_REPT AS CODED LEFT
                                                  JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                  JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT;
         /*
@@ -338,10 +338,10 @@ ON #CODED_TABLE_REPT
         INTO #CODED_COUNTY_TABLE_REPT
         FROM #CODED_TABLE_REPT AS CODED WITH(NOLOCK) LEFT
                                                          JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                          JOIN
-             NBS_SRTE.dbo.V_STATE_COUNTY_CODE_VALUE AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_State_county_code_value AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT
         WHERE METADATA.CODE_SET_NM = 'COUNTY_CCD';
@@ -419,7 +419,7 @@ ON #CODED_TABLE_REPT
         INTO #CODED_TABLE_SNTEMP_REPT
         FROM #NBS_CASE_ANSWER_REPT AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
                  INNER JOIN #phc_uids_REPT phc
                             ON phc.PAGE_CASE_UID = nrt_page.act_uid
@@ -457,10 +457,10 @@ ON #CODED_TABLE_REPT
         INTO #CODED_TABLE_SNTEMP_TRANS_A_REPT
         FROM #CODED_TABLE_SNTEMP_REPT AS CODED LEFT
                                                    JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                    JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT_CODE
         ORDER BY NBS_CASE_ANSWER_UID, RDB_COLUMN_NM;
@@ -631,7 +631,7 @@ ON #CODED_TABLE_REPT
         INTO #DATE_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
             CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -653,8 +653,8 @@ ON #CODED_TABLE_REPT
                      dbo.nrt_investigation as inv
                      ON nrt_page.ACT_UID = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                 WHERE
                     DATA_TYPE IN( 'Date/Time', 'Date', 'DATETIME', 'DATE' ) AND
                     (ISDATE(ANSWER_TXT) != 1) AND
@@ -752,7 +752,7 @@ ON #CODED_TABLE_REPT
         INTO #NUMERIC_BASE_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE ANSWER_GROUP_SEQ_NBR IS NOT NULL
           AND CVG.CODE_SET_NM = 'NBS_DATA_TYPE'
@@ -831,10 +831,10 @@ ON #CODED_TABLE_REPT
         INTO #NUMERIC_DATA_TRANS_REPT
         FROM #NUMERIC_DATA_MERGED_REPT AS CODED LEFT
                                                     JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.UNIT_VALUE1 LEFT
                                                     JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 ANSWER_GROUP_SEQ_NBR IS NOT NULL;
 
@@ -882,8 +882,8 @@ ON #CODED_TABLE_REPT
                          dbo.nrt_investigation as inv
                          ON rept.page_case_uid= inv.PUBLIC_HEALTH_CASE_UID
                              INNER JOIN
-                         NBS_SRTE.DBO.CONDITION_CODE
-                         ON CONDITION_CODE.CONDITION_CD = inv.CD
+                         DBO.nrt_srte_Condition_code cc
+                         ON cc.CONDITION_CD = inv.CD
                              INNER JOIN
                          #NRT_PAGE as nrt_page
                          ON nrt_page.act_uid = inv.PUBLIC_HEALTH_CASE_UID

--- a/db/upgrade/rdb_modern/routines/011-sp_f_page_case_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/011-sp_f_page_case_postprocessing.sql
@@ -48,7 +48,7 @@ BEGIN
                CD,
                LAST_CHG_TIME
         INTO #PHC_UIDS
-        FROM dbo.nrt_investigation inv
+        FROM dbo.nrt_investigation inv WITH(NOLOCK)
         WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
           AND INVESTIGATION_FORM_CD  NOT IN ( 'INV_FORM_BMDGAS','INV_FORM_BMDGBS','INV_FORM_BMDGEN',
                                               'INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV',
@@ -81,10 +81,7 @@ BEGIN
             CD,
             LAST_CHG_TIME
         INTO  #PHC_CASE_UIDS_ALL
-        FROM
-            dbo.nrt_investigation inv
-        --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
-        --LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND
+        FROM dbo.nrt_investigation inv WITH(NOLOCK)
         where inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
           and INVESTIGATION_FORM_CD  NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
           AND CASE_MANAGEMENT_UID is null;

--- a/db/upgrade/rdb_modern/routines/015-sp_nrt_morbidity_report_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/015-sp_nrt_morbidity_report_postprocessing.sql
@@ -264,7 +264,7 @@ BEGIN
         UPDATE #tmp_morb_root
         SET jurisdiction_nm = (
             SELECT code_short_desc_txt
-            FROM NBS_SRTE.dbo.jurisdiction_code WHERE code= #tmp_morb_root.Jurisdiction_cd and code_set_nm = 'S_JURDIC_C'
+            FROM dbo.nrt_srte_Jurisdiction_code WHERE code= #tmp_morb_root.Jurisdiction_cd and code_set_nm = 'S_JURDIC_C'
         )
         WHERE Jurisdiction_cd IS NOT NULL;
 

--- a/db/upgrade/rdb_modern/routines/017-sp_d_lab_test_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/017-sp_d_lab_test_postprocessing.sql
@@ -158,11 +158,11 @@ BEGIN
                         obs.PROCESSING_DECISION_CD
         into #LAB_TESTinit_a
         from dbo.nrt_observation obs
-                 left join nbs_srte..loinc_condition as loinc_con on obs.cd = loinc_con.loinc_cd
-                 left join nbs_srte..code_value_general as cvg
+                 left join dbo.nrt_srte_Loinc_condition as loinc_con on obs.cd = loinc_con.loinc_cd
+                 left join dbo.nrt_srte_Code_value_general as cvg
                            on obs.status_cd = cvg.code
                                and cvg.code_set_nm = 'ACT_OBJ_ST'
-                 left join nbs_srte..Jurisdiction_code jc
+                 left join dbo.nrt_srte_Jurisdiction_code jc
                            on obs.jurisdiction_cd = jc.code
                                and jc.code_set_nm = 'S_JURDIC_C'
         where obs.obs_domain_cd_st_1 in ('Order', 'Result', 'R_Order', 'R_Result', 'I_Order', 'I_Result', 'Order_rslt')
@@ -895,7 +895,7 @@ BEGIN
         from #LAB_TEST1_uid2 lt1
                  left outer join #LAB_TEST1_TMP lto on lt1.lab_rpt_uid = lto.Lab_Rpt_Uid_Test1
                  left outer join #Morb_OID tmo on lt1.lab_rpt_uid = tmo.lab_rpt_uid_mor
-                 left join nbs_srte..Code_value_general cvg
+                 left join dbo.nrt_srte_Code_value_general cvg
                            on lto.processing_decision_cd = cvg.code
                                and lto.processing_decision_cd is not null
                                and cvg.code_set_nm = 'STD_NBS_PROCESSING_DECISION_ALL';
@@ -2114,7 +2114,7 @@ BEGIN
                             FROM ordered_mat
                             where row_num = 1) mat
                            on obs.observation_uid = mat.act_uid
-                 left join nbs_srte..jurisdiction_code jc
+                 left join dbo.nrt_srte_Jurisdiction_code jc
                            on obs.jurisdiction_cd = jc.code
                                and jc.code_set_nm = 'S_JURDIC_C';
 

--- a/db/upgrade/rdb_modern/routines/018-sp_lab100_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/018-sp_lab100_datamart_postprocessing.sql
@@ -493,7 +493,7 @@ BEGIN
             tlroc1.*, pac.*
         into #TMP_LAB_RESULTS_ORDER_CONTACT2
         from #TMP_LAB_RESULTS_ORDER_CONTACT1 tlroc1
-                 left outer join nbs_srte.dbo.PROGRAM_AREA_CODE pac with(NOLOCK)
+                 left outer join dbo.nrt_srte_Program_area_code pac with(NOLOCK)
                                  on left( pac.NBS_UID+ space(5), 5)  = cast(tlroc1.PROGRAM_AREA_ID as int)
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
@@ -954,7 +954,7 @@ BEGIN
              , cast ( null as varchar(50)) as  CONDITION
         into #TMP_LABTESTS
         from #TMP_LABTESTSINIT li
-                 left outer join nbs_srte.dbo.CONDITION_CODE cc with(NOLOCK) on cc.CONDITION_CD = li.CONDITION_CD
+                 left outer join dbo.nrt_srte_Condition_code cc with(NOLOCK) on cc.CONDITION_CD = li.CONDITION_CD
                  left outer join #TMP_LAB_RESULTS_ORDER_CONTACT2  lroc2 on lroc2.RESULTED_TEST_UID = li.RESULTED_TEST_UID
         ;
 
@@ -1124,7 +1124,7 @@ BEGIN
             tl.CONDITION
         into #TMP_LABTESTS2
         from #TMP_LABTESTS tl
-                 left outer join NBS_SRTE..LABTEST_LOINC ll  on ll.LAB_TEST_CD = tl.ORDERED_LAB_TEST_CD
+                 left outer join dbo.nrt_srte_Labtest_loinc ll  on ll.LAB_TEST_CD = tl.ORDERED_LAB_TEST_CD
         ;
 
 
@@ -1296,7 +1296,7 @@ BEGIN
             lt2.CONDITION
         into #TMP_LABTESTS3
         from #TMP_LABTESTS2 lt2
-                 left outer join nbs_srte.dbo.LOINC_CONDITION lc with(NOLOCK) on lc.loinc_cd = lt2.LOINC
+                 left outer join dbo.nrt_srte_Loinc_condition lc with(NOLOCK) on lc.loinc_cd = lt2.LOINC
         ;
 
 
@@ -1488,7 +1488,7 @@ BEGIN
                 end as SNOMED
         into #TMP_LABTESTS4
         from #TMP_LABTESTS3 lt3
-                 left outer join nbs_srte.dbo.SNOMED_CONDITION sc with(NOLOCK) on sc.SNOMED_CD = lt3.TEST_RESULT_VAL_CD
+                 left outer join dbo.nrt_srte_Snomed_condition sc with(NOLOCK) on sc.SNOMED_CD = lt3.TEST_RESULT_VAL_CD
         ;
 
 
@@ -1866,5 +1866,4 @@ BEGIN
 
     END CATCH
 
-END
-    ;
+END;

--- a/db/upgrade/rdb_modern/routines/024-sp_f_std_page_case_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/024-sp_f_std_page_case_postprocessing.sql
@@ -80,7 +80,7 @@ BEGIN
         FROM
             dbo.nrt_investigation  ni
                 LEFT OUTER JOIN dbo.nrt_investigation_case_management nicm ON	ni.public_health_case_uid = nicm.public_health_case_uid
-                LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE cc with(nolock) ON 	cc.CONDITION_CD= ni.CD AND	cc.INVESTIGATION_FORM_CD
+                LEFT OUTER JOIN dbo.nrt_srte_Condition_code cc with(nolock) ON 	cc.CONDITION_CD= ni.CD AND	cc.INVESTIGATION_FORM_CD
                 NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
         where
             ni.public_health_case_uid in (

--- a/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/031-sp_crs_case_datamart_postprocessing.sql
@@ -124,7 +124,7 @@ BEGIN
                 FROM dbo.v_rdb_obs_mapping rom
                 LEFT JOIN (SELECT code_desc_txt,
                                   nbs_uid
-                                FROM dbo.v_nrt_srte_code_value_general
+                                FROM dbo.nrt_srte_Code_value_general
                                 WHERE code_set_nm = 'RUB_PRE_CARE_T') cvg
                     ON rom.coded_response = cvg.code_desc_txt)
             select public_health_case_uid,
@@ -227,7 +227,7 @@ BEGIN
             /*
                 AND unique_cd != 'CRS013'
 
-                This condition wass in temporarily, as CRS013 wass improperly labeled as a date value. It caused an error if it is used in the date table.
+                This condition was in temporarily, as CRS013 was improperly labeled as a date value. It caused an error if it is used in the date table.
                 As of the completion of ticket CNDE-2107, this value has been fixed in DTS1's NBS_SRTE.dbo.imrdbmapping
             */
 

--- a/db/upgrade/rdb_modern/routines/046-sp_morbidity_report_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/046-sp_morbidity_report_datamart_postprocessing.sql
@@ -48,7 +48,7 @@ BEGIN TRY
                 CODE_SET_NM,
                 CODE_SHORT_DESC_TXT
         INTO #SRTLOOKUP
-        FROM dbo.v_nrt_srte_code_value_general WITH (NOLOCK)
+        FROM dbo.nrt_srte_Code_value_general WITH (NOLOCK)
         WHERE CODE_SET_NM IN('MORB_RPT_TYPE','MRB_RPT_METH','P_NM_SFX','AGE_UNIT','YNU');
 
         if @debug = 'true'

--- a/db/upgrade/rdb_modern/views/001-v_getobscode.sql
+++ b/db/upgrade/rdb_modern/views/001-v_getobscode.sql
@@ -82,10 +82,10 @@ SELECT
     label
 FROM InvFormQObservations obs
          LEFT JOIN dbo.v_codeset cs with (nolock) on cs.cd = obs.cd
-         LEFT JOIN nbs_srte.dbo.code_value_general cvg with (nolock)  on
+         LEFT JOIN dbo.nrt_srte_Code_value_general cvg with (nolock)  on
     cvg.code_set_nm = cs.CODE_SET_NM and cvg.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Country_code cc with (nolock) on cc.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.State_code sc with (nolock) on sc.state_cd = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.State_county_code_value sccv with (nolock) on sccv.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Jurisdiction_code jc with (nolock) on jc.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Condition_code con_code with (nolock) on con_code.condition_cd = obs.ovc_code;
+         LEFT JOIN dbo.nrt_srte_Country_code cc with (nolock) on cc.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_State_code sc with (nolock) on sc.state_cd = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_State_county_code_value sccv with (nolock) on sccv.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_Jurisdiction_code jc with (nolock) on jc.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_Condition_code con_code with (nolock) on con_code.condition_cd = obs.ovc_code;

--- a/db/upgrade/rdb_modern/views/013-v_rdb_obs_mapping.sql
+++ b/db/upgrade/rdb_modern/views/013-v_rdb_obs_mapping.sql
@@ -45,7 +45,7 @@ FROM (SELECT
         RDB_attribute,
         db_field,
         r.n 
-    FROM nbs_srte.dbo.imrdbmapping
+    FROM dbo.nrt_srte_IMRDBMapping
 CROSS JOIN (SELECT 1 AS n UNION ALL SELECT 2) r) imrdb
          LEFT JOIN dbo.v_getobscode ovc ON imrdb.unique_cd = ovc.cd and imrdb.n = 2
          LEFT JOIN dbo.v_getobsnum ovn ON imrdb.unique_cd = ovn.cd and imrdb.n = 2

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/007-sp_s_pagebuilder_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/007-sp_s_pagebuilder_postprocessing-001.sql
@@ -93,7 +93,7 @@ BEGIN
         INTO #text_data_INV
         FROM #NRT_PAGE AS nrt_page
             INNER JOIN
-            NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+            dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
             ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
             AND (nrt_page.RDB_TABLE_NM = @rdb_table_name AND nrt_page.QUESTION_GROUP_SEQ_NBR IS NULL AND UPPER(nrt_page.DATA_TYPE) = 'TEXT')
@@ -213,7 +213,7 @@ BEGIN
         INTO #CODED_TABLE_INV
         FROM #CASE_ANSWER_PHC_UIDS AS PA WITH(NOLOCK)
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(PA.DATA_TYPE)
         WHERE CVG.CODE_SET_NM = 'NBS_DATA_TYPE'
           AND UPPER(data_type) = 'CODED'
@@ -389,7 +389,7 @@ BEGIN
         WHERE CODED.CODE_SET_GROUP_ID IN
               (
                   SELECT code_set_group_id
-                  FROM nbs_srte..codeset
+                  FROM dbo.nrt_srte_Codeset
                   WHERE CLASS_CD = 'V_State_county_code_value'
               )
         ORDER BY NBS_CASE_ANSWER_UID, RDB_COLUMN_NM;
@@ -423,7 +423,7 @@ BEGIN
         INTO #CODED_TABLE_SNTEMP_INV
         FROM #NRT_PAGE AS nrt_page WITH(NOLOCK) --3
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -481,8 +481,8 @@ BEGIN
                      dbo.nrt_investigation inv
                      on #CODED_TABLE_SNTEMP_INV.page_case_uid = inv.public_health_case_uid
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                          INNER JOIN
                      #NRT_PAGE nrt_page
                      ON nrt_page.act_uid = inv.public_health_case_uid
@@ -687,10 +687,10 @@ BEGIN
         INTO #CODED_COUNTY_TABLE_INV
         FROM #CODED_TABLE_INV AS CODED WITH(NOLOCK) LEFT
                                                         JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                         JOIN
-             NBS_SRTE.dbo.V_STATE_COUNTY_CODE_VALUE AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_State_county_code_value AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT
         WHERE METADATA.CODE_SET_NM = 'COUNTY_CCD';
@@ -793,7 +793,7 @@ BEGIN
         INTO #DATE_DATA_INV
         FROM #NRT_PAGE AS nrt_page
                  LEFT OUTER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -816,15 +816,15 @@ BEGIN
                      dbo.nrt_investigation inv
                      ON nrt_page.ACT_UID = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                 WHERE
                     DATA_TYPE IN ( 'Date/Time', 'Date', 'DATETIME', 'DATE' ) AND
                     (ISDATE(ANSWER_TXT) != 1) AND
                     UPPER(nrt_page.DATA_LOCATION) = 'NBS_CASE_ANSWER.ANSWER_TXT' AND
                     ANSWER_TXT IS NOT NULL AND
                     nrt_page.rdb_table_nm = @rdb_table_name
-                  AND CONDITION_CODE.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD
+                  AND cc.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD
             );
 
 
@@ -954,7 +954,7 @@ BEGIN
         INTO #NUMERIC_BASE_DATA_INV_CAT
         FROM #NRT_PAGE AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
           nrt_page.ANSWER_GROUP_SEQ_NBR IS NULL
@@ -1047,10 +1047,10 @@ BEGIN
         INTO #NUMERIC_DATA_TRANS_INV_CAT
         FROM #NUMERIC_DATA_MERGED_INV_CAT AS CODED WITH(NOLOCK) LEFT
                                                                     JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                                     JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM
         WHERE CVG.CODE = CODED.ANSWER_CODED OR
             ANSWER_CODED IS NULL
@@ -1296,15 +1296,15 @@ BEGIN
                      dbo.nrt_investigation inv
                      ON numeric_inv.page_case_uid = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                          INNER JOIN
                      #NRT_PAGE nrt_page
                      ON nrt_page.act_uid = inv.public_health_case_uid
                 WHERE
                     (isNumeric(numeric_inv.ANSWER_TXT) != 1) AND
                     numeric_inv.ANSWER_TXT IS NOT NULL AND
-                    CONDITION_CODE.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD);
+                    cc.INVESTIGATION_FORM_CD = nrt_page.INVESTIGATION_FORM_CD);
 
         SELECT @RowCount_no = @@ROWCOUNT;
         INSERT INTO [dbo].[job_flow_log]( batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count] )

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/010-sp_sld_investigation_repeat_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/010-sp_sld_investigation_repeat_postprocessing-001.sql
@@ -170,7 +170,7 @@ BEGIN
         INTO #TEXT_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NOT NULL
           AND CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -238,7 +238,7 @@ BEGIN
         INTO #CODED_TABLE_TEMP_REPT
         FROM #NBS_CASE_ANSWER_REPT AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE nrt_page.ANSWER_GROUP_SEQ_NBR IS NOT NULL AND
             CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -277,10 +277,10 @@ BEGIN
         INTO #CODED_TABLE_REPT
         FROM #CODED_TABLE_TEMP_REPT AS CODED LEFT
                                                  JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                  JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT;
         /*
@@ -338,10 +338,10 @@ ON #CODED_TABLE_REPT
         INTO #CODED_COUNTY_TABLE_REPT
         FROM #CODED_TABLE_REPT AS CODED WITH(NOLOCK) LEFT
                                                          JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA WITH(NOLOCK)
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA WITH(NOLOCK)
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                          JOIN
-             NBS_SRTE.dbo.V_STATE_COUNTY_CODE_VALUE AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_State_county_code_value AS CVG WITH(NOLOCK)
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT
         WHERE METADATA.CODE_SET_NM = 'COUNTY_CCD';
@@ -419,7 +419,7 @@ ON #CODED_TABLE_REPT
         INTO #CODED_TABLE_SNTEMP_REPT
         FROM #NBS_CASE_ANSWER_REPT AS nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
                  INNER JOIN #phc_uids_REPT phc
                             ON phc.PAGE_CASE_UID = nrt_page.act_uid
@@ -457,10 +457,10 @@ ON #CODED_TABLE_REPT
         INTO #CODED_TABLE_SNTEMP_TRANS_A_REPT
         FROM #CODED_TABLE_SNTEMP_REPT AS CODED LEFT
                                                    JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.CODE_SET_GROUP_ID LEFT
                                                    JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 CVG.CODE = CODED.ANSWER_TXT_CODE
         ORDER BY NBS_CASE_ANSWER_UID, RDB_COLUMN_NM;
@@ -631,7 +631,7 @@ ON #CODED_TABLE_REPT
         INTO #DATE_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE
             CVG.CODE_SET_NM = 'NBS_DATA_TYPE' AND
@@ -653,8 +653,8 @@ ON #CODED_TABLE_REPT
                      dbo.nrt_investigation as inv
                      ON nrt_page.ACT_UID = inv.PUBLIC_HEALTH_CASE_UID
                          INNER JOIN
-                     NBS_SRTE.DBO.CONDITION_CODE
-                     ON CONDITION_CODE.CONDITION_CD = inv.CD
+                     dbo.nrt_srte_Condition_code cc
+                     ON cc.CONDITION_CD = inv.CD
                 WHERE
                     DATA_TYPE IN( 'Date/Time', 'Date', 'DATETIME', 'DATE' ) AND
                     (ISDATE(ANSWER_TXT) != 1) AND
@@ -752,7 +752,7 @@ ON #CODED_TABLE_REPT
         INTO #NUMERIC_BASE_DATA_REPT
         FROM #NBS_CASE_ANSWER_REPT as nrt_page
                  INNER JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG WITH(NOLOCK)
+             dbo.nrt_srte_Code_value_general AS CVG WITH(NOLOCK)
              ON UPPER(CVG.CODE) = UPPER(nrt_page.DATA_TYPE)
         WHERE ANSWER_GROUP_SEQ_NBR IS NOT NULL
           AND CVG.CODE_SET_NM = 'NBS_DATA_TYPE'
@@ -831,10 +831,10 @@ ON #CODED_TABLE_REPT
         INTO #NUMERIC_DATA_TRANS_REPT
         FROM #NUMERIC_DATA_MERGED_REPT AS CODED LEFT
                                                     JOIN
-             NBS_SRTE.dbo.CODESET_GROUP_METADATA AS METADATA
+             dbo.nrt_srte_Codeset_Group_Metadata AS METADATA
              ON METADATA.CODE_SET_GROUP_ID = CODED.UNIT_VALUE1 LEFT
                                                     JOIN
-             NBS_SRTE.dbo.CODE_VALUE_GENERAL AS CVG
+             dbo.nrt_srte_Code_value_general AS CVG
              ON CVG.CODE_SET_NM = METADATA.CODE_SET_NM AND
                 ANSWER_GROUP_SEQ_NBR IS NOT NULL;
 
@@ -882,8 +882,8 @@ ON #CODED_TABLE_REPT
                          dbo.nrt_investigation as inv
                          ON rept.page_case_uid= inv.PUBLIC_HEALTH_CASE_UID
                              INNER JOIN
-                         NBS_SRTE.DBO.CONDITION_CODE
-                         ON CONDITION_CODE.CONDITION_CD = inv.CD
+                         DBO.nrt_srte_Condition_code cc
+                         ON cc.CONDITION_CD = inv.CD
                              INNER JOIN
                          #NRT_PAGE as nrt_page
                          ON nrt_page.act_uid = inv.PUBLIC_HEALTH_CASE_UID

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/012-sp_f_page_case_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/012-sp_f_page_case_postprocessing-001.sql
@@ -48,7 +48,7 @@ BEGIN
                CD,
                LAST_CHG_TIME
         INTO #PHC_UIDS
-        FROM dbo.nrt_investigation inv
+        FROM dbo.nrt_investigation inv WITH(NOLOCK)
         WHERE inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
           AND INVESTIGATION_FORM_CD  NOT IN ( 'INV_FORM_BMDGAS','INV_FORM_BMDGBS','INV_FORM_BMDGEN',
                                               'INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV',
@@ -81,10 +81,7 @@ BEGIN
             CD,
             LAST_CHG_TIME
         INTO  #PHC_CASE_UIDS_ALL
-        FROM
-            dbo.nrt_investigation inv
-        --LEFT OUTER JOIN NBS_ODSE.dbo.CASE_MANAGEMENT ON	inv.PUBLIC_HEALTH_CASE_UID= CASE_MANAGEMENT.PUBLIC_HEALTH_CASE_UID
-        --LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE ON 	CONDITION_CODE.CONDITION_CD= inv.CD AND
+        FROM dbo.nrt_investigation inv WITH(NOLOCK)
         where inv.public_health_case_uid IN (SELECT value FROM STRING_SPLIT(@phc_ids, ','))
           and INVESTIGATION_FORM_CD  NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
           AND CASE_MANAGEMENT_UID is null;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/016-sp_nrt_morbidity_report_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/016-sp_nrt_morbidity_report_postprocessing-001.sql
@@ -264,7 +264,7 @@ BEGIN
         UPDATE #tmp_morb_root
         SET jurisdiction_nm = (
             SELECT code_short_desc_txt
-            FROM NBS_SRTE.dbo.jurisdiction_code WHERE code= #tmp_morb_root.Jurisdiction_cd and code_set_nm = 'S_JURDIC_C'
+            FROM dbo.nrt_srte_Jurisdiction_code WHERE code= #tmp_morb_root.Jurisdiction_cd and code_set_nm = 'S_JURDIC_C'
         )
         WHERE Jurisdiction_cd IS NOT NULL;
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/018-sp_d_lab_test_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/018-sp_d_lab_test_postprocessing-001.sql
@@ -158,11 +158,11 @@ BEGIN
                         obs.PROCESSING_DECISION_CD
         into #LAB_TESTinit_a
         from dbo.nrt_observation obs
-                 left join nbs_srte..loinc_condition as loinc_con on obs.cd = loinc_con.loinc_cd
-                 left join nbs_srte..code_value_general as cvg
+                 left join dbo.nrt_srte_Loinc_condition as loinc_con on obs.cd = loinc_con.loinc_cd
+                 left join dbo.nrt_srte_Code_value_general as cvg
                            on obs.status_cd = cvg.code
                                and cvg.code_set_nm = 'ACT_OBJ_ST'
-                 left join nbs_srte..Jurisdiction_code jc
+                 left join dbo.nrt_srte_Jurisdiction_code jc
                            on obs.jurisdiction_cd = jc.code
                                and jc.code_set_nm = 'S_JURDIC_C'
         where obs.obs_domain_cd_st_1 in ('Order', 'Result', 'R_Order', 'R_Result', 'I_Order', 'I_Result', 'Order_rslt')
@@ -895,7 +895,7 @@ BEGIN
         from #LAB_TEST1_uid2 lt1
                  left outer join #LAB_TEST1_TMP lto on lt1.lab_rpt_uid = lto.Lab_Rpt_Uid_Test1
                  left outer join #Morb_OID tmo on lt1.lab_rpt_uid = tmo.lab_rpt_uid_mor
-                 left join nbs_srte..Code_value_general cvg
+                 left join dbo.nrt_srte_Code_value_general cvg
                            on lto.processing_decision_cd = cvg.code
                                and lto.processing_decision_cd is not null
                                and cvg.code_set_nm = 'STD_NBS_PROCESSING_DECISION_ALL';
@@ -2114,7 +2114,7 @@ BEGIN
                             FROM ordered_mat
                             where row_num = 1) mat
                            on obs.observation_uid = mat.act_uid
-                 left join nbs_srte..jurisdiction_code jc
+                 left join dbo.nrt_srte_Jurisdiction_code jc
                            on obs.jurisdiction_cd = jc.code
                                and jc.code_set_nm = 'S_JURDIC_C';
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -493,7 +493,7 @@ BEGIN
             tlroc1.*, pac.*
         into #TMP_LAB_RESULTS_ORDER_CONTACT2
         from #TMP_LAB_RESULTS_ORDER_CONTACT1 tlroc1
-                 left outer join nbs_srte.dbo.PROGRAM_AREA_CODE pac with(NOLOCK)
+                 left outer join dbo.nrt_srte_Program_area_code pac with(NOLOCK)
                                  on left( pac.NBS_UID+ space(5), 5)  = cast(tlroc1.PROGRAM_AREA_ID as int)
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
@@ -954,7 +954,7 @@ BEGIN
              , cast ( null as varchar(50)) as  CONDITION
         into #TMP_LABTESTS
         from #TMP_LABTESTSINIT li
-                 left outer join nbs_srte.dbo.CONDITION_CODE cc with(NOLOCK) on cc.CONDITION_CD = li.CONDITION_CD
+                 left outer join dbo.nrt_srte_Condition_code cc with(NOLOCK) on cc.CONDITION_CD = li.CONDITION_CD
                  left outer join #TMP_LAB_RESULTS_ORDER_CONTACT2  lroc2 on lroc2.RESULTED_TEST_UID = li.RESULTED_TEST_UID
         ;
 
@@ -1124,7 +1124,7 @@ BEGIN
             tl.CONDITION
         into #TMP_LABTESTS2
         from #TMP_LABTESTS tl
-                 left outer join NBS_SRTE..LABTEST_LOINC ll  on ll.LAB_TEST_CD = tl.ORDERED_LAB_TEST_CD
+                 left outer join dbo.nrt_srte_Labtest_loinc ll  on ll.LAB_TEST_CD = tl.ORDERED_LAB_TEST_CD
         ;
 
 
@@ -1296,7 +1296,7 @@ BEGIN
             lt2.CONDITION
         into #TMP_LABTESTS3
         from #TMP_LABTESTS2 lt2
-                 left outer join nbs_srte.dbo.LOINC_CONDITION lc with(NOLOCK) on lc.loinc_cd = lt2.LOINC
+                 left outer join dbo.nrt_srte_Loinc_condition lc with(NOLOCK) on lc.loinc_cd = lt2.LOINC
         ;
 
 
@@ -1488,7 +1488,7 @@ BEGIN
                 end as SNOMED
         into #TMP_LABTESTS4
         from #TMP_LABTESTS3 lt3
-                 left outer join nbs_srte.dbo.SNOMED_CONDITION sc with(NOLOCK) on sc.SNOMED_CD = lt3.TEST_RESULT_VAL_CD
+                 left outer join dbo.nrt_srte_Snomed_condition sc with(NOLOCK) on sc.SNOMED_CD = lt3.TEST_RESULT_VAL_CD
         ;
 
 
@@ -1866,5 +1866,4 @@ BEGIN
 
     END CATCH
 
-END
-    ;
+END;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/025-sp_f_std_page_case_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/025-sp_f_std_page_case_postprocessing-001.sql
@@ -80,7 +80,7 @@ BEGIN
         FROM
             dbo.nrt_investigation  ni
                 LEFT OUTER JOIN dbo.nrt_investigation_case_management nicm ON	ni.public_health_case_uid = nicm.public_health_case_uid
-                LEFT OUTER JOIN NBS_SRTE.dbo.CONDITION_CODE cc with(nolock) ON 	cc.CONDITION_CD= ni.CD AND	cc.INVESTIGATION_FORM_CD
+                LEFT OUTER JOIN dbo.nrt_srte_Condition_code cc with(nolock) ON 	cc.CONDITION_CD= ni.CD AND	cc.INVESTIGATION_FORM_CD
                 NOT IN 	( 'bo.','INV_FORM_BMDGBS','INV_FORM_BMDGEN','INV_FORM_BMDNM','INV_FORM_BMDSP','INV_FORM_GEN','INV_FORM_HEPA','INV_FORM_HEPBV','INV_FORM_HEPCV','INV_FORM_HEPGEN','INV_FORM_MEA','INV_FORM_PER','INV_FORM_RUB','INV_FORM_RVCT','INV_FORM_VAR')
         where
             ni.public_health_case_uid in (

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/032-sp_crs_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/032-sp_crs_case_datamart_postprocessing-001.sql
@@ -124,7 +124,7 @@ BEGIN
                 FROM dbo.v_rdb_obs_mapping rom
                 LEFT JOIN (SELECT code_desc_txt,
                                   nbs_uid
-                                FROM dbo.v_nrt_srte_code_value_general
+                                FROM dbo.nrt_srte_Code_value_general
                                 WHERE code_set_nm = 'RUB_PRE_CARE_T') cvg
                     ON rom.coded_response = cvg.code_desc_txt)
             select public_health_case_uid,
@@ -227,7 +227,7 @@ BEGIN
             /*
                 AND unique_cd != 'CRS013'
 
-                This condition wass in temporarily, as CRS013 wass improperly labeled as a date value. It caused an error if it is used in the date table.
+                This condition was in temporarily, as CRS013 was improperly labeled as a date value. It caused an error if it is used in the date table.
                 As of the completion of ticket CNDE-2107, this value has been fixed in DTS1's NBS_SRTE.dbo.imrdbmapping
             */
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/048-sp_morbidity_report_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/048-sp_morbidity_report_datamart_postprocessing-001.sql
@@ -48,7 +48,7 @@ BEGIN TRY
                 CODE_SET_NM,
                 CODE_SHORT_DESC_TXT
         INTO #SRTLOOKUP
-        FROM dbo.v_nrt_srte_code_value_general WITH (NOLOCK)
+        FROM dbo.nrt_srte_Code_value_general WITH (NOLOCK)
         WHERE CODE_SET_NM IN('MORB_RPT_TYPE','MRB_RPT_METH','P_NM_SFX','AGE_UNIT','YNU');
 
         if @debug = 'true'

--- a/liquibase-service/src/main/resources/db/rdb_modern/views/001-v_getobscode-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/views/001-v_getobscode-001.sql
@@ -82,10 +82,10 @@ SELECT
     label
 FROM InvFormQObservations obs
          LEFT JOIN dbo.v_codeset cs with (nolock) on cs.cd = obs.cd
-         LEFT JOIN nbs_srte.dbo.code_value_general cvg with (nolock)  on
+         LEFT JOIN dbo.nrt_srte_Code_value_general cvg with (nolock)  on
     cvg.code_set_nm = cs.CODE_SET_NM and cvg.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Country_code cc with (nolock) on cc.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.State_code sc with (nolock) on sc.state_cd = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.State_county_code_value sccv with (nolock) on sccv.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Jurisdiction_code jc with (nolock) on jc.code = obs.ovc_code
-         LEFT JOIN nbs_srte.dbo.Condition_code con_code with (nolock) on con_code.condition_cd = obs.ovc_code;
+         LEFT JOIN dbo.nrt_srte_Country_code cc with (nolock) on cc.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_State_code sc with (nolock) on sc.state_cd = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_State_county_code_value sccv with (nolock) on sccv.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_Jurisdiction_code jc with (nolock) on jc.code = obs.ovc_code
+         LEFT JOIN dbo.nrt_srte_Condition_code con_code with (nolock) on con_code.condition_cd = obs.ovc_code;

--- a/liquibase-service/src/main/resources/db/rdb_modern/views/013-v_rdb_obs_mapping-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/views/013-v_rdb_obs_mapping-001.sql
@@ -36,7 +36,7 @@ FROM (SELECT
         RDB_attribute,
         db_field,
         r.n 
-    FROM nbs_srte.dbo.imrdbmapping
+    FROM dbo.nrt_srte_IMRDBMapping
 CROSS JOIN (SELECT 1 AS n UNION ALL SELECT 2) r) imrdb
          LEFT JOIN dbo.v_getobscode ovc ON imrdb.unique_cd = ovc.cd and imrdb.n = 2
          LEFT JOIN dbo.v_getobsnum ovn ON imrdb.unique_cd = ovn.cd and imrdb.n = 2


### PR DESCRIPTION
## Notes

DB performance optimization. All the references to `NBS_SRTE` database in post-processing stored procedures and views are replaced with references to the `nrt_srte` replica tables.

## JIRA

- **Related story**: [CNDE-2381](https://cdc-nbs.atlassian.net/browse/CNDE-2381)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?