### PR TITLE
CNDE-2511: add phc_uids to nrt_observation

### DIFF
--- a/db/upgrade/odse/routines/005-sp_observation_event.sql
+++ b/db/upgrade/odse/routines/005-sp_observation_event.sql
@@ -103,7 +103,7 @@ BEGIN
                       (
                           SELECT 
                                 STRING_AGG(ar.target_act_uid, ',') AS associated_phc_uids
-                          from nbs_odse.dbo.Act_relationship ar
+                          from nbs_odse.dbo.Act_relationship ar with (NOLOCK) 
                           where ar.type_cd IN ('MorbReport', 'LabReport')
                             and ar.target_class_cd = 'CASE'
                             and ar.source_act_uid = o.observation_uid

--- a/db/upgrade/rdb_modern/routines/220-sp_nrt_tb_pam_ldf_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/220-sp_nrt_tb_pam_ldf_postprocessing.sql
@@ -13,6 +13,13 @@ BEGIN
 	DECLARE @Dataflow_Name VARCHAR(200) = 'TB_PAM_LDF POST-Processing';
 	DECLARE @Package_Name VARCHAR(200) = 'sp_nrt_tb_pam_ldf_postprocessing';
 
+    DECLARE @global_temp_table_name varchar(500) = '';
+    DECLARE @sql_code NVARCHAR(MAX);
+    DECLARE @ldf_columns NVARCHAR(MAX) = '';
+    DECLARE @tb_ldf_columns NVARCHAR(MAX) = '';
+
+    SET @global_temp_table_name = '##TB_PAM_LDF_TRANSLATED' + '_' + CAST(@Batch_id as varchar(50));    
+
     BEGIN TRY
         
 
@@ -47,7 +54,6 @@ BEGIN
 				public_health_case_uid,
 				batch_id,
 				add_user_id,
-				add_time,
 				last_chg_user_id
 			FROM [dbo].nrt_investigation I WITH (NOLOCK) 
 			INNER JOIN  (SELECT TRIM(value) AS value FROM STRING_SPLIT(@phc_id_list, ',')) nu on nu.value = I.public_health_case_uid  
@@ -59,7 +65,7 @@ BEGIN
             CAST(A.ACT_UID AS BIGINT) AS TB_PAM_UID,
             I.ADD_USER_ID,
             A.CODE_SET_GROUP_ID,
-            I.ADD_TIME,
+            A.NCA_ADD_TIME AS ADD_TIME,
             I.LAST_CHG_USER_ID,
             A.LAST_CHG_TIME
         INTO #LDF_BASE  
@@ -68,7 +74,7 @@ BEGIN
 		ON I.public_health_case_uid = A.ACT_UID AND ISNULL(I.batch_id, 1) = ISNULL(A.batch_id, 1)
         WHERE 
             A.LDF_STATUS_CD IN ('LDF_UPDATE', 'LDF_CREATE', 'LDF_PROCESSED')
-            AND A.RECORD_STATUS_CD IN ('Active', 'Inactive');
+            AND A.NUIM_RECORD_STATUS_CD IN ('Active', 'Inactive');
         
 
         SELECT @RowCount_no = @@ROWCOUNT;
@@ -95,8 +101,14 @@ BEGIN
             -- LDF_BASE_CODED
             ;WITH LDF_BASE_CODED AS (
                 SELECT 
-                    tb.*,
-                    --METADATA.CODE_SET_GROUP_ID,
+                    tb.DATAMART_COLUMN_NM,
+                    tb.ANSWER_TXT,
+                    tb.TB_PAM_UID,
+                    tb.ADD_USER_ID,
+                    tb.CODE_SET_GROUP_ID,
+                    tb.ADD_TIME,
+                    tb.LAST_CHG_USER_ID,
+                    tb.LAST_CHG_TIME,
                     METADATA.CODE_SET_NM,
                     CODESET.CLASS_CD
                 FROM #LDF_BASE tb
@@ -319,27 +331,163 @@ BEGIN
             SET
                 @PROC_STEP_NO = @PROC_STEP_NO + 1;
             SET
-                @PROC_STEP_NAME = 'GENERATING #LDF_TRANSLATED';
+                @PROC_STEP_NAME = 'GENERATING #MISSED_COLS';
 
-            IF OBJECT_ID('tempdb..#LDF_TRANSLATED') IS NOT NULL
-                DROP TABLE #LDF_TRANSLATED;
+            IF OBJECT_ID('tempdb..#MISSED_COLS') IS NOT NULL
+                DROP TABLE #MISSED_COLS;
 
-            SELECT    
-                inv.INVESTIGATION_KEY,             
-                tb.TB_PAM_UID,
-                tb.ADD_TIME                
-            INTO #LDF_TRANSLATED  
-            FROM #LDF_BASE_COUNTRY_CONCAT tb
-            LEFT OUTER JOIN [dbo].INVESTIGATION inv WITH (NOLOCK)
-                ON tb.TB_PAM_UID = inv.CASE_UID
-            GROUP BY inv.INVESTIGATION_KEY, tb.TB_PAM_UID, tb.ADD_TIME;
+            SELECT DISTINCT 
+                DATAMART_COLUMN_NM AS col_nm, 
+                'varchar' AS col_data_type, 
+                NULL AS col_NUMERIC_PRECISION, 
+                NULL AS col_NUMERIC_SCALE, 
+                2000 AS col_CHARACTER_MAXIMUM_LENGTH
+            INTO #MISSED_COLS
+            FROM #LDF_BASE_COUNTRY_CONCAT l
+            LEFT JOIN INFORMATION_SCHEMA.COLUMNS ic
+            ON upper(datamart_column_nm) = upper(ic.COLUMN_NAME) AND
+                upper(ic.table_name) = 'TB_PAM_LDF'
+            WHERE ic.COLUMN_NAME IS NULL;
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
                 SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                FROM #MISSED_COLS;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+-------------------------------------------------------------------------------------------
+
+        BEGIN TRANSACTION
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING TABLE WITH NEW COLUMNS';
+
+            
+            DECLARE @AlterQuery NVARCHAR(MAX);
+
+            set @AlterQuery = 'ALTER TABLE dbo.TB_PAM_LDF ADD ' + (select STRING_AGG( col_nm + ' ' +  col_data_type +
+            CASE
+                WHEN col_data_type IN ('decimal', 'numeric') THEN '(' + CAST(col_NUMERIC_PRECISION AS NVARCHAR) + ',' + CAST(col_NUMERIC_SCALE AS NVARCHAR) + ')'
+                WHEN col_data_type = 'varchar' THEN '(' +
+                    CASE WHEN col_CHARACTER_MAXIMUM_LENGTH = -1 THEN 'MAX' ELSE CAST(col_CHARACTER_MAXIMUM_LENGTH AS NVARCHAR) END
+                + ')'
+                ELSE ''
+            END, ', ') from #MISSED_COLS);
+
+            exec sp_executesql @AlterQuery;
+            
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+        
+        COMMIT TRANSACTION;
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING #COL_LIST';
+
+            IF OBJECT_ID('tempdb..#COL_LIST') IS NOT NULL
+                DROP TABLE #COL_LIST;
+
+            SELECT DISTINCT ic.COLUMN_NAME, ORDINAL_POSITION
+            INTO #COL_LIST
+            FROM INFORMATION_SCHEMA.COLUMNS ic 
+            WHERE ic.table_name = 'TB_PAM_LDF'
+            AND UPPER(ic.COLUMN_NAME) NOT IN ('INVESTIGATION_KEY', 'TB_PAM_UID', 'ADD_TIME'); --IGNORING FIRST THREE DEFAULT COLUMNS;
+
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            IF
+                @debug = 'true'
+                SELECT @Proc_Step_Name AS step, *
+                FROM #COL_LIST;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING LDF_COLUMNS';
+
+                   
+            SELECT @ldf_columns = COALESCE(STRING_AGG(CAST(QUOTENAME(COLUMN_NAME) AS NVARCHAR(MAX)), ',') WITHIN GROUP (ORDER BY ORDINAL_POSITION), '')
+            FROM (SELECT DISTINCT COLUMN_NAME, ORDINAL_POSITION FROM #COL_LIST) AS cols;
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING ' + @global_temp_table_name;                
+
+            EXEC ('IF OBJECT_ID(''tempdb..' + @global_temp_table_name +''', ''U'')  IS NOT NULL
+            BEGIN
+                DROP TABLE ' + @global_temp_table_name +';
+            END;')
+
+            IF @ldf_columns != ''
+            BEGIN
+                SET @sql_code = 'SELECT 
+                    TB_PAM_UID, 
+                    ADD_TIME,
+                    ' + @ldf_columns + '
+                INTO ' + @global_temp_table_name +'
+                FROM (
+                    SELECT 
+                        TB_PAM_UID, 
+                        ADD_TIME, 
+                        ANSWER_TXT, 
+                        DATAMART_COLUMN_NM 
+                    FROM #LDF_BASE_COUNTRY_CONCAT
+                    ) AS SourceTable
+                PIVOT (
+                    MAX(ANSWER_TXT)
+                    FOR DATAMART_COLUMN_NM IN (' + @ldf_columns + ')
+                ) AS PivotTable';
+            END
+            ELSE
+            BEGIN
+                SET @sql_code = 'SELECT 
+                    TB_PAM_UID, 
+                    ADD_TIME
+                INTO ' + @global_temp_table_name +'
+                FROM #LDF_BASE_COUNTRY_CONCAT
+                '
+            END;
+            EXEC sp_executesql @sql_code;    
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            IF
+                @debug = 'true'
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
 
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
@@ -354,17 +502,18 @@ BEGIN
             SET
                 @PROC_STEP_NAME = 'DELETE INCOMING RECORDS FROM TB_PAM_LDF';
 
-            DELETE D
+            SET @sql_code = 'DELETE D
             FROM [dbo].TB_PAM_LDF D
-            INNER JOIN #LDF_TRANSLATED T
+            INNER JOIN ' + @global_temp_table_name + ' T
                 ON T.TB_PAM_UID = D.TB_PAM_UID
+            '
+            EXEC sp_executesql @sql_code; 
     
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
-                SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
     
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
@@ -382,23 +531,50 @@ BEGIN
             SET
                 @PROC_STEP_NAME = 'INSERT INCOMING RECORDS TO TB_PAM_LDF';
 
-            INSERT INTO [dbo].TB_PAM_LDF (
-                INVESTIGATION_KEY,
-                TB_PAM_UID,
-                ADD_TIME
-            )
-            SELECT 
-                INVESTIGATION_KEY,
-                TB_PAM_UID,
-                ADD_TIME
-            FROM #LDF_TRANSLATED
+            SET @tb_ldf_columns = (
+                SELECT ISNULL(
+                    STRING_AGG('tb.' + TRIM(value), ','),
+                    ''
+                )
+                FROM STRING_SPLIT(ISNULL(@ldf_columns, ''), ',')
+                WHERE TRIM(value) != ''
+            );
+
+            SET @sql_code = 
+            'INSERT INTO dbo.TB_PAM_LDF([INVESTIGATION_KEY], [TB_PAM_UID], [add_time] '+ 
+                CASE
+                    WHEN @ldf_columns != '' THEN ',' + @ldf_columns
+                    ELSE ''
+                END
+            + ' )
+            SELECT
+                inv.INVESTIGATION_KEY,
+                tb.TB_PAM_UID,
+                tb.add_time'+
+            + CASE
+                    WHEN @ldf_columns != '' THEN ',' + @tb_ldf_columns
+                    ELSE ''
+                END
+            +
+            '
+            FROM
+            ' + @global_temp_table_name +' tb
+            LEFT JOIN [dbo].investigation inv WITH(nolock)
+                ON tb.TB_PAM_UID = inv.CASE_UID
+            ';
+            EXEC sp_executesql @sql_code;
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
-                SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
+
+            -- Force drop global temp table
+            EXEC ('IF OBJECT_ID(''tempdb..' + @global_temp_table_name +''', ''U'')  IS NOT NULL
+            BEGIN
+                DROP TABLE ' + @global_temp_table_name +';
+            END;')
 
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])

--- a/db/upgrade/rdb_modern/tables/017-create_nrt_observation.sql
+++ b/db/upgrade/rdb_modern/tables/017-create_nrt_observation.sql
@@ -80,6 +80,7 @@ CREATE TABLE dbo.nrt_observation
     record_status_time                      datetime                                        NULL,
     status_time                             datetime                                        NULL,
     batch_id                                bigint                                          NULL,
+    associated_phc_uids                     nvarchar(max)                                   NULL,
     refresh_datetime                        datetime2(7) GENERATED ALWAYS AS ROW START      NOT NULL,
     max_datetime                            datetime2(7) GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
     PERIOD FOR SYSTEM_TIME (refresh_datetime, max_datetime)

--- a/liquibase-service/src/main/resources/db/odse/routines/009-sp_observation_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/009-sp_observation_event-001.sql
@@ -92,6 +92,7 @@ BEGIN
                       ,nesteddata.obs_code
                       ,nesteddata.obs_date
                       ,nesteddata.obs_num
+                      ,nesteddata.associated_phc_uids
               -- ,nesteddata.associated_investigations
               -- ,nesteddata.ldf_observation
               FROM Observation o WITH (NOLOCK) OUTER apply (
@@ -99,6 +100,14 @@ BEGIN
                       *
                   FROM
                       -- follow up observations associated with observation-nested obs handling
+                      (
+                          SELECT 
+                                STRING_AGG(ar.target_act_uid, ',') AS associated_phc_uids
+                          from nbs_odse.dbo.Act_relationship ar
+                          where ar.type_cd IN ('MorbReport', 'LabReport')
+                            and ar.target_class_cd = 'CASE'
+                            and ar.source_act_uid = o.observation_uid
+                      ) as associated_phc_uids,
                       (
                           SELECT
                               (

--- a/liquibase-service/src/main/resources/db/odse/routines/009-sp_observation_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/009-sp_observation_event-001.sql
@@ -103,7 +103,7 @@ BEGIN
                       (
                           SELECT 
                                 STRING_AGG(ar.target_act_uid, ',') AS associated_phc_uids
-                          from nbs_odse.dbo.Act_relationship ar
+                          from nbs_odse.dbo.Act_relationship ar with (NOLOCK) 
                           where ar.type_cd IN ('MorbReport', 'LabReport')
                             and ar.target_class_cd = 'CASE'
                             and ar.source_act_uid = o.observation_uid

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/220-sp_nrt_tb_pam_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/220-sp_nrt_tb_pam_ldf_postprocessing-001.sql
@@ -13,6 +13,13 @@ BEGIN
 	DECLARE @Dataflow_Name VARCHAR(200) = 'TB_PAM_LDF POST-Processing';
 	DECLARE @Package_Name VARCHAR(200) = 'sp_nrt_tb_pam_ldf_postprocessing';
 
+    DECLARE @global_temp_table_name varchar(500) = '';
+    DECLARE @sql_code NVARCHAR(MAX);
+    DECLARE @ldf_columns NVARCHAR(MAX) = '';
+    DECLARE @tb_ldf_columns NVARCHAR(MAX) = '';
+
+    SET @global_temp_table_name = '##TB_PAM_LDF_TRANSLATED' + '_' + CAST(@Batch_id as varchar(50));    
+
     BEGIN TRY
         
 
@@ -47,7 +54,6 @@ BEGIN
 				public_health_case_uid,
 				batch_id,
 				add_user_id,
-				add_time,
 				last_chg_user_id
 			FROM [dbo].nrt_investigation I WITH (NOLOCK) 
 			INNER JOIN  (SELECT TRIM(value) AS value FROM STRING_SPLIT(@phc_id_list, ',')) nu on nu.value = I.public_health_case_uid  
@@ -59,7 +65,7 @@ BEGIN
             CAST(A.ACT_UID AS BIGINT) AS TB_PAM_UID,
             I.ADD_USER_ID,
             A.CODE_SET_GROUP_ID,
-            I.ADD_TIME,
+            A.NCA_ADD_TIME AS ADD_TIME,
             I.LAST_CHG_USER_ID,
             A.LAST_CHG_TIME
         INTO #LDF_BASE  
@@ -68,7 +74,7 @@ BEGIN
 		ON I.public_health_case_uid = A.ACT_UID AND ISNULL(I.batch_id, 1) = ISNULL(A.batch_id, 1)
         WHERE 
             A.LDF_STATUS_CD IN ('LDF_UPDATE', 'LDF_CREATE', 'LDF_PROCESSED')
-            AND A.RECORD_STATUS_CD IN ('Active', 'Inactive');
+            AND A.NUIM_RECORD_STATUS_CD IN ('Active', 'Inactive');
         
 
         SELECT @RowCount_no = @@ROWCOUNT;
@@ -95,8 +101,14 @@ BEGIN
             -- LDF_BASE_CODED
             ;WITH LDF_BASE_CODED AS (
                 SELECT 
-                    tb.*,
-                    --METADATA.CODE_SET_GROUP_ID,
+                    tb.DATAMART_COLUMN_NM,
+                    tb.ANSWER_TXT,
+                    tb.TB_PAM_UID,
+                    tb.ADD_USER_ID,
+                    tb.CODE_SET_GROUP_ID,
+                    tb.ADD_TIME,
+                    tb.LAST_CHG_USER_ID,
+                    tb.LAST_CHG_TIME,
                     METADATA.CODE_SET_NM,
                     CODESET.CLASS_CD
                 FROM #LDF_BASE tb
@@ -319,27 +331,163 @@ BEGIN
             SET
                 @PROC_STEP_NO = @PROC_STEP_NO + 1;
             SET
-                @PROC_STEP_NAME = 'GENERATING #LDF_TRANSLATED';
+                @PROC_STEP_NAME = 'GENERATING #MISSED_COLS';
 
-            IF OBJECT_ID('tempdb..#LDF_TRANSLATED') IS NOT NULL
-                DROP TABLE #LDF_TRANSLATED;
+            IF OBJECT_ID('tempdb..#MISSED_COLS') IS NOT NULL
+                DROP TABLE #MISSED_COLS;
 
-            SELECT    
-                inv.INVESTIGATION_KEY,             
-                tb.TB_PAM_UID,
-                tb.ADD_TIME                
-            INTO #LDF_TRANSLATED  
-            FROM #LDF_BASE_COUNTRY_CONCAT tb
-            LEFT OUTER JOIN [dbo].INVESTIGATION inv WITH (NOLOCK)
-                ON tb.TB_PAM_UID = inv.CASE_UID
-            GROUP BY inv.INVESTIGATION_KEY, tb.TB_PAM_UID, tb.ADD_TIME;
+            SELECT DISTINCT 
+                DATAMART_COLUMN_NM AS col_nm, 
+                'varchar' AS col_data_type, 
+                NULL AS col_NUMERIC_PRECISION, 
+                NULL AS col_NUMERIC_SCALE, 
+                2000 AS col_CHARACTER_MAXIMUM_LENGTH
+            INTO #MISSED_COLS
+            FROM #LDF_BASE_COUNTRY_CONCAT l
+            LEFT JOIN INFORMATION_SCHEMA.COLUMNS ic
+            ON upper(datamart_column_nm) = upper(ic.COLUMN_NAME) AND
+                upper(ic.table_name) = 'TB_PAM_LDF'
+            WHERE ic.COLUMN_NAME IS NULL;
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
                 SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                FROM #MISSED_COLS;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+-------------------------------------------------------------------------------------------
+
+        BEGIN TRANSACTION
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING TABLE WITH NEW COLUMNS';
+
+            
+            DECLARE @AlterQuery NVARCHAR(MAX);
+
+            set @AlterQuery = 'ALTER TABLE dbo.TB_PAM_LDF ADD ' + (select STRING_AGG( col_nm + ' ' +  col_data_type +
+            CASE
+                WHEN col_data_type IN ('decimal', 'numeric') THEN '(' + CAST(col_NUMERIC_PRECISION AS NVARCHAR) + ',' + CAST(col_NUMERIC_SCALE AS NVARCHAR) + ')'
+                WHEN col_data_type = 'varchar' THEN '(' +
+                    CASE WHEN col_CHARACTER_MAXIMUM_LENGTH = -1 THEN 'MAX' ELSE CAST(col_CHARACTER_MAXIMUM_LENGTH AS NVARCHAR) END
+                + ')'
+                ELSE ''
+            END, ', ') from #MISSED_COLS);
+
+            exec sp_executesql @AlterQuery;
+            
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+        
+        COMMIT TRANSACTION;
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING #COL_LIST';
+
+            IF OBJECT_ID('tempdb..#COL_LIST') IS NOT NULL
+                DROP TABLE #COL_LIST;
+
+            SELECT DISTINCT ic.COLUMN_NAME, ORDINAL_POSITION
+            INTO #COL_LIST
+            FROM INFORMATION_SCHEMA.COLUMNS ic 
+            WHERE ic.table_name = 'TB_PAM_LDF'
+            AND UPPER(ic.COLUMN_NAME) NOT IN ('INVESTIGATION_KEY', 'TB_PAM_UID', 'ADD_TIME'); --IGNORING FIRST THREE DEFAULT COLUMNS;
+
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            IF
+                @debug = 'true'
+                SELECT @Proc_Step_Name AS step, *
+                FROM #COL_LIST;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING LDF_COLUMNS';
+
+                   
+            SELECT @ldf_columns = COALESCE(STRING_AGG(CAST(QUOTENAME(COLUMN_NAME) AS NVARCHAR(MAX)), ',') WITHIN GROUP (ORDER BY ORDINAL_POSITION), '')
+            FROM (SELECT DISTINCT COLUMN_NAME, ORDINAL_POSITION FROM #COL_LIST) AS cols;
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+
+-------------------------------------------------------------------------------------------
+
+            SET
+                @PROC_STEP_NO = @PROC_STEP_NO + 1;
+            SET
+                @PROC_STEP_NAME = 'GENERATING ' + @global_temp_table_name;                
+
+            EXEC ('IF OBJECT_ID(''tempdb..' + @global_temp_table_name +''', ''U'')  IS NOT NULL
+            BEGIN
+                DROP TABLE ' + @global_temp_table_name +';
+            END;')
+
+            IF @ldf_columns != ''
+            BEGIN
+                SET @sql_code = 'SELECT 
+                    TB_PAM_UID, 
+                    ADD_TIME,
+                    ' + @ldf_columns + '
+                INTO ' + @global_temp_table_name +'
+                FROM (
+                    SELECT 
+                        TB_PAM_UID, 
+                        ADD_TIME, 
+                        ANSWER_TXT, 
+                        DATAMART_COLUMN_NM 
+                    FROM #LDF_BASE_COUNTRY_CONCAT
+                    ) AS SourceTable
+                PIVOT (
+                    MAX(ANSWER_TXT)
+                    FOR DATAMART_COLUMN_NM IN (' + @ldf_columns + ')
+                ) AS PivotTable';
+            END
+            ELSE
+            BEGIN
+                SET @sql_code = 'SELECT 
+                    TB_PAM_UID, 
+                    ADD_TIME
+                INTO ' + @global_temp_table_name +'
+                FROM #LDF_BASE_COUNTRY_CONCAT
+                '
+            END;
+            EXEC sp_executesql @sql_code;    
+
+            SELECT @RowCount_no = @@ROWCOUNT;
+
+            IF
+                @debug = 'true'
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
 
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
@@ -354,17 +502,18 @@ BEGIN
             SET
                 @PROC_STEP_NAME = 'DELETE INCOMING RECORDS FROM TB_PAM_LDF';
 
-            DELETE D
+            SET @sql_code = 'DELETE D
             FROM [dbo].TB_PAM_LDF D
-            INNER JOIN #LDF_TRANSLATED T
+            INNER JOIN ' + @global_temp_table_name + ' T
                 ON T.TB_PAM_UID = D.TB_PAM_UID
+            '
+            EXEC sp_executesql @sql_code; 
     
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
-                SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
     
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
@@ -382,23 +531,50 @@ BEGIN
             SET
                 @PROC_STEP_NAME = 'INSERT INCOMING RECORDS TO TB_PAM_LDF';
 
-            INSERT INTO [dbo].TB_PAM_LDF (
-                INVESTIGATION_KEY,
-                TB_PAM_UID,
-                ADD_TIME
-            )
-            SELECT 
-                INVESTIGATION_KEY,
-                TB_PAM_UID,
-                ADD_TIME
-            FROM #LDF_TRANSLATED
+            SET @tb_ldf_columns = (
+                SELECT ISNULL(
+                    STRING_AGG('tb.' + TRIM(value), ','),
+                    ''
+                )
+                FROM STRING_SPLIT(ISNULL(@ldf_columns, ''), ',')
+                WHERE TRIM(value) != ''
+            );
+
+            SET @sql_code = 
+            'INSERT INTO dbo.TB_PAM_LDF([INVESTIGATION_KEY], [TB_PAM_UID], [add_time] '+ 
+                CASE
+                    WHEN @ldf_columns != '' THEN ',' + @ldf_columns
+                    ELSE ''
+                END
+            + ' )
+            SELECT
+                inv.INVESTIGATION_KEY,
+                tb.TB_PAM_UID,
+                tb.add_time'+
+            + CASE
+                    WHEN @ldf_columns != '' THEN ',' + @tb_ldf_columns
+                    ELSE ''
+                END
+            +
+            '
+            FROM
+            ' + @global_temp_table_name +' tb
+            LEFT JOIN [dbo].investigation inv WITH(nolock)
+                ON tb.TB_PAM_UID = inv.CASE_UID
+            ';
+            EXEC sp_executesql @sql_code;
 
             SELECT @RowCount_no = @@ROWCOUNT;
 
             IF
                 @debug = 'true'
-                SELECT @Proc_Step_Name AS step, *
-                FROM #LDF_TRANSLATED;
+                EXEC('SELECT '''+ @Proc_Step_Name +''' AS step, * FROM ' + @global_temp_table_name + ';');
+
+            -- Force drop global temp table
+            EXEC ('IF OBJECT_ID(''tempdb..' + @global_temp_table_name +''', ''U'')  IS NOT NULL
+            BEGIN
+                DROP TABLE ' + @global_temp_table_name +';
+            END;')
 
             INSERT INTO [dbo].[job_flow_log]
             (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/017-create_nrt_observation-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/017-create_nrt_observation-001.sql
@@ -358,5 +358,12 @@ IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_observation' and xtype = '
                     ADD batch_id bigint;
             END;
 
+--CNDE-2511
+        IF NOT EXISTS(SELECT 1 FROM sys.columns   WHERE Name = N'associated_phc_uids'   AND Object_ID = Object_ID(N'nrt_observation'))
+            BEGIN
+                ALTER TABLE nrt_observation
+                    ADD associated_phc_uids NVARCHAR(MAX);
+            END;
+
     END;
 


### PR DESCRIPTION
## Notes

This PR makes the necessary updates to `sp_observation_event`, `nrt_observation`, and the Observation Java service for including a comma separated list of phc_uids that are associated with a given observation.

## JIRA

- **Related story**: [CNDE-2511](https://cdc-nbs.atlassian.net/browse/CNDE-2511)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?