### PR TITLE
CNDE-2509: Fix investigation_key associations in Morbidity Reports

### DIFF
--- a/db/upgrade/rdb_modern/routines/046-sp_morbidity_report_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/046-sp_morbidity_report_datamart_postprocessing.sql
@@ -164,7 +164,7 @@ BEGIN TRY
             EM.LAST_CHG_TIME AS MORB_REPORT_LAST_UPDATED_DATE, 
             EM.LAST_CHG_USER_ID,
             inv.INV_CASE_STATUS AS CASE_STATUS,
-            IIF(inv.INVESTIGATION_KEY IS NULL, 'No', 'Yes') AS INVESTIGATION_CREATED_IND,
+            IIF(COALESCE(inv.INVESTIGATION_KEY, 1) = 1, 'No', 'Yes') AS INVESTIGATION_CREATED_IND,
             inv.INVESTIGATION_KEY,
             CASE  
             WHEN CHARINDEX(',', EM.add_user_name) > 0  

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/048-sp_morbidity_report_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/048-sp_morbidity_report_datamart_postprocessing-001.sql
@@ -164,7 +164,7 @@ BEGIN TRY
             EM.LAST_CHG_TIME AS MORB_REPORT_LAST_UPDATED_DATE, 
             EM.LAST_CHG_USER_ID,
             inv.INV_CASE_STATUS AS CASE_STATUS,
-            IIF(inv.INVESTIGATION_KEY IS NULL, 'No', 'Yes') AS INVESTIGATION_CREATED_IND,
+            IIF(COALESCE(inv.INVESTIGATION_KEY, 1) = 1, 'No', 'Yes') AS INVESTIGATION_CREATED_IND,
             inv.INVESTIGATION_KEY,
             CASE  
             WHEN CHARINDEX(',', EM.add_user_name) > 0  


### PR DESCRIPTION
## Notes

This PR includes the necessary changes to properly populate the investigation keys in `dbo.MORBIDITY_REPORT_EVENT` as well as `dbo.MORBIDITY_REPORT_DATAMART` .

## JIRA

- **Related story**: [CNDE-2509](https://cdc-nbs.atlassian.net/browse/CNDE-2509)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?