### PR TITLE
CNDE-2568 Handling Empty Datamart Names in Postprocessing

### DIFF
--- a/db/upgrade/rdb_modern/routines/005-sp_nrt_notification_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/005-sp_nrt_notification_postprocessing.sql
@@ -323,7 +323,7 @@ BEGIN
                  LEFT JOIN dbo.INVESTIGATION inv with (nolock) ON inv.INVESTIGATION_KEY = ntf.INVESTIGATION_KEY
                  LEFT JOIN dbo.v_condition_dim c with (nolock) ON c.CONDITION_KEY = ntf.CONDITION_KEY
                  LEFT JOIN dbo.D_PATIENT pat with (nolock) ON pat.PATIENT_KEY = ntf.PATIENT_KEY
-                 LEFT JOIN dbo.nrt_datamart_metadata dtm with (nolock) ON dtm.condition_cd = c.CONDITION_CD;
+                 INNER JOIN dbo.nrt_datamart_metadata dtm with (nolock) ON dtm.condition_cd = c.CONDITION_CD;
 
     END TRY
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/006-sp_nrt_notification_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/006-sp_nrt_notification_postprocessing-001.sql
@@ -323,7 +323,7 @@ BEGIN
                  LEFT JOIN dbo.INVESTIGATION inv with (nolock) ON inv.INVESTIGATION_KEY = ntf.INVESTIGATION_KEY
                  LEFT JOIN dbo.v_condition_dim c with (nolock) ON c.CONDITION_KEY = ntf.CONDITION_KEY
                  LEFT JOIN dbo.D_PATIENT pat with (nolock) ON pat.PATIENT_KEY = ntf.PATIENT_KEY
-                 LEFT JOIN dbo.nrt_datamart_metadata dtm with (nolock) ON dtm.condition_cd = c.CONDITION_CD;
+                 INNER JOIN dbo.nrt_datamart_metadata dtm with (nolock) ON dtm.condition_cd = c.CONDITION_CD;
 
     END TRY
 


### PR DESCRIPTION
## Notes

This ticket includes handling Empty Datamart values. Currently, the sp_nrt_notification_postprocessing  has a left join to the  nrt_datamart_metadata. This is changed to Inner Join. 
 
No changes required in:
sp_d_morbidity_report_postprocessing
sp_d_labtest_result_postprocessing

## JIRA

- **Related story**: [CNDE-2568](https://cdc-nbs.atlassian.net/browse/CNDE-2568)

## Checklist

- [X] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [X] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [X] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [X] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?