### PR TITLE
CNDE-2569: add deletes to dynamic datamarts

### DIFF
--- a/db/upgrade/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing.sql
@@ -21,6 +21,7 @@ BEGIN
         DECLARE @datamart_suffix varchar(100) = @DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50))
 
         DECLARE @tmp_DynDm_INCOMING_DATA varchar(200) = 'tmp_DynDm_INCOMING_DATA_'+@datamart_suffix;
+        DECLARE @tmp_DynDm_INACTIVE_INVESTIGATIONS VARCHAR(200) = 'dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix;
 
 
     DECLARE @tgt_table_nm NVARCHAR(200) = 'DM_INV_' + @DATAMART_NAME;
@@ -274,6 +275,33 @@ LEFT JOIN dbo.tmp_DynDm_REPEAT_BLOCK_NUMERIC_ALL_' + @datamart_suffix + '   with
             END;
 
             COMMIT TRANSACTION;
+
+
+            IF OBJECT_ID('dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+
+            BEGIN TRANSACTION
+
+                SET @Proc_Step_no = @Proc_Step_no + 1;
+                SET @Proc_Step_Name = 'DELETING INACTIVE RECORDS FROM ' + @tgt_table_nm;
+
+                set @temp_sql = '
+                DELETE inv 
+                FROM dbo.' + @tgt_table_nm + ' inv 
+                INNER JOIN ' + @tmp_DynDm_INACTIVE_INVESTIGATIONS + ' del_inv 
+                    ON inv.INVESTIGATION_KEY = del_inv.INVESTIGATION_KEY ';
+
+
+
+            if @debug = 'true'
+            select @Proc_Step_Name, @temp_sql;
+
+            exec sp_executesql @temp_sql;
+
+            COMMIT TRANSACTION;
+                
+            END
+            
 
             BEGIN TRANSACTION
 

--- a/db/upgrade/rdb_modern/routines/250-sp_dyn_dm_invest_clear_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/250-sp_dyn_dm_invest_clear_postprocessing.sql
@@ -61,6 +61,12 @@ BEGIN
                 exec sp_executesql @temp_sql;
             END
 
+        IF OBJECT_ID('dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+                SET @temp_sql = 'drop table dbo.tmp_DynDm_Inactive_Investigations_' + @datamart_suffix;
+                exec sp_executesql @temp_sql;
+            END
+
         IF OBJECT_ID('dbo.tmp_DynDm_INV_SUMM_DATAMART_'+@datamart_suffix, 'U') IS NOT NULL
             BEGIN
                 SET @temp_sql = 'drop table dbo.tmp_DynDm_INV_SUMM_DATAMART_' + @datamart_suffix;
@@ -262,6 +268,12 @@ BEGIN
         IF OBJECT_ID('dbo.tmp_DynDm_REPEAT_BLOCK_'+@datamart_suffix, 'U') IS NOT NULL
             BEGIN
                 SET @temp_sql = 'drop table dbo.tmp_DynDm_REPEAT_BLOCK_' + @datamart_suffix;
+                exec sp_executesql @temp_sql;
+            END
+
+        IF OBJECT_ID('dbo.tmp_DynDm_INCOMING_DATA_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+                SET @temp_sql = 'drop table dbo.tmp_DynDm_INCOMING_DATA_' + @datamart_suffix;
                 exec sp_executesql @temp_sql;
             END
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/115-sp_dyn_dm_invest_form_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/115-sp_dyn_dm_invest_form_postprocessing-001.sql
@@ -25,6 +25,7 @@ BEGIN
         DECLARE @tmp_DynDm_INV_SUMM_DATAMART VARCHAR(200) = 'dbo.tmp_DynDm_INV_SUMM_DATAMART_'+@DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50));
         DECLARE @tmp_DynDm_PATIENT_DATA VARCHAR(200) = 'dbo.tmp_DynDm_Patient_Data_'+@DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50));
         DECLARE @tmp_DynDm_INVESTIGATION_DATA VARCHAR(200) = 'dbo.tmp_DynDm_Investigation_Data_'+@DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50));
+        DECLARE @tmp_DynDm_INACTIVE_INVESTIGATIONS VARCHAR(200) = 'dbo.tmp_DynDm_Inactive_Investigations_'+@DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50));
 
         DECLARE @temp_sql nvarchar(max);
 
@@ -61,6 +62,41 @@ BEGIN
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
         INSERT INTO dbo.job_flow_log ( batch_id ,[Dataflow_Name] ,[package_Name] ,[Status_Type] ,[step_number] ,[step_name] ,[row_count] )
         VALUES ( @batch_id ,@Dataflow_Name ,@Package_Name ,'START' ,@Proc_Step_no ,@Proc_Step_Name ,@ROWCOUNT_NO );
+
+-------------------------------------------------------------------------------------------------------------------------------------------
+
+        SET @Proc_Step_no = @Proc_Step_no + 1;
+        SET @Proc_Step_Name = ' GENERATING  '+ @tmp_DynDm_INACTIVE_INVESTIGATIONS;
+
+
+
+        IF OBJECT_ID(@tmp_DynDm_INACTIVE_INVESTIGATIONS, 'U') IS NOT NULL
+            exec ('drop table '+ @tmp_DynDm_INACTIVE_INVESTIGATIONS);
+
+        if len(@phc_id_list) > 1
+            BEGIN
+                SET @temp_sql = '
+                SELECT  inv.INVESTIGATION_KEY 
+                into '+@tmp_DynDm_INACTIVE_INVESTIGATIONS+' 
+                FROM 
+                    dbo.INVESTIGATION inv with ( nolock) 
+                WHERE inv.RECORD_STATUS_CD = ''INACTIVE'' AND inv.CASE_UID IN (' + @phc_id_list + ') ';
+
+
+            if @debug = 'true'
+            select @temp_sql;
+
+            exec sp_executesql @temp_sql;
+
+            if @debug = 'true'
+                exec('select * from '+@tmp_DynDm_INACTIVE_INVESTIGATIONS);
+            END
+
+
+
+        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
+        INSERT INTO dbo.job_flow_log ( batch_id ,[Dataflow_Name] ,[package_Name] ,[Status_Type] ,[step_number] ,[step_name] ,[row_count] )
+        VALUES ( @batch_id ,@Dataflow_Name ,@Package_Name  ,'START' ,@Proc_Step_no ,@Proc_Step_Name ,@ROWCOUNT_NO );
 
 -------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing-001.sql
@@ -21,6 +21,7 @@ BEGIN
         DECLARE @datamart_suffix varchar(100) = @DATAMART_NAME+'_'+CAST(@batch_id AS varchar(50))
 
         DECLARE @tmp_DynDm_INCOMING_DATA varchar(200) = 'tmp_DynDm_INCOMING_DATA_'+@datamart_suffix;
+        DECLARE @tmp_DynDm_INACTIVE_INVESTIGATIONS VARCHAR(200) = 'dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix;
 
 
     DECLARE @tgt_table_nm NVARCHAR(200) = 'DM_INV_' + @DATAMART_NAME;
@@ -274,6 +275,33 @@ LEFT JOIN dbo.tmp_DynDm_REPEAT_BLOCK_NUMERIC_ALL_' + @datamart_suffix + '   with
             END;
 
             COMMIT TRANSACTION;
+
+
+            IF OBJECT_ID('dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+
+            BEGIN TRANSACTION
+
+                SET @Proc_Step_no = @Proc_Step_no + 1;
+                SET @Proc_Step_Name = 'DELETING INACTIVE RECORDS FROM ' + @tgt_table_nm;
+
+                set @temp_sql = '
+                DELETE inv 
+                FROM dbo.' + @tgt_table_nm + ' inv 
+                INNER JOIN ' + @tmp_DynDm_INACTIVE_INVESTIGATIONS + ' del_inv 
+                    ON inv.INVESTIGATION_KEY = del_inv.INVESTIGATION_KEY ';
+
+
+
+            if @debug = 'true'
+            select @Proc_Step_Name, @temp_sql;
+
+            exec sp_executesql @temp_sql;
+
+            COMMIT TRANSACTION;
+                
+            END
+            
 
             BEGIN TRANSACTION
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/250-sp_dyn_dm_invest_clear_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/250-sp_dyn_dm_invest_clear_postprocessing-001.sql
@@ -61,6 +61,12 @@ BEGIN
                 exec sp_executesql @temp_sql;
             END
 
+        IF OBJECT_ID('dbo.tmp_DynDm_Inactive_Investigations_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+                SET @temp_sql = 'drop table dbo.tmp_DynDm_Inactive_Investigations_' + @datamart_suffix;
+                exec sp_executesql @temp_sql;
+            END
+
         IF OBJECT_ID('dbo.tmp_DynDm_INV_SUMM_DATAMART_'+@datamart_suffix, 'U') IS NOT NULL
             BEGIN
                 SET @temp_sql = 'drop table dbo.tmp_DynDm_INV_SUMM_DATAMART_' + @datamart_suffix;
@@ -262,6 +268,12 @@ BEGIN
         IF OBJECT_ID('dbo.tmp_DynDm_REPEAT_BLOCK_'+@datamart_suffix, 'U') IS NOT NULL
             BEGIN
                 SET @temp_sql = 'drop table dbo.tmp_DynDm_REPEAT_BLOCK_' + @datamart_suffix;
+                exec sp_executesql @temp_sql;
+            END
+
+        IF OBJECT_ID('dbo.tmp_DynDm_INCOMING_DATA_'+@datamart_suffix, 'U') IS NOT NULL
+            BEGIN
+                SET @temp_sql = 'drop table dbo.tmp_DynDm_INCOMING_DATA_' + @datamart_suffix;
                 exec sp_executesql @temp_sql;
             END
 


### PR DESCRIPTION
## Notes

This PR introduces a new global temp table for holding inactive investigation keys for dynamic datamarts as well as a new section in the CreateDM stored procedure for deleting the investigation keys that are now inactive.

## JIRA

- **Related story**: [CNDE-2569](https://cdc-nbs.atlassian.net/browse/CNDE-2569)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?