### PR TITLE
CNDE-2361 D_PATIENT patient country populating incorrectly

### DIFF
--- a/db/upgrade/odse/routines/004-sp_patient_event.sql
+++ b/db/upgrade/odse/routines/004-sp_patient_event.sql
@@ -235,7 +235,7 @@ BEGIN
                                                select tmp.code, tmp.code_short_desc_txt from (
                                                                                                  -- ranking added to pick the latest valid short desc
                                                                                                  select code, code_short_desc_txt, rank () OVER (PARTITION BY code order by nbs_uid desc) rnk
-                                                                                                 from nbs_srte.dbo.CODE_VALUE_GENERAL with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
+                                                                                                 from nbs_srte.dbo.Country_CODE with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
                                                                                              ) tmp where rnk=1
                                            ) cc ON cc.code = pl.cntry_cd
                                            WHERE elp.entity_uid = p.person_uid

--- a/db/upgrade/odse/routines/004-sp_patient_event.sql
+++ b/db/upgrade/odse/routines/004-sp_patient_event.sql
@@ -231,13 +231,7 @@ BEGIN
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_code sc with (NOLOCK) ON sc.state_cd = pl.state_cd
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_county_code_value scc with (NOLOCK)
                                                                     ON scc.code = pl.cnty_cd
-                                                    LEFT OUTER JOIN (
-                                               select tmp.code, tmp.code_short_desc_txt from (
-                                                                                                 -- ranking added to pick the latest valid short desc
-                                                                                                 select code, code_short_desc_txt, rank () OVER (PARTITION BY code order by nbs_uid desc) rnk
-                                                                                                 from nbs_srte.dbo.Country_CODE with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
-                                                                                             ) tmp where rnk=1
-                                           ) cc ON cc.code = pl.cntry_cd
+                                                    LEFT OUTTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd                                                         
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
                                              AND elp.use_cd IN ('H', 'BIR')

--- a/db/upgrade/odse/routines/004-sp_patient_event.sql
+++ b/db/upgrade/odse/routines/004-sp_patient_event.sql
@@ -224,14 +224,21 @@ BEGIN
                                                       when elp.use_cd = 'H'
                                                           then coalesce(cc.code_short_desc_txt, pl.cntry_cd)
                                                       else null end                                                      AS [home_country],
-                                                  case when elp.use_cd = 'BIR' then cc.code_short_desc_txt else null end AS [birth_country]
+                                                  case when elp.use_cd = 'BIR' then cvg.code_short_desc_txt else null end AS [birth_country]
                                            FROM nbs_odse.dbo.Entity_locator_participation elp WITH (NOLOCK)
                                                     LEFT OUTER JOIN nbs_odse.dbo.Postal_locator pl WITH (NOLOCK)
                                                                     ON elp.locator_uid = pl.postal_locator_uid
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_code sc with (NOLOCK) ON sc.state_cd = pl.state_cd
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_county_code_value scc with (NOLOCK)
                                                                     ON scc.code = pl.cnty_cd
-                                                    LEFT OUTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd                                                         
+                                                    LEFT OUTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd
+                                                    LEFT OUTER JOIN (
+                                                        select tmp.code, tmp.code_short_desc_txt from (
+                                                            -- ranking added to pick the latest valid short desc
+                                                            select code, code_short_desc_txt, rank () OVER (PARTITION BY code order by nbs_uid desc) rnk
+                                                            from nbs_srte.dbo.CODE_VALUE_GENERAL with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
+                                                        ) tmp where rnk=1
+                                                    ) cvg ON cvg.code = pl.cntry_cd
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
                                              AND elp.use_cd IN ('H', 'BIR')

--- a/db/upgrade/odse/routines/004-sp_patient_event.sql
+++ b/db/upgrade/odse/routines/004-sp_patient_event.sql
@@ -231,7 +231,7 @@ BEGIN
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_code sc with (NOLOCK) ON sc.state_cd = pl.state_cd
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_county_code_value scc with (NOLOCK)
                                                                     ON scc.code = pl.cnty_cd
-                                                    LEFT OUTTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd                                                         
+                                                    LEFT OUTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd                                                         
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
                                              AND elp.use_cd IN ('H', 'BIR')

--- a/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
@@ -231,7 +231,7 @@ BEGIN
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_code sc with (NOLOCK) ON sc.state_cd = pl.state_cd
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_county_code_value scc with (NOLOCK)
                                                                     ON scc.code = pl.cnty_cd
-                                                    LEFT OUTTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd 
+                                                    LEFT OUTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd 
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
                                              AND elp.use_cd IN ('H', 'BIR')

--- a/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
@@ -235,7 +235,7 @@ BEGIN
                                                select tmp.code, tmp.code_short_desc_txt from (
                                                                                                  -- ranking added to pick the latest valid short desc
                                                                                                  select code, code_short_desc_txt, rank () OVER (PARTITION BY code order by nbs_uid desc) rnk
-                                                                                                 from nbs_srte.dbo.CODE_VALUE_GENERAL with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
+                                                                                                 from nbs_srte.dbo.Country_CODE with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
                                                                                              ) tmp where rnk=1
                                            ) cc ON cc.code = pl.cntry_cd
                                            WHERE elp.entity_uid = p.person_uid

--- a/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
+++ b/liquibase-service/src/main/resources/db/odse/routines/008-sp_patient_event-001.sql
@@ -231,13 +231,7 @@ BEGIN
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_code sc with (NOLOCK) ON sc.state_cd = pl.state_cd
                                                     LEFT OUTER JOIN nbs_srte.dbo.State_county_code_value scc with (NOLOCK)
                                                                     ON scc.code = pl.cnty_cd
-                                                    LEFT OUTER JOIN (
-                                               select tmp.code, tmp.code_short_desc_txt from (
-                                                                                                 -- ranking added to pick the latest valid short desc
-                                                                                                 select code, code_short_desc_txt, rank () OVER (PARTITION BY code order by nbs_uid desc) rnk
-                                                                                                 from nbs_srte.dbo.Country_CODE with (nolock) where CODE_SET_NM in( 'PHVS_BIRTHCOUNTRY_CDC', 'PHVS_TB_BIRTH_CNTRY', 'PSL_CNTRY')
-                                                                                             ) tmp where rnk=1
-                                           ) cc ON cc.code = pl.cntry_cd
+                                                    LEFT OUTTER JOIN nbs_srte.dbo.Country_CODE cc with (nolock) ON cc.code = pl.cntry_cd 
                                            WHERE elp.entity_uid = p.person_uid
                                              AND elp.class_cd = 'PST'
                                              AND elp.use_cd IN ('H', 'BIR')


### PR DESCRIPTION
## Notes

Country text was taken from nbs_srte.dbo.CODE_VALUE_GENERAL where the country name is in Capital letters. Also it requires rank. Nevertheless if we take the country name from  nbs_srte.dbo.Country_CODE , the country name is not in Capital letters and it doesn't require rank

Also, Birth_country must be read from nbs_srte.dbo.CODE_VALUE_GENERAL. So

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2361)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?