### PR TITLE
CNDE-2809: Refactor extractUid for NBS_ODSE snapshots

### DIFF
--- a/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
+++ b/common-util/src/main/java/gov/cdc/etldatapipeline/commonutil/UtilHelper.java
@@ -32,9 +32,12 @@ public class UtilHelper {
 
     public static String extractUid(String value, String uidName, String... overridePath) throws JsonProcessingException {
         JsonNode jsonNode = objectMapper.readTree(value);
+        JsonNode payloadNode = jsonNode.get(PAYLOAD_KEY);
+
         String path = overridePath.length > 0 ? overridePath[0] : DEFAULT_PATH;
-        JsonNode payloadNode = jsonNode.get(PAYLOAD_KEY).path(path);
-        if (!payloadNode.isMissingNode() && payloadNode.has(uidName)) {
+        JsonNode dataNode = jsonNode.get(PAYLOAD_KEY).path(path);
+        payloadNode = dataNode.isMissingNode() ? payloadNode : dataNode;
+        if (payloadNode.has(uidName)) {
             return payloadNode.get(uidName).asText();
         } else {
             throw new NoSuchElementException("The " + uidName + " field is missing in the message payload.");

--- a/common-util/src/test/java/gov/cdc/etldatapipeline/commonutil/UtilHelperTest.java
+++ b/common-util/src/test/java/gov/cdc/etldatapipeline/commonutil/UtilHelperTest.java
@@ -77,6 +77,9 @@ class UtilHelperTest {
 
         uid = UtilHelper.extractUid(sampleJson, "uid", "before");
         assertEquals("12344", uid);
+
+        uid = UtilHelper.extractUid("{\"payload\": {\"uid\": \"12346\"}}", "uid");
+        assertEquals("12346", uid);
     }
 
     @Test

--- a/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataService.java
+++ b/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataService.java
@@ -89,10 +89,10 @@ public class LdfDataService {
         String ldfUid = "";
         String busObjUid = "";
         try {
-            JsonNode jsonNode = objectMapper.readTree(value);
+            JsonNode jsonNode = objectMapper.readTree(value).get("payload");
             String operationType = extractChangeDataCaptureOperation(value);
-            String payloadString = "payload";
-            JsonNode payloadNode = operationType.equals("d")? jsonNode.get(payloadString).path("before"): jsonNode.get(payloadString).path("after");
+            JsonNode payloadNode = operationType.equals("d")? jsonNode.path("before"): jsonNode.path("after");
+            payloadNode = payloadNode.isMissingNode() ? jsonNode : payloadNode;
             ldfUid = extractUid(payloadNode);
             busObjNm = payloadNode.get("business_object_nm").asText();
             busObjUid = payloadNode.get("business_object_uid").asText();
@@ -104,8 +104,7 @@ public class LdfDataService {
             if (operationType.equals("d")){
                 LdfData custLdfData = initializeBean(ldfUid, busObjUid, busObjNm);
                 ldfDataKey.setLdfUid(Long.valueOf(ldfUid));
-                ldfData =  Optional.of(custLdfData);
-                pushKeyValuePairToKafka(ldfDataKey, ldfData.get(), ldfDataTopicReporting);
+                pushKeyValuePairToKafka(ldfDataKey, custLdfData, ldfDataTopicReporting);
                 logger.info("LDF data (uid={}) sent to {}", ldfUid, ldfDataTopicReporting);
 
             } else {

--- a/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataServiceTest.java
+++ b/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/service/LdfDataServiceTest.java
@@ -115,32 +115,14 @@ class LdfDataServiceTest {
         ConsumerRecord<String, String> rec = getRecord(invalidPayload, ldfTopic);
         var ldfDataService = getInvestigationService(ldfTopic, ldfTopicOutput);
         assertThrows(RuntimeException.class, () -> ldfDataService.processMessage(rec, consumer));
-    
-
-    }
-    @Test
-    void testNonNullBusObNmEmptyMessageException() {
-        String ldfTopic = "LdfData";
-        String ldfTopicOutput = "LdfDataOutput";
-        String busObjNm = "PHC";
-        long ldfUid = 100000001L;
-        String invalidPayload = "{\"payload\": {\"after\": {" +
-                "\"business_object_nm\": \"" + busObjNm + "\"," +
-                "\"ldf_uid\": \"" + ldfUid + "\"}}}";
-
-        ConsumerRecord<String, String> rec = getRecord(invalidPayload, ldfTopic);
-        var ldfDataService = getInvestigationService(ldfTopic, ldfTopicOutput);
-        assertThrows(RuntimeException.class, () -> ldfDataService.processMessage(rec, consumer));
     }
 
     @Test
     void testProcessEmptyMessage() {
         String ldfTopic = "LdfData";
         String ldfTopicOutput = "LdfDataOutput";
-        String invalidPayload = null;
-        String emptyPayload = "";
-        testEmptyMessage(ldfTopic, ldfTopicOutput, invalidPayload);
-        testEmptyMessage(ldfTopic, ldfTopicOutput, emptyPayload);
+        testEmptyMessage(ldfTopic, ldfTopicOutput, null);
+        testEmptyMessage(ldfTopic, ldfTopicOutput, "");
     }
 
     private void testEmptyMessage(String ldfTopic, String ldfTopicOutput, String payload){
@@ -148,7 +130,7 @@ class LdfDataServiceTest {
         final var ldfDataService = getInvestigationService(ldfTopic, ldfTopicOutput);
         ldfDataService.processMessage(rec, consumer);
         List<ILoggingEvent> logs = listAppender.list;
-        assertTrue(logs.get(0).getFormattedMessage().contains("Received null or empty message on topic: "+ldfTopic));
+        assertTrue(logs.getFirst().getFormattedMessage().contains("Received null or empty message on topic: "+ldfTopic));
     }
 
     @Test
@@ -186,7 +168,7 @@ class LdfDataServiceTest {
         ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
         RuntimeException ex = assertThrows(RuntimeException.class,
                 () -> ldfDataService.processMessage(rec, consumer));
-        assertEquals(ex.getCause().getClass(), NoSuchElementException.class);
+        assertEquals(NoSuchElementException.class, ex.getCause().getClass());
     }
 
     private void validateData(String inputTopicName, String outputTopicName,


### PR DESCRIPTION
## Notes

This PR refactors the utility method responsible for extracting UIDs from Kafka message payloads, particularly to support Debezium messages generated with **snapshot.mode=initial**, which may lack child nodes like `after` or `before`.

- UitlHelper::extractUid - updated to handle UID extraction from payloads with or without an `after` node.
- LdfDataService - revised its custom extractUid method to align with the new logic.
 
## JIRA

- **Related story**: [CNDE-2809](https://cdc-nbs.atlassian.net/browse/CNDE-2809)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?