### PR TITLE
CNDE-2832: Remove covid Feature Flag

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -77,15 +77,6 @@ public class InvestigationService {
     @Value("${featureFlag.phc-datamart-enable}")
     private boolean phcDatamartEnable;
 
-    @Value("${featureFlag.bmird-case-enable}")
-    private boolean bmirdCaseEnable;
-
-    @Value("${featureFlag.contact-record-enable}")
-    public boolean contactRecordEnable;
-
-    @Value("${featureFlag.treatment-enable}")
-    public boolean treatmentEnable;
-
     private final InvestigationRepository investigationRepository;
     private final NotificationRepository notificationRepository;
     private final InterviewRepository interviewRepository;
@@ -145,11 +136,11 @@ public class InvestigationService {
             processNotification(message);
         } else if (topic.equals(interviewTopic)) {
             processInterview(message, batchId);
-        } else if (topic.equals(contactTopic) && contactRecordEnable) {
+        } else if (topic.equals(contactTopic)) {
             processContact(message);
         } else if (topic.equals(vaccinationTopic)) {
             processVaccination(message, true, "");
-        } else if (topic.equals(treatmentTopic) && treatmentEnable) {
+        } else if (topic.equals(treatmentTopic)) {
             processTreatment(message, true, "");
         } else if (topic.equals(actRelationshipTopic) && message != null) {
             processActRelationship(message);
@@ -164,12 +155,6 @@ public class InvestigationService {
 
             if (phcDatamartEnable) {
                 CompletableFuture.runAsync(() -> processDataUtil.processPhcFactDatamart(phcUid), phcExecutor);
-            }
-
-            // Check if feature flag for BMIRD is enabled
-            final String programArea = extractValue(value, "prog_area_cd");
-            if ("BMIRD".equals(programArea) && !bmirdCaseEnable) {
-                return;
             }
 
             logger.info(topicDebugLog, "Investigation", publicHealthCaseUid, investigationTopic);
@@ -217,7 +202,7 @@ public class InvestigationService {
             if (typeCd.equals("1180")) {
                 processVaccination(value, false, sourceActUid);
             }
-            if ((typeCd.equals("TreatmentToPHC") || typeCd.equals("TreatmentToMorb")) && treatmentEnable) {
+            if (typeCd.equals("TreatmentToPHC") || typeCd.equals("TreatmentToMorb")) {
                 processTreatment(value, false, sourceActUid);
             }
         } catch (Exception e) {

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -44,16 +44,9 @@ spring:
     username: ${DB_USERNAME:-sa}
     driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver
     url: ${DB_ODSE_URL:jdbc:sqlserver://localhost:1433;databaseName=:NBS_ODSE;encrypt=true;trustServerCertificate=true;}
-    odse:
-      url: ${DB_ODSE_URL:jdbc:sqlserver://localhost:1433;databaseName=:NBS_ODSE;encrypt=true;trustServerCertificate=true;}
-    rdb:
-      url: ${DB_RDB_URL:jdbc:sqlserver://localhost:1433;databaseName=:RDB;encrypt=true;trustServerCertificate=true;}
   liquibase:
     change-log: db/changelog/db.changelog-master.yaml
 featureFlag:
   phc-datamart-enable: ${FF_PHC_DM_ENABLE:false}
-  bmird-case-enable: ${FF_BMIRD_CASE_ENABLE:false}
-  contact-record-enable: ${FF_CONTACT_RECORD_ENABLE:false}
-  treatment-enable: ${FF_TREATMENT_ENABLE:false}
 server:
   port: '8093'

--- a/post-processing-service/src/main/resources/application.yaml
+++ b/post-processing-service/src/main/resources/application.yaml
@@ -39,8 +39,6 @@ spring:
   jpa:
     properties:
       javax.persistence.query.timeout: -1
-featureFlag:
-  covid-dm-enable: ${FF_COVID_DM_ENABLE:false}
 service:
   fixed-delay:
     cached-ids: ${FIXED_DELAY_ID:20000}

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
@@ -50,7 +50,6 @@ class DatamartProcessingTest {
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
         datamartProcessor = new ProcessDatamartData(kafkaTemplate);
-        datamartProcessor.setCovidDmEnable(true);
     }
 
     @AfterEach


### PR DESCRIPTION
## Notes

This PR cleans up the codebase by removing deprecated feature flags from Post-processing and Investigation pre-processing services.

-Post-processing logic: `covid-dm-enable`
-Investigation pre-processing: `bmird-case-enable`, `contact-record-enable`, `treatment-enable`

## JIRA

- **Related story**: [CNDE-2832](https://cdc-nbs.atlassian.net/browse/CNDE-2832)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?