### PR TITLE
CNDE-2751: Covid Lab Bugfix Part 1

### DIFF
--- a/db/upgrade/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing.sql
@@ -108,20 +108,20 @@ BEGIN
           AND (o_result.cd IN
                (
                    SELECT loinc_cd
-                   FROM nbs_srte..Loinc_condition
+                   FROM dbo.nrt_srte_Loinc_condition
                    WHERE condition_cd = '11065'
                )
             OR o_result.cd IN(''))--replace '' with the local codes seperated by comma
           AND o_result.cd NOT IN
               (
                   SELECT loinc_cd
-                  FROM nbs_srte..Loinc_code
+                  FROM dbo.nrt_srte_Loinc_code
                   WHERE time_aspect = 'Pt'
                     AND system_cd = '^Patient'
               );
 
-        SELECT '#COVID_RESULT_LIST',*
-        from #COVID_RESULT_LIST;
+        IF @debug = 'true' SELECT '#COVID_RESULT_LIST', *
+                           from #COVID_RESULT_LIST;
 
 
         SELECT DISTINCT
@@ -140,8 +140,8 @@ BEGIN
             AND otxt_comment.ovt_txt_type_cd = 'N'
         ;
 
-        SELECT '#COVID_TEXT_RESULT_LIST',*
-        from #COVID_TEXT_RESULT_LIST;
+        IF @debug = 'true' SELECT '#COVID_TEXT_RESULT_LIST',*
+                           from #COVID_TEXT_RESULT_LIST;
 
         /* Logging */
         SET @rowcount = @@ROWCOUNT;
@@ -375,7 +375,7 @@ BEGIN
             COALESCE(d_patient.PATIENT_MIDDLE_NAME,p.middle_name) AS Middle_Name,
             COALESCE(d_patient.PATIENT_FIRST_NAME,p.first_name) AS First_Name,
             COALESCE(d_patient.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            NULL AS Current_Sex_Cd, --Code is not recorded in D_PATIENT
+            NULL AS Current_Sex_Cd, --CNDE-2751: Code is not recorded in D_PATIENT. Temporary stopgap.
             COALESCE(d_patient.PATIENT_AGE_REPORTED,p.age_reported) AS Age_Reported,
             COALESCE(d_patient.PATIENT_AGE_REPORTED_UNIT,p.age_reported_unit) AS Age_Unit_Cd,
             COALESCE(d_patient.PATIENT_DOB,p.dob) AS Birth_Dt,

--- a/db/upgrade/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing.sql
@@ -53,12 +53,7 @@ BEGIN
                 INTO #COVID_OBSERVATIONS_TO_PROCESS
                 FROM STRING_SPLIT(@observation_id_list, ',') split_ids
                          INNER JOIN dbo.nrt_observation obs WITH(NOLOCK) ON TRY_CAST(split_ids.value AS BIGINT) = obs.observation_uid
-                         LEFT JOIN dbo.D_Patient dp WITH(NOLOCK) ON obs.patient_id = dp.PATIENT_UID
-                         LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON obs.patient_id = p.patient_uid
-                         INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
-                WHERE COALESCE(obs.record_status_cd, '') <> 'LOG_DEL'
-                  AND COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL;
-                /*Update Condition: if key exists in nrt_patient>nrt_patient values, else D_Patient.  */
+                WHERE COALESCE(obs.record_status_cd, '') <> 'LOG_DEL';
 
             END
 
@@ -97,10 +92,8 @@ BEGIN
             o_result.observation_uid,
             o.observation_uid AS target_observation_uid, --result
             o.local_id AS Lab_Local_ID,
-            COALESCE(dp.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            replace(replace(otxt.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Text_Result_Desc,
-            replace(replace(otxt_comment.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Result_Comments
-        INTO #COVID_TEXT_RESULT_LIST
+            COALESCE(dp.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID
+        INTO #COVID_RESULT_LIST
         FROM #COVID_OBSERVATIONS_TO_PROCESS cp --Order
                  INNER JOIN dbo.nrt_observation o_result WITH(NOLOCK) ON cp.observation_uid = o_result.observation_uid
                  CROSS APPLY (
@@ -111,11 +104,44 @@ BEGIN
                  LEFT JOIN dbo.D_PATIENT dp WITH(NOLOCK) ON o_result.patient_id = dp.patient_uid
                  LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON o_result.patient_id = p.patient_uid
                  INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
+        WHERE COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL
+          AND (o_result.cd IN
+               (
+                   SELECT loinc_cd
+                   FROM nbs_srte..Loinc_condition
+                   WHERE condition_cd = '11065'
+               )
+            OR o_result.cd IN(''))--replace '' with the local codes seperated by comma
+          AND o_result.cd NOT IN
+              (
+                  SELECT loinc_cd
+                  FROM nbs_srte..Loinc_code
+                  WHERE time_aspect = 'Pt'
+                    AND system_cd = '^Patient'
+              );
+
+        SELECT '#COVID_RESULT_LIST',*
+        from #COVID_RESULT_LIST;
+
+
+        SELECT DISTINCT
+            cp.observation_uid,
+            cp.target_observation_uid, --result
+            cp.Lab_Local_ID,
+            cp.Patient_Local_ID,
+            replace(replace(otxt.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Text_Result_Desc,
+            replace(replace(otxt_comment.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Result_Comments
+        INTO #COVID_TEXT_RESULT_LIST
+        FROM #COVID_RESULT_LIST cp --Order
+                 INNER JOIN dbo.nrt_observation o WITH(NOLOCK) ON cp.target_observation_uid = o.observation_uid
                  LEFT OUTER JOIN dbo.nrt_observation_txt otxt WITH(NOLOCK) ON o.observation_uid = otxt.observation_uid AND isnull(o.batch_id,1) = isnull(otxt.batch_id,1)
             AND (otxt.ovt_txt_type_cd = 'O' OR otxt.ovt_txt_type_cd IS NULL)
                  LEFT OUTER JOIN dbo.nrt_observation_txt otxt_comment WITH(NOLOCK) ON o.observation_uid = otxt_comment.observation_uid AND isnull(o.batch_id,1) = isnull(otxt_comment.batch_id,1)
             AND otxt_comment.ovt_txt_type_cd = 'N'
-            AND COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL;
+        ;
+
+        SELECT '#COVID_TEXT_RESULT_LIST',*
+        from #COVID_TEXT_RESULT_LIST;
 
         /* Logging */
         SET @rowcount = @@ROWCOUNT;
@@ -167,8 +193,8 @@ BEGIN
             cvg1.code_short_desc_txt AS Order_result_status,
             j_code.code_desc_txt AS Jurisdiction_Nm,
             mat.material_cd AS Specimen_Cd,
-            mat.material_nm AS Specimen_Desc,
-            mat.material_desc AS Specimen_type_free_text,
+            mat.material_desc AS Specimen_Desc,
+            mat.material_details AS Specimen_type_free_text,
             CASE
                 WHEN o.accession_number IS NULL
                     OR o.accession_number = ''
@@ -276,6 +302,7 @@ BEGIN
 
         SELECT
             core.Observation_UID AS RT_Observation_UID,
+--            core.target_observation_uid,
             core.Result AS RT_Result,
             CASE
                 -- Modify the logic (add additional variables) to determine negative labs
@@ -348,7 +375,7 @@ BEGIN
             COALESCE(d_patient.PATIENT_MIDDLE_NAME,p.middle_name) AS Middle_Name,
             COALESCE(d_patient.PATIENT_FIRST_NAME,p.first_name) AS First_Name,
             COALESCE(d_patient.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            COALESCE(d_patient.PATIENT_CURRENT_SEX,p.current_sex) AS Current_Sex_Cd,
+            NULL AS Current_Sex_Cd, --Code is not recorded in D_PATIENT
             COALESCE(d_patient.PATIENT_AGE_REPORTED,p.age_reported) AS Age_Reported,
             COALESCE(d_patient.PATIENT_AGE_REPORTED_UNIT,p.age_reported_unit) AS Age_Unit_Cd,
             COALESCE(d_patient.PATIENT_DOB,p.dob) AS Birth_Dt,
@@ -359,10 +386,10 @@ BEGIN
             COALESCE(d_patient.PATIENT_STREET_ADDRESS_2,p.street_address_2) AS Address_Two,
             COALESCE(d_patient.PATIENT_CITY,p.city) AS City,
             COALESCE(d_patient.PATIENT_STATE_CODE,p.state_code) AS State_Cd,
-            COALESCE(d_patient.PATIENT_STATE,state.state_NM) AS State,
+            COALESCE(dim_state.state_NM,nrt_state.state_NM) AS State,
             COALESCE(d_patient.PATIENT_ZIP,p.zip) AS Zip_Code,
             COALESCE(d_patient.PATIENT_COUNTY_CODE,p.county_code) AS County_Cd,
-            COALESCE(d_patient.PATIENT_COUNTY,p.country) AS County_Desc,
+            COALESCE(d_patient.PATIENT_COUNTY,p.county) AS County_Desc,
             COALESCE(d_patient.PATIENT_RACE_CALCULATED,p.race_calculated) AS PATIENT_RACE_CALC,
             COALESCE(d_patient.PATIENT_ETHNICITY,p.ethnicity) AS PATIENT_ETHNICITY
         INTO #COVID_LAB_PATIENT_DATA
@@ -370,10 +397,9 @@ BEGIN
                  INNER JOIN dbo.nrt_observation obs WITH(NOLOCK) ON o.observation_uid = obs.observation_uid
                  LEFT JOIN dbo.d_patient d_patient WITH(NOLOCK) ON obs.patient_id = d_patient.PATIENT_UID
                  LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON obs.patient_id = p.patient_uid
-                 INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
-                 LEFT OUTER JOIN dbo.nrt_srte_State_county_code_value county ON county.code = p.county_code
-                 LEFT OUTER JOIN dbo.nrt_srte_State_code state ON state.state_cd = p.state_code
-            AND COALESCE(d_patient.patient_uid, pk.patient_uid) IS NOT NULL;
+                 LEFT OUTER JOIN dbo.nrt_srte_State_code dim_state WITH(NOLOCK) ON dim_state.state_cd = d_patient.PATIENT_STATE_CODE
+                 LEFT OUTER JOIN dbo.nrt_srte_State_code nrt_state WITH(NOLOCK) ON nrt_state.state_cd = p.state_code;
+
 
         IF @debug = 'true'
             SELECT @proc_step_name, * FROM #COVID_LAB_PATIENT_DATA;
@@ -456,15 +482,14 @@ BEGIN
                  LEFT JOIN dbo.nrt_observation obs WITH(NOLOCK) ON o.Observation_UID = obs.observation_uid
             /*Auth Org*/
                  LEFT JOIN dbo.nrt_organization org_author WITH(NOLOCK) ON obs.author_organization_id = org_author.organization_uid
-                 LEFT JOIN dbo.D_Organization d_org_author WITH(NOLOCK) ON org_author.organization_uid = d_org_author.ORGANIZATION_UID
+                 LEFT JOIN dbo.D_Organization d_org_author WITH(NOLOCK) ON obs.author_organization_id = d_org_author.ORGANIZATION_UID
             /*Ordering Org*/
                  LEFT JOIN dbo.nrt_organization org_order WITH(NOLOCK) ON obs.ordering_organization_id = org_order.organization_uid
-                 LEFT JOIN dbo.D_Organization d_org_order WITH(NOLOCK) ON org_order.organization_uid = d_org_order.ORGANIZATION_UID
+                 LEFT JOIN dbo.D_Organization d_org_order WITH(NOLOCK) ON obs.ordering_organization_id = d_org_order.ORGANIZATION_UID
             /*Ordering Provider*/
                  LEFT JOIN dbo.nrt_provider 	AS provider_order with (nolock)
                            ON EXISTS (SELECT 1 FROM STRING_SPLIT(obs.ordering_person_id, ',') nprv
                                       WHERE cast(nprv.value as bigint) = provider_order.provider_uid)
-                 INNER JOIN dbo.nrt_provider_key pk WITH(NOLOCK) ON pk.d_provider_key = provider_order.provider_uid
                  LEFT JOIN dbo.D_PROVIDER AS d_provider_order with (nolock)  ON EXISTS (SELECT 1 FROM STRING_SPLIT(obs.ordering_person_id, ',') nprv
                                                                                         WHERE cast(nprv.value as bigint) = d_provider_order.provider_uid)
         ;
@@ -536,6 +561,7 @@ BEGIN
                ,@rowcount
                ,LEFT(ISNULL(@observation_id_list, 'NULL'),500)
                );
+
 
         /* Start transaction for the actual update to the datamart */
         SET @proc_step_name = 'Update COVID_LAB_DATAMART';
@@ -708,73 +734,73 @@ BEGIN
             core.Lab_Rpt_Received_By_PH_Dt,
             core.Order_result_status,
             core.Jurisdiction_Nm,
-            core.Specimen_Cd,
-            core.Specimen_Desc,
-            core.Specimen_type_free_text,
-            core.Specimen_Id,
-            core.SPECIMEN_SOURCE_SITE_CD,
-            core.SPECIMEN_SOURCE_SITE_DESC,
-            core.Testing_Lab_Accession_Number,
+            LEFT(core.Specimen_Cd,50),
+            LEFT(core.Specimen_Desc,100),
+            LEFT(core.Specimen_type_free_text,1000),
+            LEFT(core.Specimen_Id,100),
+            LEFT(core.SPECIMEN_SOURCE_SITE_CD,20),
+            LEFT(core.SPECIMEN_SOURCE_SITE_DESC,100),
+            LEFT(core.Testing_Lab_Accession_Number,199),
             core.Lab_Added_Dt,
             core.Lab_Update_Dt,
             core.Specimen_Coll_Dt,
             core.COVID_LAB_DATAMART_KEY,
-            core.Resulted_Test_Cd,
-            core.Resulted_Test_Desc,
-            core.Resulted_Test_Code_System,
-            core.DEVICE_INSTANCE_ID_1,
-            core.DEVICE_INSTANCE_ID_2,
-            core.Test_result_status,
-            core.Test_Method_Desc,
-            core.Device_Type_Id_1,
-            core.Device_Type_Id_2,
-            core.Perform_Facility_Name,
-            core.Testing_lab_Address_One,
-            core.Testing_lab_Address_Two,
-            core.Testing_lab_Country,
-            core.Testing_lab_county,
-            core.Testing_lab_county_Desc,
-            core.Testing_lab_City,
-            core.Testing_lab_State_Cd,
-            core.Testing_lab_State,
-            core.Testing_lab_Zip_Cd,
-            core.Result_Cd,
-            core.Result_Cd_Sys,
-            core.Result_Desc,
+            LEFT(core.Resulted_Test_Cd,50),
+            LEFT(core.Resulted_Test_Desc,1000),
+            LEFT(core.Resulted_Test_Code_System,300),
+            LEFT(core.DEVICE_INSTANCE_ID_1,199),
+            LEFT(core.DEVICE_INSTANCE_ID_2,199),
+            LEFT(core.Test_result_status,100),
+            LEFT(core.Test_Method_Desc,2000),
+            LEFT(core.Device_Type_Id_1,199),
+            LEFT(core.Device_Type_Id_2,199),
+            LEFT(core.Perform_Facility_Name,100),
+            LEFT(core.Testing_lab_Address_One,100),
+            LEFT(core.Testing_lab_Address_Two,100),
+            LEFT(core.Testing_lab_Country,20),
+            LEFT(core.Testing_lab_county,20),
+            LEFT(core.Testing_lab_county_Desc,255),
+            LEFT(core.Testing_lab_City,100),
+            LEFT(core.Testing_lab_State_Cd,20),
+            LEFT(core.Testing_lab_State,2),
+            LEFT(core.Testing_lab_Zip_Cd,20),
+            LEFT(core.Result_Cd,20),
+            LEFT(core.Result_Cd_Sys,300),
+            LEFT(core.Result_Desc,300),
             core.Text_Result_Desc,
-            core.Numeric_Comparator_Cd,
+            LEFT(core.Numeric_Comparator_Cd,20),
             core.Numeric_Value_1,
             core.Numeric_Value_2,
-            core.Numeric_Unit_Cd,
-            core.Numeric_Low_Range,
-            core.Numeric_High_Range,
-            core.Numeric_Separator_Cd,
-            core.Interpretation_Cd,
-            core.Interpretation_Desc,
+            LEFT(core.Numeric_Unit_Cd,20),
+            LEFT(core.Numeric_Low_Range,20),
+            LEFT(core.Numeric_High_Range,20),
+            LEFT(core.Numeric_Separator_Cd,10),
+            LEFT(core.Interpretation_Cd,20),
+            LEFT(core.Interpretation_Desc,100),
             core.Result_Comments,
             core.Result,
-            rslt.Result_Category,
+            LEFT(rslt.Result_Category,13),
             pat.Last_Name,
             pat.Middle_Name,
             pat.First_Name,
             pat.Patient_Local_ID,
             pat.Current_Sex_Cd,
-            pat.Age_Reported,
-            pat.Age_Unit_Cd,
+            LEFT(pat.Age_Reported,10),
+            LEFT(pat.Age_Unit_Cd,20),
             pat.Birth_Dt,
             pat.PATIENT_DEATH_DATE,
-            pat.PATIENT_DEATH_IND,
-            pat.Phone_Number,
-            pat.Address_One,
-            pat.Address_Two,
-            pat.City,
-            pat.State_Cd,
-            pat.State,
-            pat.Zip_Code,
-            pat.County_Cd,
-            pat.County_Desc,
+            LEFT(pat.PATIENT_DEATH_IND,20),
+            LEFT(pat.Phone_Number,20),
+            LEFT( pat.Address_One,100),
+            LEFT(pat.Address_Two,100),
+            LEFT(pat.City,100),
+            LEFT(pat.State_Cd,20),
+            LEFT(pat.State,2),
+            LEFT(pat.Zip_Code,20),
+            LEFT(pat.County_Cd,20),
+            LEFT(pat.County_Desc,255),
             pat.PATIENT_RACE_CALC,
-            pat.PATIENT_ETHNICITY,
+            LEFT(pat.PATIENT_ETHNICITY,20),
             ent.Reporting_Facility_Name,
             ent.Reporting_Facility_Address_One,
             ent.Reporting_Facility_Address_Two,
@@ -795,8 +821,8 @@ BEGIN
             ent.Ordering_Facility_County,
             ent.Ordering_Facility_County_Desc,
             ent.Ordering_Facility_City,
-            ent.Ordering_Facility_State_Cd,
-            ent.Ordering_Facility_State,
+            LEFT(ent.Ordering_Facility_State_Cd,20),
+            LEFT(ent.Ordering_Facility_State,2),
             ent.Ordering_Facility_Zip_Cd,
             ent.Ordering_Facility_Phone_Nbr,
             ent.Ordering_Facility_Phone_Ext,
@@ -813,10 +839,11 @@ BEGIN
             ent.Ordering_Provider_Zip_Cd,
             ent.Ordering_Provider_Phone_Nbr,
             ent.Ordering_Provider_Phone_Ext,
-            ent.ORDERING_PROVIDER_ID,
+            LEFT(ent.ORDERING_PROVIDER_ID,199),
             assoc.Associated_Case_ID
         FROM #COVID_LAB_CORE_DATA core
                  LEFT JOIN #COVID_LAB_RSLT_TYPE rslt ON core.Observation_UID = rslt.RT_Observation_UID
+            AND core.Result = rslt.RT_Result
                  LEFT JOIN #COVID_LAB_PATIENT_DATA pat ON core.Observation_UID = pat.Pat_Observation_UID
                  LEFT JOIN #COVID_LAB_ENTITIES_DATA ent ON core.Observation_UID = ent.Entity_Observation_uid
                  LEFT JOIN #COVID_LAB_ASSOCIATIONS assoc ON core.Observation_UID = assoc.ASSOC_OBSERVATION_UID;
@@ -874,6 +901,8 @@ BEGIN
                );
 
     END TRY
+
+
     BEGIN CATCH
         IF @@TRANCOUNT > 0
             ROLLBACK TRANSACTION;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing-001.sql
@@ -108,20 +108,20 @@ BEGIN
           AND (o_result.cd IN
                (
                    SELECT loinc_cd
-                   FROM nbs_srte..Loinc_condition
+                   FROM dbo.nrt_srte_Loinc_condition
                    WHERE condition_cd = '11065'
                )
             OR o_result.cd IN(''))--replace '' with the local codes seperated by comma
           AND o_result.cd NOT IN
               (
                   SELECT loinc_cd
-                  FROM nbs_srte..Loinc_code
+                  FROM dbo.nrt_srte_Loinc_code
                   WHERE time_aspect = 'Pt'
                     AND system_cd = '^Patient'
               );
 
-        SELECT '#COVID_RESULT_LIST',*
-        from #COVID_RESULT_LIST;
+        IF @debug = 'true' SELECT '#COVID_RESULT_LIST', *
+                           from #COVID_RESULT_LIST;
 
 
         SELECT DISTINCT
@@ -140,8 +140,8 @@ BEGIN
             AND otxt_comment.ovt_txt_type_cd = 'N'
         ;
 
-        SELECT '#COVID_TEXT_RESULT_LIST',*
-        from #COVID_TEXT_RESULT_LIST;
+        IF @debug = 'true' SELECT '#COVID_TEXT_RESULT_LIST',*
+                           from #COVID_TEXT_RESULT_LIST;
 
         /* Logging */
         SET @rowcount = @@ROWCOUNT;
@@ -375,7 +375,7 @@ BEGIN
             COALESCE(d_patient.PATIENT_MIDDLE_NAME,p.middle_name) AS Middle_Name,
             COALESCE(d_patient.PATIENT_FIRST_NAME,p.first_name) AS First_Name,
             COALESCE(d_patient.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            NULL AS Current_Sex_Cd, --Code is not recorded in D_PATIENT
+            NULL AS Current_Sex_Cd, --CNDE-2751: Code is not recorded in D_PATIENT. Temporary stopgap.
             COALESCE(d_patient.PATIENT_AGE_REPORTED,p.age_reported) AS Age_Reported,
             COALESCE(d_patient.PATIENT_AGE_REPORTED_UNIT,p.age_reported_unit) AS Age_Unit_Cd,
             COALESCE(d_patient.PATIENT_DOB,p.dob) AS Birth_Dt,

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/330-sp_covid_lab_datamart_postprocessing-001.sql
@@ -53,12 +53,7 @@ BEGIN
                 INTO #COVID_OBSERVATIONS_TO_PROCESS
                 FROM STRING_SPLIT(@observation_id_list, ',') split_ids
                          INNER JOIN dbo.nrt_observation obs WITH(NOLOCK) ON TRY_CAST(split_ids.value AS BIGINT) = obs.observation_uid
-                         LEFT JOIN dbo.D_Patient dp WITH(NOLOCK) ON obs.patient_id = dp.PATIENT_UID
-                         LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON obs.patient_id = p.patient_uid
-                         INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
-                WHERE COALESCE(obs.record_status_cd, '') <> 'LOG_DEL'
-                  AND COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL;
-                /*Update Condition: if key exists in nrt_patient>nrt_patient values, else D_Patient.  */
+                WHERE COALESCE(obs.record_status_cd, '') <> 'LOG_DEL';
 
             END
 
@@ -97,10 +92,8 @@ BEGIN
             o_result.observation_uid,
             o.observation_uid AS target_observation_uid, --result
             o.local_id AS Lab_Local_ID,
-            COALESCE(dp.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            replace(replace(otxt.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Text_Result_Desc,
-            replace(replace(otxt_comment.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Result_Comments
-        INTO #COVID_TEXT_RESULT_LIST
+            COALESCE(dp.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID
+        INTO #COVID_RESULT_LIST
         FROM #COVID_OBSERVATIONS_TO_PROCESS cp --Order
                  INNER JOIN dbo.nrt_observation o_result WITH(NOLOCK) ON cp.observation_uid = o_result.observation_uid
                  CROSS APPLY (
@@ -111,11 +104,44 @@ BEGIN
                  LEFT JOIN dbo.D_PATIENT dp WITH(NOLOCK) ON o_result.patient_id = dp.patient_uid
                  LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON o_result.patient_id = p.patient_uid
                  INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
+        WHERE COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL
+          AND (o_result.cd IN
+               (
+                   SELECT loinc_cd
+                   FROM nbs_srte..Loinc_condition
+                   WHERE condition_cd = '11065'
+               )
+            OR o_result.cd IN(''))--replace '' with the local codes seperated by comma
+          AND o_result.cd NOT IN
+              (
+                  SELECT loinc_cd
+                  FROM nbs_srte..Loinc_code
+                  WHERE time_aspect = 'Pt'
+                    AND system_cd = '^Patient'
+              );
+
+        SELECT '#COVID_RESULT_LIST',*
+        from #COVID_RESULT_LIST;
+
+
+        SELECT DISTINCT
+            cp.observation_uid,
+            cp.target_observation_uid, --result
+            cp.Lab_Local_ID,
+            cp.Patient_Local_ID,
+            replace(replace(otxt.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Text_Result_Desc,
+            replace(replace(otxt_comment.ovt_value_txt, CHAR(13), ' '), CHAR(10), ' ') AS Result_Comments
+        INTO #COVID_TEXT_RESULT_LIST
+        FROM #COVID_RESULT_LIST cp --Order
+                 INNER JOIN dbo.nrt_observation o WITH(NOLOCK) ON cp.target_observation_uid = o.observation_uid
                  LEFT OUTER JOIN dbo.nrt_observation_txt otxt WITH(NOLOCK) ON o.observation_uid = otxt.observation_uid AND isnull(o.batch_id,1) = isnull(otxt.batch_id,1)
             AND (otxt.ovt_txt_type_cd = 'O' OR otxt.ovt_txt_type_cd IS NULL)
                  LEFT OUTER JOIN dbo.nrt_observation_txt otxt_comment WITH(NOLOCK) ON o.observation_uid = otxt_comment.observation_uid AND isnull(o.batch_id,1) = isnull(otxt_comment.batch_id,1)
             AND otxt_comment.ovt_txt_type_cd = 'N'
-            AND COALESCE(dp.patient_uid, pk.patient_uid) IS NOT NULL;
+        ;
+
+        SELECT '#COVID_TEXT_RESULT_LIST',*
+        from #COVID_TEXT_RESULT_LIST;
 
         /* Logging */
         SET @rowcount = @@ROWCOUNT;
@@ -167,8 +193,8 @@ BEGIN
             cvg1.code_short_desc_txt AS Order_result_status,
             j_code.code_desc_txt AS Jurisdiction_Nm,
             mat.material_cd AS Specimen_Cd,
-            mat.material_nm AS Specimen_Desc,
-            mat.material_desc AS Specimen_type_free_text,
+            mat.material_desc AS Specimen_Desc,
+            mat.material_details AS Specimen_type_free_text,
             CASE
                 WHEN o.accession_number IS NULL
                     OR o.accession_number = ''
@@ -276,6 +302,7 @@ BEGIN
 
         SELECT
             core.Observation_UID AS RT_Observation_UID,
+--            core.target_observation_uid,
             core.Result AS RT_Result,
             CASE
                 -- Modify the logic (add additional variables) to determine negative labs
@@ -348,7 +375,7 @@ BEGIN
             COALESCE(d_patient.PATIENT_MIDDLE_NAME,p.middle_name) AS Middle_Name,
             COALESCE(d_patient.PATIENT_FIRST_NAME,p.first_name) AS First_Name,
             COALESCE(d_patient.PATIENT_LOCAL_ID,p.local_id) AS Patient_Local_ID,
-            COALESCE(d_patient.PATIENT_CURRENT_SEX,p.current_sex) AS Current_Sex_Cd,
+            NULL AS Current_Sex_Cd, --Code is not recorded in D_PATIENT
             COALESCE(d_patient.PATIENT_AGE_REPORTED,p.age_reported) AS Age_Reported,
             COALESCE(d_patient.PATIENT_AGE_REPORTED_UNIT,p.age_reported_unit) AS Age_Unit_Cd,
             COALESCE(d_patient.PATIENT_DOB,p.dob) AS Birth_Dt,
@@ -359,10 +386,10 @@ BEGIN
             COALESCE(d_patient.PATIENT_STREET_ADDRESS_2,p.street_address_2) AS Address_Two,
             COALESCE(d_patient.PATIENT_CITY,p.city) AS City,
             COALESCE(d_patient.PATIENT_STATE_CODE,p.state_code) AS State_Cd,
-            COALESCE(d_patient.PATIENT_STATE,state.state_NM) AS State,
+            COALESCE(dim_state.state_NM,nrt_state.state_NM) AS State,
             COALESCE(d_patient.PATIENT_ZIP,p.zip) AS Zip_Code,
             COALESCE(d_patient.PATIENT_COUNTY_CODE,p.county_code) AS County_Cd,
-            COALESCE(d_patient.PATIENT_COUNTY,p.country) AS County_Desc,
+            COALESCE(d_patient.PATIENT_COUNTY,p.county) AS County_Desc,
             COALESCE(d_patient.PATIENT_RACE_CALCULATED,p.race_calculated) AS PATIENT_RACE_CALC,
             COALESCE(d_patient.PATIENT_ETHNICITY,p.ethnicity) AS PATIENT_ETHNICITY
         INTO #COVID_LAB_PATIENT_DATA
@@ -370,10 +397,9 @@ BEGIN
                  INNER JOIN dbo.nrt_observation obs WITH(NOLOCK) ON o.observation_uid = obs.observation_uid
                  LEFT JOIN dbo.d_patient d_patient WITH(NOLOCK) ON obs.patient_id = d_patient.PATIENT_UID
                  LEFT JOIN dbo.nrt_patient p WITH(NOLOCK) ON obs.patient_id = p.patient_uid
-                 INNER JOIN dbo.nrt_patient_key pk WITH(NOLOCK) ON pk.patient_uid = p.patient_uid
-                 LEFT OUTER JOIN dbo.nrt_srte_State_county_code_value county ON county.code = p.county_code
-                 LEFT OUTER JOIN dbo.nrt_srte_State_code state ON state.state_cd = p.state_code
-            AND COALESCE(d_patient.patient_uid, pk.patient_uid) IS NOT NULL;
+                 LEFT OUTER JOIN dbo.nrt_srte_State_code dim_state WITH(NOLOCK) ON dim_state.state_cd = d_patient.PATIENT_STATE_CODE
+                 LEFT OUTER JOIN dbo.nrt_srte_State_code nrt_state WITH(NOLOCK) ON nrt_state.state_cd = p.state_code;
+
 
         IF @debug = 'true'
             SELECT @proc_step_name, * FROM #COVID_LAB_PATIENT_DATA;
@@ -456,15 +482,14 @@ BEGIN
                  LEFT JOIN dbo.nrt_observation obs WITH(NOLOCK) ON o.Observation_UID = obs.observation_uid
             /*Auth Org*/
                  LEFT JOIN dbo.nrt_organization org_author WITH(NOLOCK) ON obs.author_organization_id = org_author.organization_uid
-                 LEFT JOIN dbo.D_Organization d_org_author WITH(NOLOCK) ON org_author.organization_uid = d_org_author.ORGANIZATION_UID
+                 LEFT JOIN dbo.D_Organization d_org_author WITH(NOLOCK) ON obs.author_organization_id = d_org_author.ORGANIZATION_UID
             /*Ordering Org*/
                  LEFT JOIN dbo.nrt_organization org_order WITH(NOLOCK) ON obs.ordering_organization_id = org_order.organization_uid
-                 LEFT JOIN dbo.D_Organization d_org_order WITH(NOLOCK) ON org_order.organization_uid = d_org_order.ORGANIZATION_UID
+                 LEFT JOIN dbo.D_Organization d_org_order WITH(NOLOCK) ON obs.ordering_organization_id = d_org_order.ORGANIZATION_UID
             /*Ordering Provider*/
                  LEFT JOIN dbo.nrt_provider 	AS provider_order with (nolock)
                            ON EXISTS (SELECT 1 FROM STRING_SPLIT(obs.ordering_person_id, ',') nprv
                                       WHERE cast(nprv.value as bigint) = provider_order.provider_uid)
-                 INNER JOIN dbo.nrt_provider_key pk WITH(NOLOCK) ON pk.d_provider_key = provider_order.provider_uid
                  LEFT JOIN dbo.D_PROVIDER AS d_provider_order with (nolock)  ON EXISTS (SELECT 1 FROM STRING_SPLIT(obs.ordering_person_id, ',') nprv
                                                                                         WHERE cast(nprv.value as bigint) = d_provider_order.provider_uid)
         ;
@@ -536,6 +561,7 @@ BEGIN
                ,@rowcount
                ,LEFT(ISNULL(@observation_id_list, 'NULL'),500)
                );
+
 
         /* Start transaction for the actual update to the datamart */
         SET @proc_step_name = 'Update COVID_LAB_DATAMART';
@@ -708,73 +734,73 @@ BEGIN
             core.Lab_Rpt_Received_By_PH_Dt,
             core.Order_result_status,
             core.Jurisdiction_Nm,
-            core.Specimen_Cd,
-            core.Specimen_Desc,
-            core.Specimen_type_free_text,
-            core.Specimen_Id,
-            core.SPECIMEN_SOURCE_SITE_CD,
-            core.SPECIMEN_SOURCE_SITE_DESC,
-            core.Testing_Lab_Accession_Number,
+            LEFT(core.Specimen_Cd,50),
+            LEFT(core.Specimen_Desc,100),
+            LEFT(core.Specimen_type_free_text,1000),
+            LEFT(core.Specimen_Id,100),
+            LEFT(core.SPECIMEN_SOURCE_SITE_CD,20),
+            LEFT(core.SPECIMEN_SOURCE_SITE_DESC,100),
+            LEFT(core.Testing_Lab_Accession_Number,199),
             core.Lab_Added_Dt,
             core.Lab_Update_Dt,
             core.Specimen_Coll_Dt,
             core.COVID_LAB_DATAMART_KEY,
-            core.Resulted_Test_Cd,
-            core.Resulted_Test_Desc,
-            core.Resulted_Test_Code_System,
-            core.DEVICE_INSTANCE_ID_1,
-            core.DEVICE_INSTANCE_ID_2,
-            core.Test_result_status,
-            core.Test_Method_Desc,
-            core.Device_Type_Id_1,
-            core.Device_Type_Id_2,
-            core.Perform_Facility_Name,
-            core.Testing_lab_Address_One,
-            core.Testing_lab_Address_Two,
-            core.Testing_lab_Country,
-            core.Testing_lab_county,
-            core.Testing_lab_county_Desc,
-            core.Testing_lab_City,
-            core.Testing_lab_State_Cd,
-            core.Testing_lab_State,
-            core.Testing_lab_Zip_Cd,
-            core.Result_Cd,
-            core.Result_Cd_Sys,
-            core.Result_Desc,
+            LEFT(core.Resulted_Test_Cd,50),
+            LEFT(core.Resulted_Test_Desc,1000),
+            LEFT(core.Resulted_Test_Code_System,300),
+            LEFT(core.DEVICE_INSTANCE_ID_1,199),
+            LEFT(core.DEVICE_INSTANCE_ID_2,199),
+            LEFT(core.Test_result_status,100),
+            LEFT(core.Test_Method_Desc,2000),
+            LEFT(core.Device_Type_Id_1,199),
+            LEFT(core.Device_Type_Id_2,199),
+            LEFT(core.Perform_Facility_Name,100),
+            LEFT(core.Testing_lab_Address_One,100),
+            LEFT(core.Testing_lab_Address_Two,100),
+            LEFT(core.Testing_lab_Country,20),
+            LEFT(core.Testing_lab_county,20),
+            LEFT(core.Testing_lab_county_Desc,255),
+            LEFT(core.Testing_lab_City,100),
+            LEFT(core.Testing_lab_State_Cd,20),
+            LEFT(core.Testing_lab_State,2),
+            LEFT(core.Testing_lab_Zip_Cd,20),
+            LEFT(core.Result_Cd,20),
+            LEFT(core.Result_Cd_Sys,300),
+            LEFT(core.Result_Desc,300),
             core.Text_Result_Desc,
-            core.Numeric_Comparator_Cd,
+            LEFT(core.Numeric_Comparator_Cd,20),
             core.Numeric_Value_1,
             core.Numeric_Value_2,
-            core.Numeric_Unit_Cd,
-            core.Numeric_Low_Range,
-            core.Numeric_High_Range,
-            core.Numeric_Separator_Cd,
-            core.Interpretation_Cd,
-            core.Interpretation_Desc,
+            LEFT(core.Numeric_Unit_Cd,20),
+            LEFT(core.Numeric_Low_Range,20),
+            LEFT(core.Numeric_High_Range,20),
+            LEFT(core.Numeric_Separator_Cd,10),
+            LEFT(core.Interpretation_Cd,20),
+            LEFT(core.Interpretation_Desc,100),
             core.Result_Comments,
             core.Result,
-            rslt.Result_Category,
+            LEFT(rslt.Result_Category,13),
             pat.Last_Name,
             pat.Middle_Name,
             pat.First_Name,
             pat.Patient_Local_ID,
             pat.Current_Sex_Cd,
-            pat.Age_Reported,
-            pat.Age_Unit_Cd,
+            LEFT(pat.Age_Reported,10),
+            LEFT(pat.Age_Unit_Cd,20),
             pat.Birth_Dt,
             pat.PATIENT_DEATH_DATE,
-            pat.PATIENT_DEATH_IND,
-            pat.Phone_Number,
-            pat.Address_One,
-            pat.Address_Two,
-            pat.City,
-            pat.State_Cd,
-            pat.State,
-            pat.Zip_Code,
-            pat.County_Cd,
-            pat.County_Desc,
+            LEFT(pat.PATIENT_DEATH_IND,20),
+            LEFT(pat.Phone_Number,20),
+            LEFT( pat.Address_One,100),
+            LEFT(pat.Address_Two,100),
+            LEFT(pat.City,100),
+            LEFT(pat.State_Cd,20),
+            LEFT(pat.State,2),
+            LEFT(pat.Zip_Code,20),
+            LEFT(pat.County_Cd,20),
+            LEFT(pat.County_Desc,255),
             pat.PATIENT_RACE_CALC,
-            pat.PATIENT_ETHNICITY,
+            LEFT(pat.PATIENT_ETHNICITY,20),
             ent.Reporting_Facility_Name,
             ent.Reporting_Facility_Address_One,
             ent.Reporting_Facility_Address_Two,
@@ -795,8 +821,8 @@ BEGIN
             ent.Ordering_Facility_County,
             ent.Ordering_Facility_County_Desc,
             ent.Ordering_Facility_City,
-            ent.Ordering_Facility_State_Cd,
-            ent.Ordering_Facility_State,
+            LEFT(ent.Ordering_Facility_State_Cd,20),
+            LEFT(ent.Ordering_Facility_State,2),
             ent.Ordering_Facility_Zip_Cd,
             ent.Ordering_Facility_Phone_Nbr,
             ent.Ordering_Facility_Phone_Ext,
@@ -813,10 +839,11 @@ BEGIN
             ent.Ordering_Provider_Zip_Cd,
             ent.Ordering_Provider_Phone_Nbr,
             ent.Ordering_Provider_Phone_Ext,
-            ent.ORDERING_PROVIDER_ID,
+            LEFT(ent.ORDERING_PROVIDER_ID,199),
             assoc.Associated_Case_ID
         FROM #COVID_LAB_CORE_DATA core
                  LEFT JOIN #COVID_LAB_RSLT_TYPE rslt ON core.Observation_UID = rslt.RT_Observation_UID
+            AND core.Result = rslt.RT_Result
                  LEFT JOIN #COVID_LAB_PATIENT_DATA pat ON core.Observation_UID = pat.Pat_Observation_UID
                  LEFT JOIN #COVID_LAB_ENTITIES_DATA ent ON core.Observation_UID = ent.Entity_Observation_uid
                  LEFT JOIN #COVID_LAB_ASSOCIATIONS assoc ON core.Observation_UID = assoc.ASSOC_OBSERVATION_UID;
@@ -874,6 +901,8 @@ BEGIN
                );
 
     END TRY
+
+
     BEGIN CATCH
         IF @@TRANCOUNT > 0
             ROLLBACK TRANSACTION;


### PR DESCRIPTION
## Notes

Bug fix for errors in covid lab post-processing. Additional loinc_cd to filter out non-covid results for multiple result orders
Update to constraint on string length during insert, patient demographic, observation material and stopgap for patient current_sex_cd.

## JIRA

- **CNDE-2751**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2751)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?