### PR TITLE
CNDE-2865 RTR: Create Insert scripts for initial hydration of Set 2 of nrt key tables

### DIFF
--- a/db/upgrade/rdb_modern/data_load/014-nrt_vaccination_key.sql
+++ b/db/upgrade/rdb_modern/data_load/014-nrt_vaccination_key.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_vaccination_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_VACCINATION' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_vaccination_key ON
+
+        INSERT INTO [dbo].nrt_vaccination_key(
+            d_vaccination_key, vaccination_uid
+        )
+        SELECT 
+            dv.d_vaccination_key,
+            dv.vaccination_uid as vaccination_uid
+        FROM [dbo].D_VACCINATION dv WITH(NOLOCK) 
+        LEFT JOIN [dbo].nrt_vaccination_key k WITH(NOLOCK)
+            ON k.d_vaccination_key = dv.d_vaccination_key 
+            and k.vaccination_uid= dv.vaccination_uid
+        WHERE 
+            k.d_vaccination_key IS NULL 
+            AND k.vaccination_uid IS NULL and dv.d_vaccination_key<>1
+        order by dv.d_vaccination_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_vaccination_key OFF
+
+    END

--- a/db/upgrade/rdb_modern/data_load/015-nrt_case_management_key.sql
+++ b/db/upgrade/rdb_modern/data_load/015-nrt_case_management_key.sql
@@ -1,0 +1,25 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_case_management_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_CASE_MANAGEMENT' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'INVESTIGATION' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_case_management_key ON
+
+        INSERT INTO [dbo].nrt_case_management_key(
+            d_case_management_key, public_health_case_uid
+        )
+        select 
+        dc.d_case_management_key,
+        i.case_uid as public_health_case_uid
+        from dbo.D_CASE_MANAGEMENT dc with (nolock) 
+        inner join (select distinct CASE_UID, INVESTIGATION_KEY from dbo.INVESTIGATION with (nolock)) i 
+            on dc.INVESTIGATION_KEY = i.INVESTIGATION_KEY
+        left join dbo.nrt_case_management_key k with (nolock) 
+            on k.d_case_management_key = dc.d_case_management_key
+            and k.public_health_case_uid = i.CASE_UID
+        where k.d_case_management_key is null and k.public_health_case_uid is null
+        order by dc.d_case_management_key
+
+        SET IDENTITY_INSERT [dbo].nrt_case_management_key OFF
+
+    END

--- a/db/upgrade/rdb_modern/data_load/016-nrt_contact_key.sql
+++ b/db/upgrade/rdb_modern/data_load/016-nrt_contact_key.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_contact_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_CONTACT_RECORD' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_contact_key ON
+
+        INSERT INTO [dbo].nrt_contact_key(
+            d_contact_record_key, contact_uid
+        )
+        select dcr.d_contact_record_key,
+        cc.ct_contact_uid as contact_uid
+        from dbo.d_contact_record dcr with (nolock)
+        inner join (select distinct ct_contact_uid, local_id, version_ctrl_nbr from nbs_odse.dbo.CT_CONTACT with (nolock)) cc 
+            on dcr.LOCAL_ID = cc.local_id
+            and dcr.version_ctrl_nbr = cc.version_ctrl_nbr
+        left join dbo.nrt_contact_key k with (nolock)
+            on k.d_contact_record_key = dcr.d_contact_record_key
+            and k.contact_uid = cc.ct_contact_uid
+        where k.d_contact_record_key is null and 
+        k.contact_uid is null order by dcr.d_contact_record_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_contact_key OFF
+
+    END

--- a/db/upgrade/rdb_modern/data_load/017-nrt_d_tb_pam_key.sql
+++ b/db/upgrade/rdb_modern/data_load/017-nrt_d_tb_pam_key.sql
@@ -1,0 +1,21 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_d_tb_pam_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_TB_PAM' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_d_tb_pam_key ON
+
+        INSERT INTO [dbo].nrt_d_tb_pam_key(
+            d_tb_pam_key, tb_pam_uid
+        )
+        select d.d_tb_pam_key,
+            d.tb_pam_uid
+        from dbo.d_tb_pam d with (nolock)
+        left join dbo.nrt_d_tb_pam_key k
+            on k.D_TB_PAM_KEY = d.D_TB_PAM_KEY AND
+            k.TB_PAM_UID = d.TB_PAM_UID
+        where k.D_TB_PAM_KEY is null and k.TB_PAM_UID is null
+        order by d.d_tb_pam_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_d_tb_pam_key OFF
+
+    END

--- a/db/upgrade/rdb_modern/data_load/018-nrt_var_pam_key.sql
+++ b/db/upgrade/rdb_modern/data_load/018-nrt_var_pam_key.sql
@@ -1,0 +1,21 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_var_pam_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_VAR_PAM' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_var_pam_key ON
+
+        INSERT INTO [dbo].nrt_var_pam_key(
+            d_var_pam_key, var_pam_uid
+        )
+        select d.d_var_pam_key,
+            d.var_pam_uid
+        from dbo.d_var_pam d with (nolock)
+        left join dbo.nrt_var_pam_key k
+            on k.D_VAR_PAM_KEY = d.D_VAR_PAM_KEY AND
+            k.VAR_PAM_UID = d.VAR_PAM_UID
+        where k.D_VAR_PAM_KEY is null and k.VAR_PAM_UID is null
+        order by d.d_var_pam_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_var_pam_key OFF
+
+    END

--- a/db/upgrade/rdb_modern/routines/021-sp_nrt_case_management_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/021-sp_nrt_case_management_postprocessing.sql
@@ -39,7 +39,7 @@ BEGIN
                ,0);
 
         SET @proc_step_name = 'Create CASE_MANAGEMENT Temp table -' + LEFT(@id_list, 160);
-        SET @proc_step_no = 1;
+        SET @proc_step_no = @proc_step_no + 1;
 
         SELECT
                nrt.public_health_case_uid,
@@ -141,7 +141,7 @@ BEGIN
         /* Investigation Update Operation */
         BEGIN TRANSACTION;
         SET @proc_step_name = 'Update D_CASE_MANAGEMENT';
-        SET @proc_step_no = 2;
+        SET @proc_step_no = @proc_step_no + 1;
 
         UPDATE dbo.D_CASE_MANAGEMENT
         SET
@@ -237,8 +237,45 @@ BEGIN
                ,LEFT(@id_list, 500));
 
         /* Investigation Insert Operation */
+        SET @proc_step_name = 'Update nrt_case_management_key table updated_dttm';
+        SET @proc_step_no = @proc_step_no + 1;
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].nrt_case_management_key tgt 
+        INNER JOIN dbo.d_case_management g with (nolock) 
+            ON g.d_case_management_key = tgt.d_case_management_key
+        INNER JOIN #temp_cm_table tmp
+            on tmp.public_health_case_uid = tgt.public_health_case_uid;
+
+        if @debug = 'true' select * from dbo.nrt_case_management_key;
+
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list, 500)
+               );
+        
+        /* Investigation Insert Operation */
         SET @proc_step_name = 'Insert into D_CASE_MANAGEMENT';
-        SET @proc_step_no = 3;
+        SET @proc_step_no = @proc_step_no + 1;
 
         INSERT INTO dbo.nrt_case_management_key(public_health_case_uid)
         SELECT public_health_case_uid

--- a/db/upgrade/rdb_modern/routines/021-sp_nrt_case_management_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/021-sp_nrt_case_management_postprocessing.sql
@@ -236,7 +236,6 @@ BEGIN
                ,@rowcount
                ,LEFT(@id_list, 500));
 
-        /* Investigation Insert Operation */
         SET @proc_step_name = 'Update nrt_case_management_key table updated_dttm';
         SET @proc_step_no = @proc_step_no + 1;
 

--- a/db/upgrade/rdb_modern/routines/035-sp_d_contact_record_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/035-sp_d_contact_record_postprocessing.sql
@@ -205,8 +205,29 @@ BEGIN
         VALUES (@BATCH_ID,@Dataflow_Name,@Package_Name, 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO);
 
         COMMIT TRANSACTION;
+   
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET @PROC_STEP_NAME = 'Update nrt_contact_key updated_dttm';
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].NRT_CONTACT_KEY tgt 
+        inner join dbo.d_contact_record d with (nolock)
+            on d.d_contact_record_key = tgt.d_contact_record_key
+        INNER JOIN #CONTACT_INIT ci 
+            ON ci.contact_uid = tgt.contact_uid;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id,@Dataflow_Name,@Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
 
 
+        COMMIT TRANSACTION;
+   
         BEGIN TRANSACTION;
 
         SET @PROC_STEP_NO = @PROC_STEP_NO + 1;

--- a/db/upgrade/rdb_modern/routines/042-sp_d_vaccination_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/042-sp_d_vaccination_postprocessing.sql
@@ -170,6 +170,27 @@ BEGIN
 
         COMMIT TRANSACTION;
 
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET @PROC_STEP_NAME = 'Update nrt_vaccination_key updated_dttm';
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].NRT_VACCINATION_KEY tgt 
+        INNER JOIN DBO.D_VACCINATION d WITH (NOLOCK)
+            on d.d_vaccination_key = tgt.d_vaccination_key
+            and d.vaccination_uid = tgt.vaccination_uid
+        INNER JOIN #D_VACCINATION_INIT g 
+            ON g.D_VACCINATION_KEY = tgt.D_VACCINATION_KEY
+            AND g.VACCINATION_UID = tgt.VACCINATION_UID;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id,@Dataflow_Name,@Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+        COMMIT TRANSACTION;
 
         BEGIN TRANSACTION;
 

--- a/db/upgrade/rdb_modern/routines/147-sp_nrt_d_tb_pam_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/147-sp_nrt_d_tb_pam_postprocessing.sql
@@ -194,7 +194,7 @@ BEGIN TRY
 			CODE_SET_GROUP_ID, 
 			DATAMART_COLUMN_NM, 
 			CASE 
-				WHEN COALESCE(CODE_SET_GROUP_ID, '') = ''  
+				WHEN COALESCE(CODE_SET_GROUP_ID, '') = '' 
 					AND CODE_SET_NM NOT IN ('STATE_CCD', 'COUNTY_CCD', 'PSL_CNTRY', 'S_JURDIC_C', 'S_PROGRA_C') 
 				THEN ANSWER_TXT
 				WHEN CODE_SET_NM NOT IN ('STATE_CCD', 'COUNTY_CCD', 'PSL_CNTRY', 'S_JURDIC_C', 'S_PROGRA_C')
@@ -881,6 +881,30 @@ BEGIN TRY
 
 	COMMIT transaction;
 
+	BEGIN TRANSACTION
+
+	SET
+		@PROC_STEP_NO = @PROC_STEP_NO + 1;
+	SET
+		@PROC_STEP_NAME = 'Update nrt_d_tb_pam_key updated_dttm';
+
+	UPDATE tgt 
+	SET tgt.[updated_dttm] = GETDATE()
+	FROM [dbo].nrt_d_tb_pam_key tgt 
+	INNER JOIN dbo.d_tb_pam d WITH (NOLOCK)
+		on tgt.D_TB_PAM_KEY = tgt.D_TB_PAM_KEY AND
+		tgt.TB_PAM_UID = tgt.TB_PAM_UID
+	INNER JOIN #S_TB_PAM_SET S
+		ON S.TB_PAM_UID = D.TB_PAM_UID
+
+	SELECT @RowCount_no = @@ROWCOUNT;
+
+	INSERT INTO [dbo].[job_flow_log]
+	(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+	VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+	COMMIT TRANSACTION;
+	
 	BEGIN TRANSACTION
 
 		SET

--- a/db/upgrade/rdb_modern/routines/215-sp_nrt_d_var_pam_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/215-sp_nrt_d_var_pam_postprocessing.sql
@@ -465,8 +465,32 @@ BEGIN
         (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @dataflow_name, @package_name, 'START', @Proc_Step_no, @Proc_Step_Name,
                 @RowCount_no);
-            
 
+--------------------------------------------------------------------------------------------------------
+    BEGIN TRANSACTION
+        SET
+            @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET
+            @PROC_STEP_NAME = 'Update nrt_var_pam_key updated_dttm';
+          
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].nrt_var_pam_key tgt 
+        INNER JOIN dbo.d_var_pam d WITH (NOLOCK)
+            on tgt.D_VAR_PAM_KEY = tgt.D_VAR_PAM_KEY AND
+            tgt.VAR_PAM_UID = tgt.VAR_PAM_UID
+        INNER JOIN #S_VAR_PAM_SET_TRANSLATED S
+            ON S.VAR_PAM_UID = D.VAR_PAM_UID
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @dataflow_name, @package_name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+        
+        COMMIT TRANSACTION;
+    
 --------------------------------------------------------------------------------------------------------
     BEGIN TRANSACTION
         SET

--- a/liquibase-service/src/main/resources/db/rdb_modern/data_load/014-nrt_vaccination_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/data_load/014-nrt_vaccination_key-001.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_vaccination_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_VACCINATION' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_vaccination_key ON
+
+        INSERT INTO [dbo].nrt_vaccination_key(
+            d_vaccination_key, vaccination_uid
+        )
+        SELECT 
+            dv.d_vaccination_key,
+            dv.vaccination_uid as vaccination_uid
+        FROM [dbo].D_VACCINATION dv WITH(NOLOCK) 
+        LEFT JOIN [dbo].nrt_vaccination_key k WITH(NOLOCK)
+            ON k.d_vaccination_key = dv.d_vaccination_key 
+            and k.vaccination_uid= dv.vaccination_uid
+        WHERE 
+            k.d_vaccination_key IS NULL 
+            AND k.vaccination_uid IS NULL and dv.d_vaccination_key<>1
+        order by dv.d_vaccination_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_vaccination_key OFF
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/data_load/015-nrt_case_management_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/data_load/015-nrt_case_management_key-001.sql
@@ -1,0 +1,25 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_case_management_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_CASE_MANAGEMENT' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'INVESTIGATION' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_case_management_key ON
+
+        INSERT INTO [dbo].nrt_case_management_key(
+            d_case_management_key, public_health_case_uid
+        )
+        select 
+        dc.d_case_management_key,
+        i.case_uid as public_health_case_uid
+        from dbo.D_CASE_MANAGEMENT dc with (nolock) 
+        inner join (select distinct CASE_UID, INVESTIGATION_KEY from dbo.INVESTIGATION with (nolock)) i 
+            on dc.INVESTIGATION_KEY = i.INVESTIGATION_KEY
+        left join dbo.nrt_case_management_key k with (nolock) 
+            on k.d_case_management_key = dc.d_case_management_key
+            and k.public_health_case_uid = i.CASE_UID
+        where k.d_case_management_key is null and k.public_health_case_uid is null
+        order by dc.d_case_management_key
+
+        SET IDENTITY_INSERT [dbo].nrt_case_management_key OFF
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/data_load/016-nrt_contact_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/data_load/016-nrt_contact_key-001.sql
@@ -1,0 +1,24 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_contact_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_CONTACT_RECORD' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_contact_key ON
+
+        INSERT INTO [dbo].nrt_contact_key(
+            d_contact_record_key, contact_uid
+        )
+        select dcr.d_contact_record_key,
+        cc.ct_contact_uid as contact_uid
+        from dbo.d_contact_record dcr with (nolock)
+        inner join (select distinct ct_contact_uid, local_id, version_ctrl_nbr from nbs_odse.dbo.CT_CONTACT with (nolock)) cc 
+            on dcr.LOCAL_ID = cc.local_id
+            and dcr.version_ctrl_nbr = cc.version_ctrl_nbr
+        left join dbo.nrt_contact_key k with (nolock)
+            on k.d_contact_record_key = dcr.d_contact_record_key
+            and k.contact_uid = cc.ct_contact_uid
+        where k.d_contact_record_key is null and 
+        k.contact_uid is null order by dcr.d_contact_record_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_contact_key OFF
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/data_load/017-nrt_d_tb_pam_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/data_load/017-nrt_d_tb_pam_key-001.sql
@@ -1,0 +1,21 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_d_tb_pam_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_TB_PAM' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_d_tb_pam_key ON
+
+        INSERT INTO [dbo].nrt_d_tb_pam_key(
+            d_tb_pam_key, tb_pam_uid
+        )
+        select d.d_tb_pam_key,
+            d.tb_pam_uid
+        from dbo.d_tb_pam d with (nolock)
+        left join dbo.nrt_d_tb_pam_key k
+            on k.D_TB_PAM_KEY = d.D_TB_PAM_KEY AND
+            k.TB_PAM_UID = d.TB_PAM_UID
+        where k.D_TB_PAM_KEY is null and k.TB_PAM_UID is null
+        order by d.d_tb_pam_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_d_tb_pam_key OFF
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/data_load/018-nrt_var_pam_key-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/data_load/018-nrt_var_pam_key-001.sql
@@ -1,0 +1,21 @@
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_var_pam_key' and xtype = 'U')
+    AND EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_VAR_PAM' and xtype = 'U')
+    BEGIN
+
+        SET IDENTITY_INSERT [dbo].nrt_var_pam_key ON
+
+        INSERT INTO [dbo].nrt_var_pam_key(
+            d_var_pam_key, var_pam_uid
+        )
+        select d.d_var_pam_key,
+            d.var_pam_uid
+        from dbo.d_var_pam d with (nolock)
+        left join dbo.nrt_var_pam_key k
+            on k.D_VAR_PAM_KEY = d.D_VAR_PAM_KEY AND
+            k.VAR_PAM_UID = d.VAR_PAM_UID
+        where k.D_VAR_PAM_KEY is null and k.VAR_PAM_UID is null
+        order by d.d_var_pam_key;
+
+        SET IDENTITY_INSERT [dbo].nrt_var_pam_key OFF
+
+    END

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
@@ -39,7 +39,7 @@ BEGIN
                ,0);
 
         SET @proc_step_name = 'Create CASE_MANAGEMENT Temp table -' + LEFT(@id_list, 160);
-        SET @proc_step_no = 1;
+        SET @proc_step_no = @proc_step_no + 1;
 
         SELECT
                nrt.public_health_case_uid,
@@ -141,7 +141,7 @@ BEGIN
         /* Investigation Update Operation */
         BEGIN TRANSACTION;
         SET @proc_step_name = 'Update D_CASE_MANAGEMENT';
-        SET @proc_step_no = 2;
+        SET @proc_step_no = @proc_step_no + 1;
 
         UPDATE dbo.D_CASE_MANAGEMENT
         SET
@@ -237,8 +237,45 @@ BEGIN
                ,LEFT(@id_list, 500));
 
         /* Investigation Insert Operation */
+        SET @proc_step_name = 'Update nrt_case_management_key table updated_dttm';
+        SET @proc_step_no = @proc_step_no + 1;
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].nrt_case_management_key tgt 
+        INNER JOIN dbo.d_case_management g with (nolock) 
+            ON g.d_case_management_key = tgt.d_case_management_key
+        INNER JOIN #temp_cm_table tmp
+            on tmp.public_health_case_uid = tgt.public_health_case_uid;
+
+        if @debug = 'true' select * from dbo.nrt_case_management_key;
+
+        set @rowcount=@@rowcount
+        INSERT INTO [dbo].[job_flow_log]
+        (
+          batch_id
+        ,[Dataflow_Name]
+        ,[package_Name]
+        ,[Status_Type]
+        ,[step_number]
+        ,[step_name]
+        ,[row_count]
+        ,[msg_description1]
+        )
+        VALUES (
+                 @batch_id
+               ,@dataflow_name
+               ,@package_name
+               ,'START'
+               ,@proc_step_no
+               ,@proc_step_name
+               ,@rowcount
+               ,LEFT(@id_list, 500)
+               );
+        
+        /* Investigation Insert Operation */
         SET @proc_step_name = 'Insert into D_CASE_MANAGEMENT';
-        SET @proc_step_no = 3;
+        SET @proc_step_no = @proc_step_no + 1;
 
         INSERT INTO dbo.nrt_case_management_key(public_health_case_uid)
         SELECT public_health_case_uid

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/022-sp_nrt_case_management_postprocessing-001.sql
@@ -236,7 +236,6 @@ BEGIN
                ,@rowcount
                ,LEFT(@id_list, 500));
 
-        /* Investigation Insert Operation */
         SET @proc_step_name = 'Update nrt_case_management_key table updated_dttm';
         SET @proc_step_no = @proc_step_no + 1;
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/036-sp_d_contact_record_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/036-sp_d_contact_record_postprocessing-001.sql
@@ -205,8 +205,29 @@ BEGIN
         VALUES (@BATCH_ID,@Dataflow_Name,@Package_Name, 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO);
 
         COMMIT TRANSACTION;
+   
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET @PROC_STEP_NAME = 'Update nrt_contact_key updated_dttm';
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].NRT_CONTACT_KEY tgt 
+        inner join dbo.d_contact_record d with (nolock)
+            on d.d_contact_record_key = tgt.d_contact_record_key
+        INNER JOIN #CONTACT_INIT ci 
+            ON ci.contact_uid = tgt.contact_uid;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id,@Dataflow_Name,@Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
 
 
+        COMMIT TRANSACTION;
+   
         BEGIN TRANSACTION;
 
         SET @PROC_STEP_NO = @PROC_STEP_NO + 1;

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/044-sp_d_vaccination_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/044-sp_d_vaccination_postprocessing-001.sql
@@ -170,6 +170,27 @@ BEGIN
 
         COMMIT TRANSACTION;
 
+        BEGIN TRANSACTION;
+
+        SET @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET @PROC_STEP_NAME = 'Update nrt_vaccination_key updated_dttm';
+
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].NRT_VACCINATION_KEY tgt 
+        INNER JOIN DBO.D_VACCINATION d WITH (NOLOCK)
+            on d.d_vaccination_key = tgt.d_vaccination_key
+            and d.vaccination_uid = tgt.vaccination_uid
+        INNER JOIN #D_VACCINATION_INIT g 
+            ON g.D_VACCINATION_KEY = tgt.D_VACCINATION_KEY
+            AND g.VACCINATION_UID = tgt.VACCINATION_UID;
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id,@Dataflow_Name,@Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+        COMMIT TRANSACTION;
 
         BEGIN TRANSACTION;
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/147-sp_nrt_d_tb_pam_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/147-sp_nrt_d_tb_pam_postprocessing-001.sql
@@ -883,6 +883,30 @@ BEGIN TRY
 
 	BEGIN TRANSACTION
 
+	SET
+		@PROC_STEP_NO = @PROC_STEP_NO + 1;
+	SET
+		@PROC_STEP_NAME = 'Update nrt_d_tb_pam_key updated_dttm';
+
+	UPDATE tgt 
+	SET tgt.[updated_dttm] = GETDATE()
+	FROM [dbo].nrt_d_tb_pam_key tgt 
+	INNER JOIN dbo.d_tb_pam d WITH (NOLOCK)
+		on tgt.D_TB_PAM_KEY = tgt.D_TB_PAM_KEY AND
+		tgt.TB_PAM_UID = tgt.TB_PAM_UID
+	INNER JOIN #S_TB_PAM_SET S
+		ON S.TB_PAM_UID = D.TB_PAM_UID
+
+	SELECT @RowCount_no = @@ROWCOUNT;
+
+	INSERT INTO [dbo].[job_flow_log]
+	(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+	VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+
+	COMMIT TRANSACTION;
+	
+	BEGIN TRANSACTION
+
 		SET
             @PROC_STEP_NO = @PROC_STEP_NO + 1;
         SET

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/215-sp_nrt_d_var_pam_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/215-sp_nrt_d_var_pam_postprocessing-001.sql
@@ -465,8 +465,32 @@ BEGIN
         (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @dataflow_name, @package_name, 'START', @Proc_Step_no, @Proc_Step_Name,
                 @RowCount_no);
-            
 
+--------------------------------------------------------------------------------------------------------
+    BEGIN TRANSACTION
+        SET
+            @PROC_STEP_NO = @PROC_STEP_NO + 1;
+        SET
+            @PROC_STEP_NAME = 'Update nrt_var_pam_key updated_dttm';
+          
+        UPDATE tgt 
+        SET tgt.[updated_dttm] = GETDATE()
+        FROM [dbo].nrt_var_pam_key tgt 
+        INNER JOIN dbo.d_var_pam d WITH (NOLOCK)
+            on tgt.D_VAR_PAM_KEY = tgt.D_VAR_PAM_KEY AND
+            tgt.VAR_PAM_UID = tgt.VAR_PAM_UID
+        INNER JOIN #S_VAR_PAM_SET_TRANSLATED S
+            ON S.VAR_PAM_UID = D.VAR_PAM_UID
+
+        SELECT @RowCount_no = @@ROWCOUNT;
+
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @dataflow_name, @package_name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+        
+        COMMIT TRANSACTION;
+    
 --------------------------------------------------------------------------------------------------------
     BEGIN TRANSACTION
         SET


### PR DESCRIPTION
## Notes

This ticket focuses on creating NRT_KEY table script to load keys from dim tables and update the timestamps in the respective postprocessing for the following tables

- nrt_vaccination_key
- nrt_case_management_key
- nrt_contact_key
- nrt_d_tb_pam_key
- nrt_var_pam_key 

## JIRA

- **Related story**: [CNDE-2865](https://cdc-nbs.atlassian.net/browse/CNDE-2865)

## Checklist

- [X] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [X] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [X] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?