### PR TITLE
CNDE-2380: Fix for Kafka sink error on snomed_condition

### DIFF
--- a/db/upgrade/rdb_modern/tables/211-create_nrt_srte_Snomed_condition.sql
+++ b/db/upgrade/rdb_modern/tables/211-create_nrt_srte_Snomed_condition.sql
@@ -12,6 +12,7 @@ IF NOT EXISTS (SELECT 1
             status_cd           char(1)      NULL,
             status_time         datetime     NULL,
             effective_from_time datetime     NULL,
-            effective_to_time   datetime     NULL
-        ) ON [PRIMARY]
+            effective_to_time   datetime     NULL,
+            PRIMARY KEY (snomed_cd)
+        ) 
     END;

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/211-create_nrt_srte_Snomed_condition-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/211-create_nrt_srte_Snomed_condition-001.sql
@@ -1,7 +1,4 @@
-IF NOT EXISTS (SELECT 1
-               FROM sysobjects
-               WHERE name = 'nrt_srte_Snomed_condition'
-                 and xtype = 'U')
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_srte_Snomed_condition' and xtype = 'U')
     BEGIN
         CREATE TABLE dbo.nrt_srte_Snomed_condition
         (
@@ -14,4 +11,10 @@ IF NOT EXISTS (SELECT 1
             effective_from_time datetime     NULL,
             effective_to_time   datetime     NULL
         ) ON [PRIMARY]
+    END;
+
+IF NOT EXISTS(SELECT 1 FROM sys.objects WHERE type = 'PK' AND object_id = OBJECT_ID('nrt_srte_Snomed_condition'))
+    BEGIN
+        ALTER TABLE dbo.nrt_srte_Snomed_condition
+        ADD CONSTRAINT pk_nrt_srte_Snomed_condition PRIMARY KEY (snomed_cd);
     END;


### PR DESCRIPTION
## Notes

- Handle table (snomed_condition) with no primary key in source table. 
- Update target sink table to contain primary key. 

Sample debezium config :

```

table.include.list= dbo.Snomed_condition
tasks.max=1
#topic.creation.default.replication.factor= 2,
#topic.creation.default.partitions= 10,
#topic.creation.default.cleanup.policy=compact
time.precision.mode= connect
transforms= dropPrefix, dropPrefixConfig, unwrapConfig, valueToKey, convertTimezone, unwrap, convertTimestamps_add_time, convertTimestamps_concept_status_time, convertTimestamps_effective_from_time, convertTimestamps_effective_to_time, convertTimestamps_status_time, convertTimestamps_status_to_time, convertTimestamps_value_set_status_time, convertTimestampsConfig_effective_from_time, convertTimestampsConfig_effective_to_time, convertTimestampsConfig_status_time
#Handle Table without keys with a predicate definition
predicates = isConfigTable
transforms.dropPrefix.regex=cdc\\.NBS_SRTE\\.dbo\\.(.+)
transforms.dropPrefix.type=org.apache.kafka.connect.transforms.RegexRouter
transforms.dropPrefix.replacement=nrt_srte_$1
transforms.dropPrefixConfig.regex = cdc\\.NBS_SRTE\\.dbo\\.Snomed_condition
transforms.dropPrefixConfig.type=org.apache.kafka.connect.transforms.RegexRouter
transforms.dropPrefixConfig.replacement=nrt_srte_Snomed_condition

transforms.unwrapConfig.type=io.debezium.transforms.ExtractNewRecordState
transforms.unwrapConfig.predicate=isConfigTable

transforms.valueToKey.type = org.apache.kafka.connect.transforms.ValueToKey
transforms.valueToKey.fields = snomed_cd
transforms.valueToKey.predicate = isConfigTable

transforms.convertTimezone.type=io.debezium.transforms.TimezoneConverter
transforms.convertTimezone.converted.timezone=UTC
transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
transforms.convertTimestamps_add_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_add_time.target.type=string
transforms.convertTimestamps_add_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_add_time.field=add_time
transforms.convertTimestamps_concept_status_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_concept_status_time.target.type=string
transforms.convertTimestamps_concept_status_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_concept_status_time.field=concept_status_time
transforms.convertTimestamps_effective_from_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_effective_from_time.target.type=string
transforms.convertTimestamps_effective_from_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_effective_from_time.field=effective_from_time
transforms.convertTimestamps_effective_to_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_effective_to_time.target.type=string
transforms.convertTimestamps_effective_to_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_effective_to_time.field=effective_to_time
transforms.convertTimestamps_status_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_status_time.target.type=string
transforms.convertTimestamps_status_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_status_time.field=status_time
transforms.convertTimestamps_status_to_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_status_to_time.target.type=string
transforms.convertTimestamps_status_to_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_status_to_time.field=status_to_time
transforms.convertTimestamps_value_set_status_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestamps_value_set_status_time.target.type=string
transforms.convertTimestamps_value_set_status_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestamps_value_set_status_time.field=value_set_status_time

#Predicate transforms
transforms.convertTimestampsConfig_effective_from_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestampsConfig_effective_from_time.target.type=string
transforms.convertTimestampsConfig_effective_from_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestampsConfig_effective_from_time.field=effective_from_time
transforms.convertTimestampsConfig_effective_from_time.predicate=isConfigTable
transforms.convertTimestampsConfig_effective_to_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestampsConfig_effective_to_time.target.type=string
transforms.convertTimestampsConfig_effective_to_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestampsConfig_effective_to_time.field=effective_to_time
transforms.convertTimestampsConfig_effective_to_time.predicate=isConfigTable
transforms.convertTimestampsConfig_status_time.type=org.apache.kafka.connect.transforms.TimestampConverter$Value
transforms.convertTimestampsConfig_status_time.target.type=string
transforms.convertTimestampsConfig_status_time.format=yyyy-MM-dd HH:mm:ss.SSS
transforms.convertTimestampsConfig_status_time.field=status_time
transforms.convertTimestampsConfig_status_time.predicate=isConfigTable

predicates.isConfigTable.type=org.apache.kafka.connect.transforms.predicates.TopicNameMatches
predicates.isConfigTable.pattern=nrt_srte_Snomed_condition

value.converter=org.apache.kafka.connect.json.JsonConverter
value.converter.schemas.enable=true
```


## JIRA

- **CNDE-2380**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2380)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [x] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?