### PR TITLE
CNDE-2922: Fixing the CVE vulnerabilty CVE-2025-48988,CVE-2025-49125 which recommends tomcat to upgrade to version 11.0.8  10.1.42 or 9.0.106

### DIFF
--- a/common-util/build.gradle
+++ b/common-util/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/investigation-service/build.gradle
+++ b/investigation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/ldfdata-service/build.gradle
+++ b/ldfdata-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
+	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'jacoco'
 	id 'org.sonarqube' version '4.2.1.3168'

--- a/liquibase-service/build.gradle
+++ b/liquibase-service/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.liquibase.gradle' version '2.2.2'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/observation-service/build.gradle
+++ b/observation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/organization-service/build.gradle
+++ b/organization-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/person-service/build.gradle
+++ b/person-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/post-processing-service/build.gradle
+++ b/post-processing-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'

--- a/status-service/build.gradle
+++ b/status-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 


### PR DESCRIPTION
CNDE-2922: Fixing the CVE vulnerabilty CVE-2025-48988,CVE-2025-49125 which recommends tomcat to upgrade to version 11.0.8  10.1.42 or 9.0.106
Upgrading the springboot to 3.5.3 which has `10.1.42 ` https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.5.3/spring-boot-dependencies-3.5.3.pom