### PR TITLE
CNDE-2941: add nrt_odse_NBS_configuration table

### DIFF
--- a/db/upgrade/rdb_modern/tables/253-create_nrt_odse_NBS_configuration.sql
+++ b/db/upgrade/rdb_modern/tables/253-create_nrt_odse_NBS_configuration.sql
@@ -1,0 +1,28 @@
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_odse_NBS_configuration' and xtype = 'U')
+   BEGIN
+        CREATE TABLE [dbo].[nrt_odse_NBS_configuration](
+            [config_key] [varchar](200) NOT NULL,
+            [config_value] [varchar](2000) NULL,
+            [short_name] [varchar](80) NULL,
+            [desc_txt] [varchar](2000) NULL,
+            [default_value] [varchar](2000) NULL,
+            [valid_values] [varchar](2000) NULL,
+            [category] [varchar](50) NULL,
+            [add_release] [varchar](50) NULL,
+            [version_ctrl_nbr] [smallint] NOT NULL,
+            [add_user_id] [bigint] NOT NULL,
+            [add_time] [datetime] NOT NULL,
+            [last_chg_user_id] [bigint] NOT NULL,
+            [last_chg_time] [datetime] NOT NULL,
+            [status_cd] [char](1) NOT NULL,
+            [status_time] [datetime] NOT NULL,
+            [admin_comment] [varchar](2000) NULL,
+            [system_usage] [varchar](2000) NULL,
+            [config_value_large] [varchar](max) NULL,
+        CONSTRAINT [PK_NBS_CONFIGURATION] PRIMARY KEY CLUSTERED 
+        (
+            [config_key] ASC
+        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+        ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+   END;

--- a/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
+++ b/liquibase-service/src/main/resources/db/changelog/db.rdb_modern.changelog-16.1.yaml
@@ -2799,3 +2799,11 @@ databaseChangeLog:
             path: 340-sp_nrt_srte_condition_code_postprocessing-001.sql
             splitStatements: true
             endDelimiter: GO
+  - changeSet:
+      id: 890
+      author: liquibase
+      runOnChange: true
+      changes:
+        - sqlFile:
+            path: 253-create_nrt_odse_NBS_configuration-001.sql
+            splitStatements: false

--- a/liquibase-service/src/main/resources/db/rdb_modern/tables/253-create_nrt_odse_NBS_configuration-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/tables/253-create_nrt_odse_NBS_configuration-001.sql
@@ -1,0 +1,28 @@
+IF NOT EXISTS (SELECT 1 FROM sysobjects WHERE name = 'nrt_odse_NBS_configuration' and xtype = 'U')
+   BEGIN
+        CREATE TABLE [dbo].[nrt_odse_NBS_configuration](
+            [config_key] [varchar](200) NOT NULL,
+            [config_value] [varchar](2000) NULL,
+            [short_name] [varchar](80) NULL,
+            [desc_txt] [varchar](2000) NULL,
+            [default_value] [varchar](2000) NULL,
+            [valid_values] [varchar](2000) NULL,
+            [category] [varchar](50) NULL,
+            [add_release] [varchar](50) NULL,
+            [version_ctrl_nbr] [smallint] NOT NULL,
+            [add_user_id] [bigint] NOT NULL,
+            [add_time] [datetime] NOT NULL,
+            [last_chg_user_id] [bigint] NOT NULL,
+            [last_chg_time] [datetime] NOT NULL,
+            [status_cd] [char](1) NOT NULL,
+            [status_time] [datetime] NOT NULL,
+            [admin_comment] [varchar](2000) NULL,
+            [system_usage] [varchar](2000) NULL,
+            [config_value_large] [varchar](max) NULL,
+        CONSTRAINT [PK_NBS_CONFIGURATION] PRIMARY KEY CLUSTERED 
+        (
+            [config_key] ASC
+        )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+        ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+   END;


### PR DESCRIPTION
## Notes

This PR adds a table in rdb_modern called `nrt_odse_NBS_configuration`, which will store data from `NBS_ODSE.dbo.NBS_configuration`.

## JIRA

- **Related story**: [CNDE-2941](https://cdc-nbs.atlassian.net/browse/CNDE-2941)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?