### PR TITLE
CNDE-2970 Stored procedure sp_d_lab_test_postprocessing is not saving the lab report comment to LAB_RPT_USER_COMMENT

### DIFF
--- a/db/upgrade/rdb_modern/routines/017-sp_d_lab_test_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/017-sp_d_lab_test_postprocessing.sql
@@ -850,6 +850,8 @@ BEGIN
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
 
         --------------------------------------------------------------------------------------------------------
+        --requires future enhancement to implement retry mechanism for ids that do not make it to target tables 
+        --due to logical errors in catch section.
 
         BEGIN TRANSACTION
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/018-sp_d_lab_test_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/018-sp_d_lab_test_postprocessing-001.sql
@@ -850,6 +850,8 @@ BEGIN
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
 
         --------------------------------------------------------------------------------------------------------
+        --requires future enhancement to implement retry mechanism for ids that do not make it to target tables 
+        --due to logical errors in catch section.
 
         BEGIN TRANSACTION
 


### PR DESCRIPTION
## Notes

Fixed error:

Stored procedure was not saving the Lab Report Comment to table LAB_RPT_USER_COMMENT due to some comments uid are not received by the stored procedure but they can be computed from the received obs_uids + followup_observation_uid  in received observations

Improvements:

All actions over persistent tables were moved to only one transaction

All fields rdb_last_refresh_time and updated_dttm will be saved with the same datetime value 


Summary: 
Now, the Lab Report Comment is saved to table LAB_RPT_USER_COMMENT

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2970)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?