### PR TITLE
[CNDE-2988] RTR - Fixing the process to compute the datamart_column_nm for LDF. There is difference in naming convention between RDB and RDB_MODERN for LDF fields

### DIFF
--- a/db/upgrade/rdb_modern/routines/265-sp_nrt_ldf_dimensional_data_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/265-sp_nrt_ldf_dimensional_data_postprocessing.sql
@@ -320,12 +320,12 @@ BEGIN
 			) AS ldf_datamart_column_ref_uid,
 			SUBSTRING(
 				CASE 
-					WHEN a.class_cd = 'State' THEN 'L_' + RTRIM(REPLACE(a.ldf_uid, ' ', '')) + '_'
-					WHEN a.class_cd = 'CDC' THEN 'C_' + RTRIM(REPLACE(a.ldf_uid, ' ', '')) + '_'
+					WHEN a.class_cd = 'State' THEN 'L_' + RTRIM(REPLACE(a.ldf_uid, ' ', ''))
+					WHEN a.class_cd = 'CDC' THEN 'C_' + RTRIM(REPLACE(a.ldf_uid, ' ', ''))
 					WHEN LEN(RTRIM(a.cdc_national_id)) > 1 
 						AND LEN(RTRIM(a.cdc_national_id)) + LEN(RTRIM(a.label_txt)) > 0 
 						AND LEN(RTRIM(CAST(a.custom_subform_metadata_uid AS VARCHAR(MAX)))) > 1 
-						THEN 'C_' + RTRIM(a.cdc_national_id) + '_'
+						THEN 'C_' + RTRIM(a.cdc_national_id)
 					ELSE ''
 				END +
 				REPLACE(

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/265-sp_nrt_ldf_dimensional_data_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/265-sp_nrt_ldf_dimensional_data_postprocessing-001.sql
@@ -320,12 +320,12 @@ BEGIN
 			) AS ldf_datamart_column_ref_uid,
 			SUBSTRING(
 				CASE 
-					WHEN a.class_cd = 'State' THEN 'L_' + RTRIM(REPLACE(a.ldf_uid, ' ', '')) + '_'
-					WHEN a.class_cd = 'CDC' THEN 'C_' + RTRIM(REPLACE(a.ldf_uid, ' ', '')) + '_'
+					WHEN a.class_cd = 'State' THEN 'L_' + RTRIM(REPLACE(a.ldf_uid, ' ', ''))
+					WHEN a.class_cd = 'CDC' THEN 'C_' + RTRIM(REPLACE(a.ldf_uid, ' ', ''))
 					WHEN LEN(RTRIM(a.cdc_national_id)) > 1 
 						AND LEN(RTRIM(a.cdc_national_id)) + LEN(RTRIM(a.label_txt)) > 0 
 						AND LEN(RTRIM(CAST(a.custom_subform_metadata_uid AS VARCHAR(MAX)))) > 1 
-						THEN 'C_' + RTRIM(a.cdc_national_id) + '_'
+						THEN 'C_' + RTRIM(a.cdc_national_id)
 					ELSE ''
 				END +
 				REPLACE(


### PR DESCRIPTION
## Notes

There is a difference in the way the DATAMART_COLUMN_NM is computed in RBD vs RDB_MODERN 

Database |  -- | --
RDB_MODERN | L_11309683_LDF_Exposure_Date
RDB | L_11309683LDF_Exposure_Date

There is an extra “_“ when computing the DATAMART_COLUMN_NM. The error is in sp_nrt_ldf_dimensional_data_postprocessing

This fix will prevent difference when comparing data between LDF_DATAMART_COLUMN_REF in RDB and RDB_MODERN

In the ticket comments there is a process to remove wrong columns from tables (this will remove data but it will be re-generated again once the investigation is updated)

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2988)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?