### PR TITLE
CNDE-2996: Address STRING_AGG overflow bug in Page Postprocessing

### DIFF
--- a/db/upgrade/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing.sql
@@ -255,14 +255,14 @@ LEFT JOIN dbo.tmp_DynDm_REPEAT_BLOCK_NUMERIC_ALL_' + @datamart_suffix + '   with
             FROM INFORMATION_SCHEMA.columns 
             where table_name = '''+ @tgt_table_nm +''' and TABLE_SCHEMA = ''dbo'')  
                 ) snt) 
-                select @altercolsOUT = STRING_AGG( col_nm + '' '' +  col_data_type + 
+                select @altercolsOUT = STRING_AGG(CAST( col_nm + '' '' +  col_data_type + 
                     CASE 
                         WHEN col_data_type IN (''decimal'', ''numeric'') THEN ''('' + CAST(col_NUMERIC_PRECISION AS NVARCHAR) + '','' + CAST(col_NUMERIC_SCALE AS NVARCHAR) + '')'' 
                         WHEN col_data_type = ''varchar'' THEN ''('' + 
                             CASE WHEN col_CHARACTER_MAXIMUM_LENGTH = -1 THEN ''MAX'' ELSE CAST(col_CHARACTER_MAXIMUM_LENGTH AS NVARCHAR) END 
                         + '') '' 
                         ELSE '''' 
-                    END, '', '') from col_cte';
+                    END AS NVARCHAR(MAX)), '', '') from col_cte';
 
                 DECLARE @altercols NVARCHAR(MAX);
 

--- a/db/upgrade/rdb_modern/routines/335-sp_nrt_odse_nbs_page_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/335-sp_nrt_odse_nbs_page_postprocessing.sql
@@ -267,7 +267,7 @@ BEGIN
             existing dimensions.
         */
         SELECT 
-            @create_dim_sql = STRING_AGG(create_statement, ' ') 
+            @create_dim_sql = STRING_AGG(CAST(create_statement AS NVARCHAR(MAX)), ' ') 
         FROM #MISSING_DIMENSION_TABLES;
 
         if @debug = 'true'
@@ -282,6 +282,7 @@ BEGIN
 		(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_name, @RowCount_no);
           
+
 --------------------------------------------------------------------------------------------------------
 
         SET
@@ -333,7 +334,7 @@ BEGIN
         DECLARE @alter_dim_sql NVARCHAR(MAX) = '';
 
         SELECT 
-            @alter_dim_sql = STRING_AGG(alter_statement, ' ') 
+            @alter_dim_sql = STRING_AGG(CAST(alter_statement AS NVARCHAR(MAX)), ' ') 
         FROM #MISSING_DIMENSION_COLUMNS;
 
         if @debug = 'true'
@@ -349,6 +350,7 @@ BEGIN
 		(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_name, @RowCount_no);
           
+
 --------------------------------------------------------------------------------------------------------
 
         SET
@@ -518,11 +520,11 @@ BEGIN
 
 
         SELECT 
-            @curr_to_placeholder_sql = STRING_AGG(rename_curr_to_placeholder_statement, ' ') 
+            @curr_to_placeholder_sql = STRING_AGG(CAST(rename_curr_to_placeholder_statement AS NVARCHAR(MAX)), ' ') 
         FROM #COLUMN_UPDATE_FINAL;
 
         SELECT 
-            @placeholder_to_new_sql = STRING_AGG(rename_placeholder_to_new_statement, ' ') 
+            @placeholder_to_new_sql = STRING_AGG(CAST(rename_placeholder_to_new_statement AS NVARCHAR(MAX)), ' ') 
         FROM #COLUMN_UPDATE_FINAL;
 
         if @debug = 'true'
@@ -554,7 +556,7 @@ BEGIN
             FROM #PAGEBUILDER_SCHEMA_INIT
         )
         SELECT 
-            @update_dyn_dm_sql = STRING_AGG('EXEC dbo.sp_dyn_dm_main_postprocessing ''' + datamart_nm + ''', '''';', ' ') 
+            @update_dyn_dm_sql = STRING_AGG(CAST('EXEC dbo.sp_dyn_dm_main_postprocessing ''' + datamart_nm + ''', '''';' AS NVARCHAR(MAX)), ' ') 
         FROM distinct_datamart_cte;
 
         if @debug = 'true'

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/245-sp_dyn_dm_createdm_postprocessing-001.sql
@@ -255,14 +255,14 @@ LEFT JOIN dbo.tmp_DynDm_REPEAT_BLOCK_NUMERIC_ALL_' + @datamart_suffix + '   with
             FROM INFORMATION_SCHEMA.columns 
             where table_name = '''+ @tgt_table_nm +''' and TABLE_SCHEMA = ''dbo'')  
                 ) snt) 
-                select @altercolsOUT = STRING_AGG( col_nm + '' '' +  col_data_type + 
+                select @altercolsOUT = STRING_AGG(CAST( col_nm + '' '' +  col_data_type + 
                     CASE 
                         WHEN col_data_type IN (''decimal'', ''numeric'') THEN ''('' + CAST(col_NUMERIC_PRECISION AS NVARCHAR) + '','' + CAST(col_NUMERIC_SCALE AS NVARCHAR) + '')'' 
                         WHEN col_data_type = ''varchar'' THEN ''('' + 
                             CASE WHEN col_CHARACTER_MAXIMUM_LENGTH = -1 THEN ''MAX'' ELSE CAST(col_CHARACTER_MAXIMUM_LENGTH AS NVARCHAR) END 
                         + '') '' 
                         ELSE '''' 
-                    END, '', '') from col_cte';
+                    END AS NVARCHAR(MAX)), '', '') from col_cte';
 
                 DECLARE @altercols NVARCHAR(MAX);
 

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/335-sp_nrt_odse_nbs_page_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/335-sp_nrt_odse_nbs_page_postprocessing-001.sql
@@ -267,7 +267,7 @@ BEGIN
             existing dimensions.
         */
         SELECT 
-            @create_dim_sql = STRING_AGG(create_statement, ' ') 
+            @create_dim_sql = STRING_AGG(CAST(create_statement AS NVARCHAR(MAX)), ' ') 
         FROM #MISSING_DIMENSION_TABLES;
 
         if @debug = 'true'
@@ -282,6 +282,7 @@ BEGIN
 		(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_name, @RowCount_no);
           
+
 --------------------------------------------------------------------------------------------------------
 
         SET
@@ -333,7 +334,7 @@ BEGIN
         DECLARE @alter_dim_sql NVARCHAR(MAX) = '';
 
         SELECT 
-            @alter_dim_sql = STRING_AGG(alter_statement, ' ') 
+            @alter_dim_sql = STRING_AGG(CAST(alter_statement AS NVARCHAR(MAX)), ' ') 
         FROM #MISSING_DIMENSION_COLUMNS;
 
         if @debug = 'true'
@@ -349,6 +350,7 @@ BEGIN
 		(batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
         VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_name, @RowCount_no);
           
+
 --------------------------------------------------------------------------------------------------------
 
         SET
@@ -518,11 +520,11 @@ BEGIN
 
 
         SELECT 
-            @curr_to_placeholder_sql = STRING_AGG(rename_curr_to_placeholder_statement, ' ') 
+            @curr_to_placeholder_sql = STRING_AGG(CAST(rename_curr_to_placeholder_statement AS NVARCHAR(MAX)), ' ') 
         FROM #COLUMN_UPDATE_FINAL;
 
         SELECT 
-            @placeholder_to_new_sql = STRING_AGG(rename_placeholder_to_new_statement, ' ') 
+            @placeholder_to_new_sql = STRING_AGG(CAST(rename_placeholder_to_new_statement AS NVARCHAR(MAX)), ' ') 
         FROM #COLUMN_UPDATE_FINAL;
 
         if @debug = 'true'
@@ -554,7 +556,7 @@ BEGIN
             FROM #PAGEBUILDER_SCHEMA_INIT
         )
         SELECT 
-            @update_dyn_dm_sql = STRING_AGG('EXEC dbo.sp_dyn_dm_main_postprocessing ''' + datamart_nm + ''', '''';', ' ') 
+            @update_dyn_dm_sql = STRING_AGG(CAST('EXEC dbo.sp_dyn_dm_main_postprocessing ''' + datamart_nm + ''', '''';' AS NVARCHAR(MAX)), ' ') 
         FROM distinct_datamart_cte;
 
         if @debug = 'true'


### PR DESCRIPTION
## Notes

This PR introduces changes to STRING_AGG in `sp_nrt_odse_nbs_page_postprocessing` and `sp_dyn_dm_createdm_postprocessing` that will prevent truncation/overflow errors when aggregating a large number of strings.

## JIRA

- **Related story**: [CNDE-2996](https://cdc-nbs.atlassian.net/browse/CNDE-2996)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?