### PR TITLE
CNDE-3042: update config value in event_metric postprocessing

### DIFF
--- a/db/upgrade/rdb_modern/routines/036-sp_event_metric_datamart_postprocessing.sql
+++ b/db/upgrade/rdb_modern/routines/036-sp_event_metric_datamart_postprocessing.sql
@@ -848,12 +848,10 @@ TRANSACTION;
 
     This variable stores the maximum age in days of an event for it to be valid in EVENT_METRIC.
     All new records are inserted in EVENT_METRIC_INC, but if a record is too old, it is not valid
-    for EVENT_METRIC. This value should be stored in an NRT table that mirrors NBS_ODSE.dbo.NBS_configuration.
-    When this table is brought in, change this value to the result of a query that references whatever
-    is in the aforementioned table as opposed to the hardcoded value.
+    for EVENT_METRIC.
 */
-        DECLARE
-@lookback_days BIGINT = 730;
+        DECLARE @lookback_days BIGINT = CAST((SELECT MAX(config_value) FROM dbo.nrt_odse_NBS_configuration WITH (NOLOCK)
+                                        WHERE config_key = 'METRICS_GOBACKBY_DAYS') AS INTEGER);
 
 
         IF

--- a/liquibase-service/src/main/resources/db/rdb_modern/routines/037-sp_event_metric_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/rdb_modern/routines/037-sp_event_metric_datamart_postprocessing-001.sql
@@ -848,12 +848,10 @@ TRANSACTION;
 
     This variable stores the maximum age in days of an event for it to be valid in EVENT_METRIC.
     All new records are inserted in EVENT_METRIC_INC, but if a record is too old, it is not valid
-    for EVENT_METRIC. This value should be stored in an NRT table that mirrors NBS_ODSE.dbo.NBS_configuration.
-    When this table is brought in, change this value to the result of a query that references whatever
-    is in the aforementioned table as opposed to the hardcoded value.
+    for EVENT_METRIC.
 */
-        DECLARE
-@lookback_days BIGINT = 730;
+        DECLARE @lookback_days BIGINT = CAST((SELECT MAX(config_value) FROM dbo.nrt_odse_NBS_configuration WITH (NOLOCK)
+                                        WHERE config_key = 'METRICS_GOBACKBY_DAYS') AS INTEGER);
 
 
         IF


### PR DESCRIPTION
## Notes

This PR updates `dbo.sp_event_metric_datamart_postprocessing` to use the config value stored in `dbo.nrt_odse_NBS_configuration` instead of a hardcoded value.

## JIRA

- **Related story**: [CNDE-3042](https://cdc-nbs.atlassian.net/browse/CNDE-3042)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?