### PR TITLE
CNDE-3064: RTR post-processing refactor for Datamart retry mechanism

### DIFF
--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
@@ -32,38 +32,38 @@ public interface InvestigationRepository extends JpaRepository<DatamartData, Lon
     @Query(value = "EXEC sp_f_std_page_case_postprocessing :publicHealthCaseUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForFStdPageCase(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_hepatitis_datamart_postprocessing")
-    void executeStoredProcForHepDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_hepatitis_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForHepDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_std_hiv_datamart_postprocessing")
-    void executeStoredProcForStdHIVDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_std_hiv_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForStdHIVDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_generic_case_datamart_postprocessing")
-    void executeStoredProcForGenericCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_generic_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForGenericCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_crs_case_datamart_postprocessing")
-    void executeStoredProcForCRSCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_crs_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCRSCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_rubella_case_datamart_postprocessing")
-    void executeStoredProcForRubellaCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_rubella_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForRubellaCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_measles_case_datamart_postprocessing")
-    void executeStoredProcForMeaslesCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_measles_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForMeaslesCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_case_lab_datamart_postprocessing")
-    void executeStoredProcForCaseLabDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_case_lab_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCaseLabDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_bmird_case_datamart_postprocessing")
-    void executeStoredProcForBmirdCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_bmird_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForBmirdCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_hepatitis_case_datamart_postprocessing")
-    void executeStoredProcForHepatitisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_hepatitis_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForHepatitisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_pertussis_case_datamart_postprocessing")
-    void executeStoredProcForPertussisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_pertussis_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForPertussisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_bmird_strep_pneumo_datamart_postprocessing")
-    void executeStoredProcForBmirdStrepPneumoDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_bmird_strep_pneumo_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForBmirdStrepPneumoDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
     @Procedure("sp_summary_report_case_postprocessing")
     void executeStoredProcForSummaryReportCase(@Param("publicHealthCaseUids") String publicHealthCaseUids);
@@ -131,48 +131,48 @@ public interface InvestigationRepository extends JpaRepository<DatamartData, Lon
     @Procedure("sp_f_var_pam_postprocessing")
     void executeStoredProcForFVarPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_tb_datamart_postprocessing")
-    void executeStoredProcForTbDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_tb_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForTbDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
     
-    @Procedure("sp_tb_hiv_datamart_postprocessing")
-    void executeStoredProcForTbHivDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_tb_hiv_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForTbHivDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
     
-    @Procedure("sp_var_datamart_postprocessing")
-    void executeStoredProcForVarDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_var_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForVarDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_generic_datamart_postprocessing")
-    void executeStoredProcForLdfGenericDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_generic_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfGenericDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_bmird_datamart_postprocessing")
-    void executeStoredProcForLdfBmirdDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_bmird_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfBmirdDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
     
-    @Procedure("sp_ldf_foodborne_datamart_postprocessing")
-    void executeStoredProcForLdfFoodBorneDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_foodborne_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfFoodBorneDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_mumps_datamart_postprocessing")
-    void executeStoredProcForLdfMumpsDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_mumps_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfMumpsDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_tetanus_datamart_postprocessing")
-    void executeStoredProcForLdfTetanusDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_tetanus_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfTetanusDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_vaccine_prevent_diseases_datamart_postprocessing")
-    void executeStoredProcForLdfVacPreventDiseasesDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_vaccine_prevent_diseases_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfVacPreventDiseasesDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_ldf_hepatitis_datamart_postprocessing")
-    void executeStoredProcForLdfHepatitisDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_ldf_hepatitis_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForLdfHepatitisDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_covid_case_datamart_postprocessing")
-    void executeStoredProcForCovidCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_covid_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCovidCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_covid_contact_datamart_postprocessing")
-    void executeStoredProcForCovidContactDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_covid_contact_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCovidContactDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_covid_vaccination_datamart_postprocessing")
-    void executeStoredProcForCovidVacDatamart(@Param("vacUids") String vacUids, @Param("patientUids") String patientUids);
+    @Query(value = "EXEC sp_covid_vaccination_datamart_postprocessing :vacUids, :patientUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCovidVacDatamart(@Param("vacUids") String vacUids, @Param("patientUids") String patientUids);
 
-    @Procedure("sp_covid_lab_datamart_postprocessing")
-    void executeStoredProcForCovidLabDatamart(@Param("observationUids") String observationUids);
+    @Query(value = "EXEC sp_covid_lab_datamart_postprocessing :observationUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCovidLabDatamart(@Param("observationUids") String observationUids);
 
-    @Procedure("sp_covid_lab_celr_datamart_postprocessing")
-    void executeStoredProcForCovidLabCelrDatamart(@Param("observationUids") String observationUids);
+    @Query(value = "EXEC sp_covid_lab_celr_datamart_postprocessing :observationUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForCovidLabCelrDatamart(@Param("observationUids") String observationUids);
 }

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
@@ -74,62 +74,62 @@ public interface InvestigationRepository extends JpaRepository<DatamartData, Lon
     @Procedure("sp_aggregate_report_datamart_postprocessing")
     void executeStoredProcForAggregateReport(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_tb_pam_postprocessing")
-    void executeStoredProcForDTbPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_tb_pam_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDTbPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_disease_site_postprocessing")
-    void executeStoredProcForDDiseaseSite(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_disease_site_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDDiseaseSite(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_addl_risk_postprocessing")
-    void executeStoredProcForDAddlRisk(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_addl_risk_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDAddlRisk(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_tb_hiv_postprocessing")
-    void executeStoredProcForDTbHiv(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_tb_hiv_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDTbHiv(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_move_cntry_postprocessing")
-    void executeStoredProcForDMoveCntry(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_move_cntry_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDMoveCntry(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_move_cnty_postprocessing")
-    void executeStoredProcForDMoveCnty(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_move_cnty_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDMoveCnty(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_move_state_postprocessing")
-    void executeStoredProcForDMoveState(@Param("publicHealthCaseUids") String publicHealthCaseUids);
-    
-    @Procedure("sp_nrt_d_out_of_cntry_postprocessing")
-    void executeStoredProcForDOutOfCntry(@Param("publicHealthCaseUids") String publicHealthCaseUids);    
-   
-    @Procedure("sp_nrt_d_moved_where_postprocessing")
-    void executeStoredProcForDMovedWhere(@Param("publicHealthCaseUids") String publicHealthCaseUids);
-    
-    @Procedure("sp_nrt_d_gt_12_reas_postprocessing")
-    void executeStoredProcForDGt12Reas(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_move_state_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDMoveState(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_hc_prov_ty_3_postprocessing")
-    void executeStoredProcForDHcProvTy3(@Param("publicHealthCaseUids") String publicHealthCaseUids);
-    
-    @Procedure("sp_nrt_d_smr_exam_ty_postprocessing")
-    void executeStoredProcForDSmrExamTy(@Param("publicHealthCaseUids") String publicHealthCaseUids); 
-    
-    @Procedure("sp_f_tb_pam_postprocessing")
-    void executeStoredProcForFTbPam(@Param("publicHealthCaseUids") String publicHealthCaseUids); 
-    
-    @Procedure("sp_nrt_tb_pam_ldf_postprocessing")
-    void executeStoredProcForTbPamLdf(@Param("publicHealthCaseUids") String publicHealthCaseUids); 
-    
-    @Procedure("sp_nrt_d_var_pam_postprocessing")
-    void executeStoredProcForDVarPam(@Param("publicHealthCaseUids") String publicHealthCaseUids); 
+    @Query(value = "EXEC sp_nrt_d_out_of_cntry_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDOutOfCntry(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_d_rash_loc_gen_postprocessing")
-    void executeStoredProcForDRashLocGen(@Param("publicHealthCaseUids") String publicHealthCaseUids);
-    
-    @Procedure("sp_nrt_d_pcr_source_postprocessing")
-    void executeStoredProcForDPcrSource(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_moved_where_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDMovedWhere(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_nrt_var_pam_ldf_postprocessing")
-    void executeStoredProcForVarPamLdf(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_gt_12_reas_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDGt12Reas(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
-    @Procedure("sp_f_var_pam_postprocessing")
-    void executeStoredProcForFVarPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+    @Query(value = "EXEC sp_nrt_d_hc_prov_ty_3_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDHcProvTy3(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_d_smr_exam_ty_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDSmrExamTy(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_f_tb_pam_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForFTbPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_tb_pam_ldf_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForTbPamLdf(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_d_var_pam_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDVarPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_d_rash_loc_gen_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDRashLocGen(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_d_pcr_source_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForDPcrSource(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_nrt_var_pam_ldf_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForVarPamLdf(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
+    @Query(value = "EXEC sp_f_var_pam_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForFVarPam(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
     @Query(value = "EXEC sp_tb_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForTbDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -653,20 +653,20 @@ public class PostProcessingService {
 
         if(!pamUids.isEmpty()){
             //TB
-            processTopic(keyTopic, D_TB_PAM, pamUids, investigationRepository::executeStoredProcForDTbPam);
-            processTopic(keyTopic, D_ADDL_RISK, pamUids, investigationRepository::executeStoredProcForDAddlRisk);
-            processTopic(keyTopic, D_DISEASE_SITE, pamUids, investigationRepository::executeStoredProcForDDiseaseSite);
-            processTopic(keyTopic, D_TB_HIV, pamUids, investigationRepository::executeStoredProcForDTbHiv);
-            processTopic(keyTopic, D_GT_12_REAS, pamUids, investigationRepository::executeStoredProcForDGt12Reas);
-            processTopic(keyTopic, D_MOVE_CNTRY, pamUids, investigationRepository::executeStoredProcForDMoveCntry);
-            processTopic(keyTopic, D_MOVE_CNTY, pamUids, investigationRepository::executeStoredProcForDMoveCnty);
-            processTopic(keyTopic, D_MOVE_STATE, pamUids, investigationRepository::executeStoredProcForDMoveState);
-            processTopic(keyTopic, D_MOVED_WHERE, pamUids, investigationRepository::executeStoredProcForDMovedWhere);
-            processTopic(keyTopic, D_HC_PROV_TY_3, pamUids, investigationRepository::executeStoredProcForDHcProvTy3);
-            processTopic(keyTopic, D_OUT_OF_CNTRY, pamUids, investigationRepository::executeStoredProcForDOutOfCntry);
-            processTopic(keyTopic, D_SMR_EXAM_TY, pamUids, investigationRepository::executeStoredProcForDSmrExamTy);
-            processTopic(keyTopic, F_TB_PAM, pamUids, investigationRepository::executeStoredProcForFTbPam);
-            processTopic(keyTopic, TB_PAM_LDF, pamUids, investigationRepository::executeStoredProcForTbPamLdf);
+            processTopic(keyTopic, D_TB_PAM, pamUids, investigationRepository::executeStoredProcForDTbPam, dmProcessor::checkResult);
+            processTopic(keyTopic, D_ADDL_RISK, pamUids, investigationRepository::executeStoredProcForDAddlRisk, dmProcessor::checkResult);
+            processTopic(keyTopic, D_DISEASE_SITE, pamUids, investigationRepository::executeStoredProcForDDiseaseSite, dmProcessor::checkResult);
+            processTopic(keyTopic, D_TB_HIV, pamUids, investigationRepository::executeStoredProcForDTbHiv, dmProcessor::checkResult);
+            processTopic(keyTopic, D_GT_12_REAS, pamUids, investigationRepository::executeStoredProcForDGt12Reas, dmProcessor::checkResult);
+            processTopic(keyTopic, D_MOVE_CNTRY, pamUids, investigationRepository::executeStoredProcForDMoveCntry, dmProcessor::checkResult);
+            processTopic(keyTopic, D_MOVE_CNTY, pamUids, investigationRepository::executeStoredProcForDMoveCnty, dmProcessor::checkResult);
+            processTopic(keyTopic, D_MOVE_STATE, pamUids, investigationRepository::executeStoredProcForDMoveState, dmProcessor::checkResult);
+            processTopic(keyTopic, D_MOVED_WHERE, pamUids, investigationRepository::executeStoredProcForDMovedWhere, dmProcessor::checkResult);
+            processTopic(keyTopic, D_HC_PROV_TY_3, pamUids, investigationRepository::executeStoredProcForDHcProvTy3, dmProcessor::checkResult);
+            processTopic(keyTopic, D_OUT_OF_CNTRY, pamUids, investigationRepository::executeStoredProcForDOutOfCntry, dmProcessor::checkResult);
+            processTopic(keyTopic, D_SMR_EXAM_TY, pamUids, investigationRepository::executeStoredProcForDSmrExamTy, dmProcessor::checkResult);
+            processTopic(keyTopic, F_TB_PAM, pamUids, investigationRepository::executeStoredProcForFTbPam, dmProcessor::checkResult);
+            processTopic(keyTopic, TB_PAM_LDF, pamUids, investigationRepository::executeStoredProcForTbPamLdf, dmProcessor::checkResult);
         }
 
         //VAR
@@ -676,11 +676,11 @@ public class PostProcessingService {
         .collect(Collectors.toSet());
 
         if(!pamUids.isEmpty()){
-            processTopic(keyTopic, D_VAR_PAM, pamUids, investigationRepository::executeStoredProcForDVarPam);
-            processTopic(keyTopic, D_RASH_LOC_GEN, pamUids, investigationRepository::executeStoredProcForDRashLocGen);
-            processTopic(keyTopic, D_PCR_SOURCE, pamUids, investigationRepository::executeStoredProcForDPcrSource);
-            processTopic(keyTopic, F_VAR_PAM, pamUids, investigationRepository::executeStoredProcForFVarPam);
-            processTopic(keyTopic, VAR_PAM_LDF, pamUids, investigationRepository::executeStoredProcForVarPamLdf);
+            processTopic(keyTopic, D_VAR_PAM, pamUids, investigationRepository::executeStoredProcForDVarPam, dmProcessor::checkResult);
+            processTopic(keyTopic, D_RASH_LOC_GEN, pamUids, investigationRepository::executeStoredProcForDRashLocGen, dmProcessor::checkResult);
+            processTopic(keyTopic, D_PCR_SOURCE, pamUids, investigationRepository::executeStoredProcForDPcrSource, dmProcessor::checkResult);
+            processTopic(keyTopic, F_VAR_PAM, pamUids, investigationRepository::executeStoredProcForFVarPam, dmProcessor::checkResult);
+            processTopic(keyTopic, VAR_PAM_LDF, pamUids, investigationRepository::executeStoredProcForVarPamLdf, dmProcessor::checkResult);
         }
     }
 

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -20,20 +20,55 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.Collections;
+import java.util.concurrent.*;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
-import static gov.cdc.etldatapipeline.postprocessingservice.service.Entity.CASE_LAB_DATAMART;
-import static gov.cdc.etldatapipeline.postprocessingservice.service.Entity.HEPATITIS_DATAMART;
+import static gov.cdc.etldatapipeline.commonutil.UtilHelper.errorMessage;
+import static gov.cdc.etldatapipeline.postprocessingservice.service.Entity.*;
 
 @Component
 @RequiredArgsConstructor @Setter
 public class ProcessDatamartData {
     private static final Logger logger = LoggerFactory.getLogger(ProcessDatamartData.class);
 
+    // unique per instance, randomly assigned once
+    static final int INSTANCE_ID = new Random(System.identityHashCode(PostProcessingService.class))
+            .nextInt(1 << 10); // 10-bit random ID
+
+    private static int nProc = Runtime.getRuntime().availableProcessors();
+    private final ExecutorService dynDmExecutor = Executors.newFixedThreadPool(nProc, new CustomizableThreadFactory("dynDm-"));
+
     private final KafkaTemplate<String, String> kafkaTemplate;
+    private final PostProcRepository procRepository;
+    private final InvestigationRepository invRepository;
+
     private final CustomJsonGeneratorImpl jsonGenerator = new CustomJsonGeneratorImpl();
     private final ModelMapper modelMapper = new ModelMapper();
+    private final Object cacheLock = new Object();
+
+    // set of caches for retrying failed datamarts/IDs and tracking retry attempts
+    final Map<Long, Map<String, Map<String, Queue<Long>>>> retryCache = new ConcurrentHashMap<>();
+    final Map<Long, String> errorMap = new ConcurrentHashMap<>();
+    final Map<Long, Integer> retryAttempts = new ConcurrentHashMap<>();
+    final Map<Long, Integer> backfillAttempts = new ConcurrentHashMap<>();
+
+    @Value("${service.max-retries}")
+    private int maxRetries;
+
+    static final String MULTI_ID_DATAMART = "MultiId_Datamart";
+    static final String SP_EXECUTION_COMPLETED = "Stored proc execution completed: {}";
+    static final String PROCESSING_MESSAGE_TOPIC_LOG_MSG = "Processing {} message topic. Calling stored proc: {} '{}'";
+    static final String PROCESSING_MESSAGE_TOPIC_LOG_MSG_2 = "Processing {} message topic. Calling stored proc: {} '{}', '{}";
+
+    static final String STATUS_READY = "READY";
+    static final String STATUS_COMPLETE = "COMPLETE";
+    static final String STATUS_SUSPENDED = "SUSPENDED";
 
     @Value("${spring.kafka.topic.datamart}")
     public String datamartTopic;
@@ -67,18 +102,524 @@ public class ProcessDatamartData {
 
     private List<DatamartData> reduce(List<DatamartData> dmData) {
         List<Long> hepUidsAlreadyInDmData =
-                dmData.stream()
-                        .filter(Objects::nonNull)
+                dmData.stream().filter(Objects::nonNull)
                         .filter(d -> HEPATITIS_DATAMART.getEntityName().equals(d.getDatamart()))
                         .map(DatamartData::getPublicHealthCaseUid).toList();
 
-        return dmData.stream()
-                .filter(Objects::nonNull)
+        return dmData.stream().filter(Objects::nonNull)
                 .filter(d -> {
                     boolean isCaseLab = CASE_LAB_DATAMART.getEntityName().equals(d.getDatamart());
                     boolean hasHepAlready = hepUidsAlreadyInDmData.contains(d.getPublicHealthCaseUid());
                     // If it's Case_Lab_Datamart AND we already have that UID in Hepatitis_Datamart -> exclude
                     return !(isCaseLab && hasHepAlready);
                 }).toList();
+    }
+
+    protected boolean processDmCache(Map<String, Map<String, List<Long>>> dmCache, Long batchId) {
+        List<Long> ldfUids = new ArrayList<>();
+        boolean failed = false;
+
+        for (Map.Entry<String, Map<String, List<Long>>> entry : dmCache.entrySet()) {
+            String dmKey = entry.getKey();
+            Map<String, List<Long>> dmValues = entry.getValue();
+
+            List<Long> uids = getUids(dmValues, INVESTIGATION);
+
+            if (failed) {
+                updateRetryCache(batchId, dmKey, dmValues);
+            } else {
+                if (batchId != null) {
+                    logger.info("Retrying {} id(s) from datamart topic: {}, attempt #{} for batch id: {}",
+                            uids.size(), dmKey, retryAttempts.getOrDefault(batchId, 0) + 1, batchId);
+                }
+
+                try {
+                    processDatamart(dmKey, dmValues, ldfUids);
+                } catch (Exception e) {
+                    logger.error(errorMessage(dmKey, listToParameterString(uids), new Exception(e.getClass().getSimpleName())));
+                    failed = true;
+                    batchId = buildRetryCache(batchId, dmKey, dmValues, e);
+                }
+            }
+        }
+
+        failed = processLdfVaccinePreventDm(batchId, ldfUids, failed);
+
+        if (dmCache.containsKey(MULTI_ID_DATAMART)) {
+            failed = processMultiIdDatamart(batchId, dmCache.get(MULTI_ID_DATAMART), failed);
+        }
+
+        return !failed;
+    }
+
+    /**
+     * Processes a datamart entry and calls the appropriate stored procedures.
+     *
+     * <p>The {@code dmKey} can include a primary datamart (e.g., {@code HEPATITIS_DATAMART}) and an optional
+     * LDF (Legacy Data Form) type separated by a comma.
+     * The {@code idMap} pairs entity names with the IDs to be processed.
+     *
+     * @param dmKey   the datamart key, optionally with an LDF type after a comma
+     * @param idMap   a map of entity names to lists of IDs
+     * @param ldfUids a list to store case IDs for LDF-related datamarts
+     */
+    private void processDatamart(String dmKey, Map<String, List<Long>> idMap, List<Long> ldfUids) {
+
+        if (MULTI_ID_DATAMART.equals(dmKey)) {
+            return;
+        }
+
+        List<Long> uids = getUids(idMap, INVESTIGATION);
+        List<Long> patUids = getUids(idMap, PATIENT);
+        List<Long> obsUids = getUids(idMap, OBSERVATION);
+
+        // for complex value (e.g. "GENERIC_CASE,LDF_GENERIC") the key should be parsed
+        String[] dmTypes = dmKey.split(",");
+        String dmType =  dmTypes[0];
+        String ldfType = dmTypes.length > 1 ? dmTypes[1] : "UNKNOWN" ;
+
+        if (ldfType.equalsIgnoreCase(LDF_VACCINE_PREVENT_DISEASES.getEntityName())) {
+            ldfUids.addAll(uids);
+        }
+
+        // list of phc uids concatenated together with ',' to be passed as input for the stored procs
+        // for COVID_VAC_DATAMART it actually contains vaccination uids
+        String cases = listToParameterString(uids);
+
+        // make sure the entity names for datamart enum values follows the same naming
+        // as the enum itself
+        switch (Entity.valueOf(dmType.toUpperCase())) {
+            case HEPATITIS_DATAMART:
+                executeDmProc(CASE_LAB_DATAMART,
+                        invRepository::executeStoredProcForCaseLabDatamart, cases, this::checkResult);
+                executeDmProc(HEPATITIS_DATAMART,
+                        invRepository::executeStoredProcForHepDatamart, cases, this::checkResult);
+                break;
+            case STD_HIV_DATAMART:
+                executeDmProc(STD_HIV_DATAMART,
+                        invRepository::executeStoredProcForStdHIVDatamart, cases, this::checkResult);
+                break;
+            case GENERIC_CASE:
+                executeDmProc(GENERIC_CASE,
+                        invRepository::executeStoredProcForGenericCaseDatamart, cases, this::checkResult);
+                processLdfLegacy(ldfType, cases);
+                break;
+            case CRS_CASE:
+                executeDmProc(CRS_CASE,
+                        invRepository::executeStoredProcForCRSCaseDatamart, cases, this::checkResult);
+                break;
+            case RUBELLA_CASE:
+                executeDmProc(RUBELLA_CASE,
+                        invRepository::executeStoredProcForRubellaCaseDatamart, cases, this::checkResult);
+                break;
+            case MEASLES_CASE:
+                executeDmProc(MEASLES_CASE,
+                        invRepository::executeStoredProcForMeaslesCaseDatamart, cases, this::checkResult);
+                break;
+            case CASE_LAB_DATAMART:
+                executeDmProc(CASE_LAB_DATAMART,
+                        invRepository::executeStoredProcForCaseLabDatamart, cases, this::checkResult);
+                break;
+            case BMIRD_CASE:
+                executeDmProc(BMIRD_CASE,
+                        invRepository::executeStoredProcForBmirdCaseDatamart, cases, this::checkResult);
+                executeDmProc(BMIRD_STREP_PNEUMO_DATAMART,
+                        invRepository::executeStoredProcForBmirdStrepPneumoDatamart, cases, this::checkResult);
+                processLdfLegacy(ldfType, cases);
+                break;
+            case HEPATITIS_CASE:
+                executeDmProc(HEPATITIS_CASE,
+                        invRepository::executeStoredProcForHepatitisCaseDatamart, cases, this::checkResult);
+                processLdfLegacy(ldfType, cases);
+                break;
+            case PERTUSSIS_CASE:
+                executeDmProc(PERTUSSIS_CASE,
+                        invRepository::executeStoredProcForPertussisCaseDatamart, cases, this::checkResult);
+                break;
+            case TB_DATAMART:
+                executeDmProc(TB_DATAMART,
+                        invRepository::executeStoredProcForTbDatamart, cases, this::checkResult);
+
+                executeDmProc(TB_HIV_DATAMART,
+                        invRepository::executeStoredProcForTbHivDatamart, cases, this::checkResult);
+                break;
+            case VAR_DATAMART:
+                executeDmProc(VAR_DATAMART,
+                        invRepository::executeStoredProcForVarDatamart, cases, this::checkResult);
+                break;
+            case COVID_CASE_DATAMART:
+                executeDmProc(COVID_CASE_DATAMART,
+                        invRepository::executeStoredProcForCovidCaseDatamart, cases, this::checkResult);
+                break;
+            case COVID_CONTACT_DATAMART:
+                executeDmProc(COVID_CONTACT_DATAMART,
+                        invRepository::executeStoredProcForCovidContactDatamart, cases, this::checkResult);
+                break;
+            case COVID_VACCINATION_DATAMART:
+                String pats = listToParameterString(patUids);
+                executeDmProc(COVID_VACCINATION_DATAMART,
+                        invRepository::executeStoredProcForCovidVacDatamart, cases, pats, this::checkResult);
+                break;
+            case COVID_LAB_DATAMART:
+                String labs = listToParameterString(obsUids);
+                executeDmProc(COVID_LAB_DATAMART,
+                        invRepository::executeStoredProcForCovidLabDatamart, labs, this::checkResult);
+                executeDmProc(COVID_LAB_CELR_DATAMART,
+                        invRepository::executeStoredProcForCovidLabCelrDatamart, labs, this::checkResult);
+                break;
+            default:
+                logger.info("No associated datamart processing logic found for the key: {} ", dmType);
+        }
+    }
+
+    private boolean processLdfVaccinePreventDm(Long batchId, List<Long> ldfUids, boolean failed) {
+        if (!failed) {
+
+            String cases = listToParameterString(ldfUids);
+            try {
+                executeDmProc(LDF_VACCINE_PREVENT_DISEASES,
+                        invRepository::executeStoredProcForLdfVacPreventDiseasesDatamart, cases, this::checkResult);
+            } catch (Exception e) {
+                String ldfType = LDF_VACCINE_PREVENT_DISEASES.getEntityName();
+                String dmKey = "LDF," + ldfType;
+
+                logger.error(errorMessage(ldfType, cases, new Exception(e.getClass().getSimpleName())));
+                buildRetryCache(batchId, dmKey, Collections.singletonMap(INVESTIGATION.getEntityName(), ldfUids), e);
+                failed = true;
+            }
+        }
+        return failed;
+    }
+
+    private void processLdfLegacy(String ldfType, String cases) {
+        switch (Entity.valueOf(ldfType.toUpperCase())) {
+            case LDF_GENERIC:
+                executeDmProc(LDF_GENERIC,
+                        invRepository::executeStoredProcForLdfGenericDatamart, cases, this::checkResult);
+                break;
+            case LDF_FOODBORNE:
+                executeDmProc(LDF_FOODBORNE,
+                        invRepository::executeStoredProcForLdfFoodBorneDatamart, cases, this::checkResult);
+                break;
+            case LDF_TETANUS:
+                // to test this, Tetanus must be added as a legacy page and
+                // [dbo].nrt_datamart_metadata table must be updated adding TETANUS
+                executeDmProc(LDF_TETANUS,
+                        invRepository::executeStoredProcForLdfTetanusDatamart, cases, this::checkResult);
+                break;
+            case LDF_MUMPS:
+                executeDmProc(LDF_MUMPS,
+                        invRepository::executeStoredProcForLdfMumpsDatamart, cases, this::checkResult);
+                break;
+            case LDF_BMIRD:
+                executeDmProc(LDF_BMIRD,
+                        invRepository::executeStoredProcForLdfBmirdDatamart, cases, this::checkResult);
+                break;
+            case LDF_HEPATITIS:
+                executeDmProc(LDF_HEPATITIS,
+                        invRepository::executeStoredProcForLdfHepatitisDatamart, cases, this::checkResult);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Processes cached IDs for multi-ID datamarts by executing the appropriate stored procedures.
+     * @param dmMulti
+     */
+    private boolean processMultiIdDatamart(Long batchId, Map<String, List<Long>> dmMulti, boolean failed) {
+        if (failed) {
+            updateRetryCache(batchId, MULTI_ID_DATAMART, dmMulti);
+        } else {
+            String invString = listToParameterString(dmMulti.get(INVESTIGATION.getEntityName()));
+            String obsString = listToParameterString(dmMulti.get(OBSERVATION.getEntityName()));
+            String notifString = listToParameterString(dmMulti.get(NOTIFICATION.getEntityName()));
+            String patString = listToParameterString(dmMulti.get(PATIENT.getEntityName()));
+            String provString = listToParameterString(dmMulti.get(PROVIDER.getEntityName()));
+            String orgString = listToParameterString(dmMulti.get(ORGANIZATION.getEntityName()));
+
+            int totalLengthHep100 = invString.length() + patString.length() + provString.length() + orgString.length();
+            int totalLengthInvSummary = invString.length() + notifString.length() + obsString.length();
+            int totalLengthMorbReportDM = obsString.length() + patString.length() + provString.length() + orgString.length() + invString.length();
+
+            try {
+                if (totalLengthHep100 > 0) {
+                    procRepository.executeStoredProcForHep100(invString, patString, provString, orgString);
+                } else {
+                    logger.info("No updates to HEP100 Datamart");
+                }
+
+                if (totalLengthInvSummary > 0) {
+                    //reusing the same DTO class for Dynamic Marts
+                    List<DatamartData> dmDataList = procRepository.executeStoredProcForInvSummaryDatamart(invString, notifString, obsString);
+                    processDynDatamart(dmDataList);
+                } else {
+                    logger.info("No updates to INV_SUMMARY Datamart");
+                }
+
+                if (totalLengthMorbReportDM > 0) {
+                    procRepository.executeStoredProcForMorbidityReportDatamart(obsString, patString, provString, orgString, invString);
+                } else {
+                    logger.info("No updates to MORBIDITY_REPORT_DATAMART");
+                }
+            } catch (Exception e) {
+                logger.error(errorMessage(MULTI_ID_DATAMART, invString, new Exception(e.getClass().getSimpleName())));
+                buildRetryCache(batchId, MULTI_ID_DATAMART, dmMulti, e);
+                failed = true;
+            }
+        }
+        return failed;
+    }
+
+    private void processDynDatamart(List<DatamartData> dmDataList) {
+        if (!dmDataList.isEmpty()) {
+            Map<String, String> datamartPhcIdMap = dmDataList.stream()
+                    .collect(Collectors.groupingBy(
+                            DatamartData::getDatamart,
+                            Collectors.mapping(
+                                    dmData -> String.valueOf(dmData.getPublicHealthCaseUid()),
+                                    Collectors.joining(",")
+                            )
+                    ));
+
+            datamartPhcIdMap.forEach((datamart, phcIds) ->
+                    CompletableFuture.runAsync(() -> procRepository.executeStoredProcForDynDatamart(datamart, phcIds), dynDmExecutor)
+                            .thenRun(() -> logger.info("Updates to Dynamic Datamart: {} ", datamart))
+            );
+        } else {
+            logger.info("No updates to Dynamic Datamarts");
+        }
+    }
+
+    /**
+     * Scheduled task to reprocess failed datamarts by iterating through retry cache and invoking {@link #processDmCache(Map, Long)}
+     * with snapshots of the cached IDs.
+     * <ul>1. Updates backfill records, manages retry attempts</ul>
+     * <ul>2. Clear caches on success</ul>
+     * <ul>3. Persists remaining IDs when the maximum retry limit is reached</ul>
+     */
+    @Scheduled(fixedDelayString = "${service.fixed-delay.datamart}")
+    protected void processRetryCache() {
+
+        for (Map.Entry<Long, Map<String, Map<String, Queue<Long>>>> retryEntry : retryCache.entrySet()) {
+
+            Long batchId = retryEntry.getKey();
+
+            // Making a cache snapshot preventing out-of-sequence ids processing
+            // creates a deep copy of cache into snapshot
+            final Map<String, Map<String, List<Long>>> retryCacheSnapshot;
+
+            synchronized (cacheLock) {
+                retryCacheSnapshot = retryEntry.getValue().entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey,
+                                        idEntry -> new ArrayList<>(idEntry.getValue())
+                                ))
+                        ));
+                retryCache.remove(batchId);
+            }
+
+            boolean processed = processDmCache(retryCacheSnapshot, batchId);
+
+            // update backfill batch record(s) if exists
+            if (updateBackfills(batchId, processed)) {
+                retryCache.remove(batchId);
+                continue;
+            }
+
+            if (processed) {
+                // clear retry caches if no errors after re-processing
+                retryAttempts.remove(batchId);
+                errorMap.remove(batchId);
+            } else {
+                int attempt = retryAttempts.getOrDefault(batchId, 0);
+                if (attempt >= maxRetries) {
+                    logger.info("Reached max retries for batch id: {}. Skipping further processing.", batchId);
+                    retryAttempts.remove(batchId);
+                    retryCache.remove(batchId);
+
+                    processBackfills(retryCacheSnapshot, batchId);
+                    errorMap.remove(batchId);
+                }
+            }
+        }
+    }
+
+    /**
+     * Persists failed entities for backfill processing into the database.
+     * <p>
+     * Applies nameOp to each cache key and invokes the backfill
+     * stored procedure with entity name, ID list, batchId, error,
+     * status, and retry count.
+     * </p>
+     * @param cache   map of entity names to failed record IDs
+     * @param nameOp  transforms the cache key into the database-specific entity name
+     * @param batchId unique batch identifier for this backfill run
+     */
+    void processBackfills(Map<String, List<Long>> cache, UnaryOperator<String> nameOp, Long batchId) {
+
+        for (Map.Entry<String, List<Long>> entry : cache.entrySet()) {
+            procRepository.executeStoredProcForBackfill(
+                    nameOp.apply(entry.getKey()),
+                    listToParameterString(entry.getValue()),
+                    batchId,
+                    errorMap.get(batchId),
+                    STATUS_READY,
+                    backfillAttempts.getOrDefault(batchId, 0)
+            );
+        }
+    }
+
+    /**
+     * Persists failed datamarts for backfill processing into the database.
+     * <p>
+     * Invokes the backfill stored procedure with datamart name, ID list, batchId, error,
+     * status, and retry count.
+     * </p>
+     * @param cache   map of datamart names to failed record IDs
+     * @param batchId unique batch identifier for this backfill run
+     */
+    void processBackfills(Map<String, Map<String, List<Long>>> cache, Long batchId) {
+        for (Map.Entry<String, Map<String, List<Long>>> entry : cache.entrySet()) {
+            String dmName = "DM^" + entry.getKey();
+            String ids = entry.getValue().entrySet().stream()
+                    .filter(idEntry -> !idEntry.getValue().isEmpty())
+                    .map(idEntry -> idEntry.getKey() + ":" + listToParameterString(idEntry.getValue()))
+                    .collect(Collectors.joining(" "));
+            procRepository.executeStoredProcForBackfill(
+                    dmName,
+                    ids.trim(),
+                    batchId,
+                    errorMap.get(batchId),
+                    STATUS_READY,
+                    backfillAttempts.getOrDefault(batchId, 0)
+            );
+        }
+    }
+
+    boolean updateBackfills(Long batchId, boolean processed) {
+        if (backfillAttempts.containsKey(batchId)) {
+            retryAttempts.remove(batchId);
+
+            String status = processed ? STATUS_COMPLETE : STATUS_READY;
+            int bfAttempt = backfillAttempts.get(batchId) + 1;
+            if (bfAttempt >= maxRetries) {
+                logger.info("Reached max backfill retries for batch id: {}. Suspend further processing.", batchId);
+                status = STATUS_SUSPENDED;
+                bfAttempt = 0;
+            }
+
+            procRepository.executeStoredProcForBackfill(null, null, batchId,
+                    errorMap.get(batchId), status, bfAttempt);
+
+            backfillAttempts.remove(batchId);
+            errorMap.remove(batchId);
+            return true;
+        }
+        return false;
+    }
+
+    private Long buildRetryCache(
+            Long batchId, String dmKey, Map<String, List<Long>> idMap, Exception e) {
+
+        //skip retrying for non-positive value
+        if (maxRetries <= 0) {
+            return null;
+        }
+
+        batchId = getBatchId(batchId, e);
+        updateRetryCache(batchId, dmKey, idMap);
+
+        return batchId;
+    }
+
+    protected Long getBatchId(Long batchId, Exception e) {
+        if (batchId == null) {
+            batchId = (System.currentTimeMillis() << 10) | INSTANCE_ID;
+            retryAttempts.put(batchId, 0);
+        } else {
+            retryAttempts.merge(batchId, 1, Integer::sum);
+        }
+
+        Throwable cause = e;
+        while (cause.getCause() != null) {
+            cause = cause.getCause(); // unwrap nested exceptions
+        }
+        String errorMsg = cause.getMessage();
+        errorMap.put(batchId, errorMsg);
+
+        return batchId;
+    }
+
+    void updateRetryCache(Long batchId, BackfillData bfd) {
+
+        String dmKey = bfd.getEntity().substring("DM^".length());
+
+        // Parse recordUidList into a map
+        String recordUidList = bfd.getRecordUidList();
+        Map<String, List<Long>> idMap =
+                Arrays.stream(recordUidList.split("\\s+"))
+                        .map(token -> token.split(":", 2))
+                        .collect(Collectors.toMap(
+                                parts -> parts[0],
+                                parts -> Arrays.stream(parts[1].split(","))
+                                        .map(Long::valueOf).toList()
+                        ));
+        backfillAttempts.put(batchId, bfd.getRetryCount());
+        retryAttempts.put(batchId, bfd.getRetryCount());
+        errorMap.put(batchId, bfd.getErrDescription());
+
+        updateRetryCache(batchId, dmKey, idMap);
+    }
+
+    private void updateRetryCache(Long batchId, String dmKey, Map<String, List<Long>> idMap) {
+        if (batchId != null) {
+            Map<String, Queue<Long>> dmMap = retryCache
+                    .computeIfAbsent(batchId, k -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(dmKey, k -> new ConcurrentHashMap<>());
+            idMap.forEach((key, value) ->
+                    dmMap.computeIfAbsent(key, k -> new ConcurrentLinkedQueue<>()).addAll(value));
+        }
+    }
+
+    private <T> void executeDmProc(Entity dmEntity, Function<String, List<T>> repositoryMethod, String ids,
+                                   Consumer<List<T>> checkResult) {
+        if (!ids.isEmpty()) {
+            logger.info(PROCESSING_MESSAGE_TOPIC_LOG_MSG, dmEntity.getEntityName(), dmEntity.getStoredProcedure(), ids);
+            List<T> result = repositoryMethod.apply(ids);
+            checkResult.accept(result);
+            logger.info(SP_EXECUTION_COMPLETED, dmEntity.getStoredProcedure());
+        }
+    }
+
+    private <T> void executeDmProc(Entity dmEntity, BiFunction<String, String, List<T>> repositoryMethod,
+                                   String ids, String pids, Consumer<List<T>> checkResult) {
+        if (!ids.isEmpty() && !pids.isEmpty()) {
+            logger.info(PROCESSING_MESSAGE_TOPIC_LOG_MSG_2, dmEntity.getEntityName(), dmEntity.getStoredProcedure(), ids, pids);
+            List<T> result = repositoryMethod.apply(ids, pids);
+            checkResult.accept(result);
+            logger.info(SP_EXECUTION_COMPLETED, dmEntity.getStoredProcedure());
+        }
+    }
+
+    private List<Long> getUids(Map<String, List<Long>> dmValues, Entity entity) {
+        return Optional.ofNullable(dmValues.get(entity.getEntityName()))
+                .map(ArrayList::new).orElseGet(ArrayList::new);
+    }
+
+    private String listToParameterString(Collection<Long> inputList) {
+        return Optional.ofNullable(inputList)
+                .map(list -> list.stream().distinct().map(String::valueOf).collect(Collectors.joining(",")))
+                .orElse("");
+    }
+
+    void checkResult(List<DatamartData> dmData) throws DataProcessingException {
+        if (!dmData.isEmpty()) {
+            DatamartData dme = dmData.getFirst();
+            if ("Error".equals(dme.getDatamart())) {
+                throw new DataProcessingException(dme.getStoredProcedure());
+            }
+        }
     }
 }

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -3,6 +3,9 @@ package gov.cdc.etldatapipeline.postprocessingservice.service;
 import com.google.common.base.Strings;
 import gov.cdc.etldatapipeline.commonutil.DataProcessingException;
 import gov.cdc.etldatapipeline.commonutil.json.CustomJsonGeneratorImpl;
+import gov.cdc.etldatapipeline.postprocessingservice.repository.InvestigationRepository;
+import gov.cdc.etldatapipeline.postprocessingservice.repository.PostProcRepository;
+import gov.cdc.etldatapipeline.postprocessingservice.repository.model.BackfillData;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.DatamartData;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.dto.Datamart;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.dto.DatamartKey;
@@ -13,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -38,7 +38,7 @@ public class ProcessDatamartData {
     private static final Logger logger = LoggerFactory.getLogger(ProcessDatamartData.class);
 
     // unique per instance, randomly assigned once
-    static final int INSTANCE_ID = new Random(System.identityHashCode(PostProcessingService.class))
+    static final int INSTANCE_ID = new Random(System.identityHashCode(ProcessDatamartData.class))
             .nextInt(1 << 10); // 10-bit random ID
 
     private static int nProc = Runtime.getRuntime().availableProcessors();

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
@@ -3,6 +3,8 @@ package gov.cdc.etldatapipeline.postprocessingservice.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.cdc.etldatapipeline.postprocessingservice.repository.InvestigationRepository;
+import gov.cdc.etldatapipeline.postprocessingservice.repository.PostProcRepository;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.DatamartData;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.dto.Datamart;
 import gov.cdc.etldatapipeline.postprocessingservice.repository.model.dto.DatamartKey;
@@ -32,12 +34,15 @@ class DatamartProcessingTest {
 
     @Captor
     private ArgumentCaptor<String> topicCaptor;
-
     @Captor
     private ArgumentCaptor<String> keyCaptor;
-
     @Captor
     private ArgumentCaptor<String> messageCaptor;
+
+    @Mock
+    private PostProcRepository postProcRepositoryMock;
+    @Mock
+    private InvestigationRepository investigationRepositoryMock;
 
     private static final String FILE_PREFIX = "rawDataFiles/";
     private static final String PAYLOAD = "payload";
@@ -49,7 +54,7 @@ class DatamartProcessingTest {
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
-        datamartProcessor = new ProcessDatamartData(kafkaTemplate);
+        datamartProcessor = new ProcessDatamartData(kafkaTemplate, postProcRepositoryMock, investigationRepositoryMock);
     }
 
     @AfterEach

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
@@ -64,9 +64,9 @@ class DatamartProcessingTest {
 
     @ParameterizedTest
     @MethodSource("provideTestData")
-    void testDatamartProcess(String conditionCd, String dmEntity, String dmSp, String dmJson) throws Exception {
+    void testDatamartProcess(String conditionCd, Entity dmEntity, String dmJson) throws Exception {
         String topic = "dummy_investigation";
-        DatamartData datamartData = getDatamartData(conditionCd, dmEntity, dmSp);
+        DatamartData datamartData = getDatamartData(conditionCd, dmEntity.getEntityName(), dmEntity.getStoredProcedure());
 
         datamartProcessor.datamartTopic = topic;
         datamartProcessor.process(List.of(datamartData));
@@ -92,17 +92,17 @@ class DatamartProcessingTest {
 
     static Stream<Arguments> provideTestData() {
         return Stream.of(
-                Arguments.of("10110", HEPATITIS_DATAMART.getEntityName(), HEPATITIS_DATAMART.getStoredProcedure(), "HepDatamart.json"),
-                Arguments.of("10110", STD_HIV_DATAMART.getEntityName(), STD_HIV_DATAMART.getStoredProcedure(), "StdDatamart.json"),
-                Arguments.of("12020", GENERIC_CASE.getEntityName(), GENERIC_CASE.getStoredProcedure(), "GenericCaseDatamart.json"),
-                Arguments.of("10370", CRS_CASE.getEntityName(), CRS_CASE.getStoredProcedure(), "CRSCaseDatamart.json"),
-                Arguments.of("10200", RUBELLA_CASE.getEntityName(), RUBELLA_CASE.getStoredProcedure(), "RubellaCaseDatamart.json"),
-                Arguments.of("10140", MEASLES_CASE.getEntityName(), MEASLES_CASE.getStoredProcedure(), "MeaslesCaseDatamart.json"),
-                Arguments.of(null, CASE_LAB_DATAMART.getEntityName(), CASE_LAB_DATAMART.getStoredProcedure(), "CaseLabDatamart.json"),
-                Arguments.of("10160", BMIRD_CASE.getEntityName(), BMIRD_CASE.getStoredProcedure(), "BMIRDCaseDatamart.json"),
-                Arguments.of("10140", HEPATITIS_CASE.getEntityName(), HEPATITIS_CASE.getStoredProcedure(), "HepatitisCaseDatamart.json"),
-                Arguments.of("10190", PERTUSSIS_CASE.getEntityName(), PERTUSSIS_CASE.getStoredProcedure(), "PertussisCaseDatamart.json"),
-                Arguments.of("11065", COVID_VACCINATION_DATAMART.getEntityName(), COVID_VACCINATION_DATAMART.getStoredProcedure(), "CovidVacDatamart.json")
+                Arguments.of("10110", HEPATITIS_DATAMART, "HepDatamart.json"),
+                Arguments.of("10110", STD_HIV_DATAMART, "StdDatamart.json"),
+                Arguments.of("12020", GENERIC_CASE, "GenericCaseDatamart.json"),
+                Arguments.of("10370", CRS_CASE, "CRSCaseDatamart.json"),
+                Arguments.of("10200", RUBELLA_CASE, "RubellaCaseDatamart.json"),
+                Arguments.of("10140", MEASLES_CASE, "MeaslesCaseDatamart.json"),
+                Arguments.of(null, CASE_LAB_DATAMART, "CaseLabDatamart.json"),
+                Arguments.of("10160", BMIRD_CASE, "BMIRDCaseDatamart.json"),
+                Arguments.of("10140", HEPATITIS_CASE, "HepatitisCaseDatamart.json"),
+                Arguments.of("10190", PERTUSSIS_CASE, "PertussisCaseDatamart.json"),
+                Arguments.of("11065", COVID_VACCINATION_DATAMART, "CovidVacDatamart.json")
         );
     }
 

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/DatamartProcessingTest.java
@@ -164,5 +164,4 @@ class DatamartProcessingTest {
         JsonNode dmNode = objectMapper.readTree(dmJson);
         return objectMapper.readValue(dmNode.get(PAYLOAD).toString(), Datamart.class);
     }
-
 }

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
@@ -56,9 +56,11 @@ class PostProcessingServiceDmTest {
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
 
-        Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
         listAppender.start();
-        logger.addAppender(listAppender);
+        Logger serviceLogger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
+        serviceLogger.addAppender(listAppender);
+        Logger procLogger = (Logger) LoggerFactory.getLogger(ProcessDatamartData.class);
+        procLogger.addAppender(listAppender);
     }
 
     @AfterEach
@@ -171,10 +173,11 @@ class PostProcessingServiceDmTest {
     @MethodSource("datamartTestData")
     void testProcessDmMessage(DatamartTestCase testCase) {
         String topic = "dummy_datamart";
+
         postProcessingServiceMock.processDmMessage(topic, testCase.msg);
+        assertTrue(postProcessingServiceMock.dmCache.containsKey(testCase.datamartEntityName));
         postProcessingServiceMock.processDatamartIds();
         testCase.verificationStep.accept(investigationRepositoryMock);
-        assertTrue(postProcessingServiceMock.dmCache.containsKey(testCase.datamartEntityName));
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(testCase.logSize, logs.size());
         assertEquals(logs.getLast().getFormattedMessage(),

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
@@ -31,12 +31,11 @@ import static org.mockito.Mockito.*;
 class PostProcessingServiceDmTest {
     @InjectMocks
     @Spy
-
     private PostProcessingService postProcessingServiceMock;
     @Mock
     private PostProcRepository postProcRepositoryMock;
     @Mock
-    private static InvestigationRepository investigationRepositoryMock;
+    private InvestigationRepository investigationRepositoryMock;
 
     @Mock
     KafkaTemplate<String, String> kafkaTemplate;
@@ -53,7 +52,7 @@ class PostProcessingServiceDmTest {
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
-        datamartProcessor = new ProcessDatamartData(kafkaTemplate);
+        datamartProcessor = new ProcessDatamartData(kafkaTemplate, postProcRepositoryMock, investigationRepositoryMock);
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
 

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceEntityTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceEntityTest.java
@@ -34,7 +34,7 @@ class PostProcessingServiceEntityTest {
     @Mock
     private PostProcRepository postProcRepositoryMock;
     @Mock
-    private static InvestigationRepository investigationRepositoryMock;
+    private InvestigationRepository investigationRepositoryMock;
 
     @Mock
     KafkaTemplate<String, String> kafkaTemplate;
@@ -45,7 +45,7 @@ class PostProcessingServiceEntityTest {
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
-        ProcessDatamartData datamartProcessor = new ProcessDatamartData(kafkaTemplate);
+        ProcessDatamartData datamartProcessor = new ProcessDatamartData(kafkaTemplate, postProcRepositoryMock, investigationRepositoryMock);
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
 
@@ -110,7 +110,7 @@ class PostProcessingServiceEntityTest {
         verify(postProcRepositoryMock).executeStoredProcForProviderIds(expectedProviderIdsString);
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(6, logs.size());
+        assertEquals(5, logs.size());
         assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
@@ -832,7 +832,7 @@ class PostProcessingServiceEntityTest {
         verify(postProcRepositoryMock).executeStoredProcForTreatment(expectedTreatmentIdsString);
 
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(8, logs.size());
+        assertEquals(5, logs.size());
         assertTrue(logs.get(2).getFormattedMessage().contains(TREATMENT.getStoredProcedure()));
         assertTrue(logs.get(3).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceRetryTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceRetryTest.java
@@ -49,7 +49,7 @@ class PostProcessingServiceRetryTest {
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
-        ProcessDatamartData datamartProcessor = new ProcessDatamartData(kafkaTemplate);
+        datamartProcessor = new ProcessDatamartData(kafkaTemplate, postProcRepositoryMock, investigationRepositoryMock);
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
         postProcessingServiceMock.setMaxRetries(2);

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceRetryTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceRetryTest.java
@@ -21,8 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static gov.cdc.etldatapipeline.postprocessingservice.service.PostProcessingService.STATUS_READY;
-import static gov.cdc.etldatapipeline.postprocessingservice.service.PostProcessingService.STATUS_SUSPENDED;
+import static gov.cdc.etldatapipeline.postprocessingservice.service.ProcessDatamartData.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -41,6 +40,8 @@ class PostProcessingServiceRetryTest {
     @Mock
     KafkaTemplate<String, String> kafkaTemplate;
 
+    private ProcessDatamartData datamartProcessor;
+
     private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
     private AutoCloseable closeable;
 
@@ -53,6 +54,7 @@ class PostProcessingServiceRetryTest {
         postProcessingServiceMock = spy(new PostProcessingService(postProcRepositoryMock, investigationRepositoryMock,
                 datamartProcessor));
         postProcessingServiceMock.setMaxRetries(2);
+        datamartProcessor.setMaxRetries(2);
 
         Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
         listAppender.start();
@@ -67,7 +69,7 @@ class PostProcessingServiceRetryTest {
     }
 
     @Test
-    void testProcessRetryCache() {
+    void testProcessRetryEntity() {
         String patTopic = "dummy_patient";
         String patKey = "{\"payload\":{\"patient_uid\":123}}";
         String invTopic = "dummy_investigation";
@@ -86,10 +88,10 @@ class PostProcessingServiceRetryTest {
         postProcessingServiceMock.processCachedIds();
 
         assertFalse(postProcessingServiceMock.retryCache.isEmpty());
-        assertFalse(postProcessingServiceMock.errorMap.isEmpty());
+        assertFalse(datamartProcessor.errorMap.isEmpty());
 
         Long batchId = postProcessingServiceMock.retryCache.entrySet().iterator().next().getKey();
-        assertEquals(errorMsg, postProcessingServiceMock.errorMap.get(batchId));
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
         assertEquals(6, postProcessingServiceMock.retryCache.get(batchId).size());
 
         postProcessingServiceMock.processRetryCache();
@@ -104,7 +106,7 @@ class PostProcessingServiceRetryTest {
     }
 
     @Test
-    void testProcessRetryCacheSuccess() {
+    void testProcessRetryEntitySuccess() {
         String patTopic = "dummy_patient";
         String patKey = "{\"payload\":{\"patient_uid\":123}}";
 
@@ -118,10 +120,10 @@ class PostProcessingServiceRetryTest {
         postProcessingServiceMock.processCachedIds();
 
         assertFalse(postProcessingServiceMock.retryCache.isEmpty());
-        assertFalse(postProcessingServiceMock.errorMap.isEmpty());
+        assertFalse(datamartProcessor.errorMap.isEmpty());
 
         Long batchId = postProcessingServiceMock.retryCache.entrySet().iterator().next().getKey();
-        assertEquals(errorMsg, postProcessingServiceMock.errorMap.get(batchId));
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
 
         postProcessingServiceMock.processRetryCache();
         verify(postProcRepositoryMock, never()).executeStoredProcForBackfill(
@@ -131,7 +133,7 @@ class PostProcessingServiceRetryTest {
     }
 
     @Test
-    void testProcessRetryCacheDisabled() {
+    void testProcessRetryDisabled() {
         String patTopic = "dummy_patient";
         String patKey = "{\"payload\":{\"patient_uid\":123}}";
 
@@ -148,6 +150,114 @@ class PostProcessingServiceRetryTest {
     }
 
     @Test
+    void testProcessRetryDatamart() {
+        String investigationKey = "{\"payload\":{\"public_health_case_uid\":123}}";
+        String notificationKey = "{\"payload\":{\"notification_uid\":124}}";
+        String observationKey = "{\"payload\":{\"observation_uid\":130}}";
+
+        String invTopic = "dummy_investigation";
+        String notTopic = "dummy_notification";
+        String obsTopic = "dummy_observation";
+
+        postProcessingServiceMock.processNrtMessage(invTopic, investigationKey, investigationKey);
+        postProcessingServiceMock.processNrtMessage(notTopic, notificationKey, notificationKey);
+        postProcessingServiceMock.processNrtMessage(obsTopic, observationKey, observationKey);
+        postProcessingServiceMock.processCachedIds();
+
+        String topic = "dummy_datamart";
+        String hepDmMsg = "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\"," +
+                "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+        String genDmMsg = "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\"," +
+                "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+
+        String phcUid = "123";
+        when(investigationRepositoryMock.executeStoredProcForHepDatamart(phcUid)).thenThrow(new RuntimeException(errorMsg));
+
+        postProcessingServiceMock.processDmMessage(topic, hepDmMsg);
+        postProcessingServiceMock.processDmMessage(topic, genDmMsg);
+        postProcessingServiceMock.processDatamartIds();
+
+        assertFalse(datamartProcessor.retryCache.isEmpty());
+        assertFalse(datamartProcessor.errorMap.isEmpty());
+
+        Long batchId = datamartProcessor.retryCache.entrySet().iterator().next().getKey();
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
+        assertEquals(3, datamartProcessor.retryCache.get(batchId).size());
+        assertTrue(datamartProcessor.retryCache.get(batchId).containsKey(MULTI_ID_DATAMART));
+
+        String dmEntity = "DM^" + Entity.HEPATITIS_DATAMART.getEntityName();
+        datamartProcessor.processRetryCache();
+        verify(postProcRepositoryMock, never()).executeStoredProcForBackfill(
+                eq(dmEntity), contains(phcUid), eq(batchId), eq(errorMsg), eq(STATUS_READY), eq(0));
+
+        datamartProcessor.processRetryCache();
+        verify(postProcRepositoryMock).executeStoredProcForBackfill(
+                eq(dmEntity), contains(phcUid), eq(batchId), eq(errorMsg), eq(STATUS_READY), eq(0));
+
+        verify(investigationRepositoryMock, times(3)).executeStoredProcForHepDatamart(anyString());
+    }
+
+    @Test
+    void testProcessRetryMultiId() {
+        String investigationKey = "{\"payload\":{\"public_health_case_uid\":123}}";
+        String notificationKey = "{\"payload\":{\"notification_uid\":124}}";
+        String observationKey = "{\"payload\":{\"observation_uid\":130}}";
+
+        String invTopic = "dummy_investigation";
+        String notTopic = "dummy_notification";
+        String obsTopic = "dummy_observation";
+
+        postProcessingServiceMock.processNrtMessage(invTopic, investigationKey, investigationKey);
+        postProcessingServiceMock.processNrtMessage(notTopic, notificationKey, notificationKey);
+        postProcessingServiceMock.processNrtMessage(obsTopic, observationKey, observationKey);
+        postProcessingServiceMock.processCachedIds();
+
+        when(postProcRepositoryMock.executeStoredProcForInvSummaryDatamart("123", "124", "130")).thenThrow(new RuntimeException(errorMsg));
+        postProcessingServiceMock.processDatamartIds();
+
+        assertFalse(datamartProcessor.retryCache.isEmpty());
+        Long batchId = datamartProcessor.retryCache.entrySet().iterator().next().getKey();
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
+        assertTrue(datamartProcessor.retryCache.get(batchId).containsKey(MULTI_ID_DATAMART));
+    }
+
+    @Test
+    void testProcessRetryDatamartSuccess() {
+        String topic = "dummy_datamart";
+        String hepDmMsg = "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\"," +
+                "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+        String genDmMsg = "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\"," +
+                "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+
+        String phcUid = "123";
+        when(investigationRepositoryMock.executeStoredProcForHepDatamart(phcUid))
+                .thenThrow(new RuntimeException(errorMsg))
+                .thenReturn(Collections.emptyList());
+
+        postProcessingServiceMock.processDmMessage(topic, hepDmMsg);
+        postProcessingServiceMock.processDmMessage(topic, genDmMsg);
+        postProcessingServiceMock.processDatamartIds();
+
+        assertFalse(datamartProcessor.retryCache.isEmpty());
+        assertFalse(datamartProcessor.errorMap.isEmpty());
+
+        Long batchId = datamartProcessor.retryCache.entrySet().iterator().next().getKey();
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
+
+        String dmEntity = "DM^" + Entity.HEPATITIS_DATAMART.getEntityName();
+        datamartProcessor.processRetryCache();
+
+        assertTrue(datamartProcessor.retryAttempts.isEmpty());
+        assertTrue(datamartProcessor.errorMap.isEmpty());
+        assertTrue(datamartProcessor.retryCache.isEmpty());
+        verify(postProcRepositoryMock, never()).executeStoredProcForBackfill(
+                eq(dmEntity), contains(phcUid), eq(batchId), eq(errorMsg), eq(STATUS_READY), eq(0));
+
+        verify(investigationRepositoryMock, times(2)).executeStoredProcForHepDatamart(anyString());
+        verify(investigationRepositoryMock).executeStoredProcForGenericCaseDatamart(anyString());
+    }
+
+    @Test
     void testProcessBackfillEvent() {
         when(postProcRepositoryMock.executeBackfillEvent(STATUS_READY))
                 .thenReturn(getBackfills())
@@ -156,16 +266,21 @@ class PostProcessingServiceRetryTest {
         postProcessingServiceMock.backfillEvent();
 
         assertFalse(postProcessingServiceMock.retryCache.isEmpty());
-        assertFalse(postProcessingServiceMock.errorMap.isEmpty());
-        assertEquals(errorMsg, postProcessingServiceMock.errorMap.get(123123L));
+        assertFalse(datamartProcessor.retryCache.isEmpty());
+        assertFalse(datamartProcessor.errorMap.isEmpty());
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(123123L));
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(123456L));
 
         postProcessingServiceMock.processRetryCache();
         verify(postProcRepositoryMock).executeStoredProcForBackfill(
                 null, null, 123123L, errorMsg, STATUS_SUSPENDED, 0);
 
+        datamartProcessor.processRetryCache();
+        verify(postProcRepositoryMock).executeStoredProcForBackfill(
+                null, null, 123456L, errorMsg, STATUS_SUSPENDED, 0);
+
         postProcessingServiceMock.backfillEvent();
         assertTrue(postProcessingServiceMock.retryCache.isEmpty());
-
     }
 
     @Test
@@ -181,11 +296,10 @@ class PostProcessingServiceRetryTest {
 
         assertFalse(postProcessingServiceMock.retryCache.isEmpty());
         Long batchId = postProcessingServiceMock.retryCache.entrySet().iterator().next().getKey();
-        assertEquals(errorMsg, postProcessingServiceMock.errorMap.get(batchId));
+        assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
     }
 
     private List<BackfillData> getBackfills() {
-        List<BackfillData> backfills = new ArrayList<>();
         BackfillData backfill = new BackfillData();
         backfill.setRecordKey(12L);
         backfill.setBatchId(123123L);
@@ -195,8 +309,16 @@ class PostProcessingServiceRetryTest {
         backfill.setErrDescription(errorMsg);
         backfill.setRetryCount(2);
 
-        backfills.add(backfill);
-        return backfills;
+        BackfillData backfillDm = new BackfillData();
+        backfillDm.setRecordKey(13L);
+        backfillDm.setBatchId(123456L);
+        backfillDm.setEntity("DM^"+Entity.GENERIC_CASE.getEntityName());
+        backfillDm.setRecordUidList("patient:100123 investigation:123124");
+        backfillDm.setStatusCd(STATUS_READY);
+        backfillDm.setErrDescription(errorMsg);
+        backfillDm.setRetryCount(2);
+
+        return new ArrayList<>(List.of(backfill, backfillDm));
     }
 
     protected List<DatamartData> getDatamartErr() {


### PR DESCRIPTION
## Notes

Enhancing RTR post-processing by adding error handling for datamarts execution.
- The majority of datamart processing logic moved to `ProcessDatamartData` component
- Unit tests updated to cover datamarts retry and backfill processing

## JIRA

- **Related story**: [CNDE-3064](url)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [x] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?