### PR TITLE
CNDE-1752: Update notification history ordering

### DIFF
--- a/liquibase-service/src/main/resources/db/003-odse/routines/018-sp_public_health_case_fact_datamart_event-001.sql
+++ b/liquibase-service/src/main/resources/db/003-odse/routines/018-sp_public_health_case_fact_datamart_event-001.sql
@@ -1601,15 +1601,15 @@ BEGIN
             MIN(ADD_TIME) AS FIRSTNOTIFICATIONDATE
                       ,
                       --DONE
-            MAX(CASE
+            NULLIF(MAX(CASE
                     WHEN version_ctrl_nbr != 1 THEN -1
                     ELSE add_user_id
-                END) AS FIRSTNOTIFICATIONSUBMITTEDBY,
+                END), -1) AS FIRSTNOTIFICATIONSUBMITTEDBY,
                       --DONE
-            MAX(CASE
+            NULLIF(MAX(CASE
                     WHEN notif_latest_rownum != 1 THEN -1
                     ELSE last_chg_user_id
-                END) AS LASTNOTIFICATIONSUBMITTEDBY
+                END), -1) AS LASTNOTIFICATIONSUBMITTEDBY
                       --DONE
                       --MIN(CASE WHEN RECORD_STATUS_CD='COMPLETED' THEN  LAST_CHG_USER_ID END) AS FIRSTNOTIFICATIONSUBMITTEDBY,
                       ,MIN(CASE

--- a/liquibase-service/src/main/resources/db/003-odse/views/004-v_notification_hist-001.sql
+++ b/liquibase-service/src/main/resources/db/003-odse/views/004-v_notification_hist-001.sql
@@ -150,14 +150,14 @@ SELECT DISTINCT
             THEN RPT_SENT_TIME
     END) AS last_notification_send_date
     ,MIN(ADD_TIME) AS first_notification_date
-    ,MAX(CASE
+    ,NULLIF(MAX(CASE
             WHEN version_ctrl_nbr != 1 THEN -1
             ELSE add_user_id
-        END) AS first_notification_submitted_by
-    ,MAX(CASE
+        END), -1) AS first_notification_submitted_by
+    ,NULLIF(MAX(CASE
             WHEN notif_latest_rownum != 1 THEN -1
             ELSE last_chg_user_id
-        END) AS last_notification_submitted_by
+        END), -1) AS last_notification_submitted_by
     ,MIN(CASE
             WHEN RECORD_STATUS_CD = 'COMPLETED' AND RPT_SENT_TIME IS NOT NULL
             THEN RPT_SENT_TIME


### PR DESCRIPTION
## Notes

This PR updates the way `first_notification_submitted_by` and `last_notification_submitted_by` are calculated, using partitioning over `version_control_nbr`.

This occurs in two places: 
- `NBS_ODSE.dbo.sp_public_health_case_fact_datamart_event`
- `NBS_ODSE.dbo.v_notification_hist`

The logic from `v_notification_hist` is not reused in `NBS_ODSE.dbo.sp_public_health_case_fact_datamart_event`, because that stored procedure needs the individual queries that make up the CTEs used in the view to be materialized in temp tables.

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-1752)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?