### PR TITLE
CNDE-2722: Order HEP100 to be only after Hepatitis_Case in postprocessing

### DIFF
--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/InvestigationRepository.java
@@ -59,6 +59,9 @@ public interface InvestigationRepository extends JpaRepository<DatamartData, Lon
     @Query(value = "EXEC sp_hepatitis_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForHepatitisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
+    @Query(value = "EXEC sp_hep100_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
+    List<DatamartData> executeStoredProcForHep100(@Param("publicHealthCaseUids") String publicHealthCaseUids);
+
     @Query(value = "EXEC sp_pertussis_case_datamart_postprocessing :publicHealthCaseUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForPertussisCaseDatamart(@Param("publicHealthCaseUids") String publicHealthCaseUids);
 
@@ -175,4 +178,5 @@ public interface InvestigationRepository extends JpaRepository<DatamartData, Lon
 
     @Query(value = "EXEC sp_covid_lab_celr_datamart_postprocessing :observationUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForCovidLabCelrDatamart(@Param("observationUids") String observationUids);
+
 }

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PostProcRepository.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PostProcRepository.java
@@ -65,13 +65,6 @@ public interface PostProcRepository extends JpaRepository<DatamartData, Long> {
     @Query(value = "EXEC sp_f_contact_record_case_postprocessing :contactUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForFContactRecordCase(@Param("contactUids") String contactUids);
 
-    @Procedure("sp_hep100_datamart_postprocessing")
-    void executeStoredProcForHep100(
-            @Param("publicHealthCaseUids") String publicHealthCaseUids,
-            @Param("patientUids") String patientUids,
-            @Param("providerUids") String providerUids,
-            @Param("organizationUids") String organizationUids);
-
     @Query(value = "exec sp_nrt_treatment_postprocessing :treatmentUids", nativeQuery = true)
     List<DatamartData> executeStoredProcForTreatment(@Param("treatmentUids") String treatmentUids);
 

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/Entity.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/Entity.java
@@ -47,6 +47,7 @@ enum Entity {
     BMIRD_CASE(0, "BMIRD_Case", Constants.PHC_UID, "sp_bmird_case_datamart_postprocessing"),
     HEPATITIS_CASE(0, "Hepatitis_Case", Constants.PHC_UID, "sp_hepatitis_case_datamart_postprocessing"),
     PERTUSSIS_CASE(0, "Pertussis_Case", Constants.PHC_UID, "sp_pertussis_case_datamart_postprocessing"),
+    HEP100(0, "HEP100", Constants.PHC_UID, "sp_hep100_datamart_postprocessing"),
     BMIRD_STREP_PNEUMO_DATAMART(0, "Bmird_Strep_Pneumo_Datamart", Constants.PHC_UID, "sp_bmird_strep_pneumo_datamart_postprocessing"),
     D_TB_HIV(0, "d_tb_hiv", Constants.PHC_UID, "sp_nrt_d_tb_hiv_postprocessing"),
     D_GT_12_REAS(0, "d_gt_12_reas", Constants.PHC_UID, "sp_nrt_d_gt_12_reas_postprocessing"),

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/ProcessDatamartData.java
@@ -230,6 +230,8 @@ public class ProcessDatamartData {
             case HEPATITIS_CASE:
                 executeDmProc(HEPATITIS_CASE,
                         invRepository::executeStoredProcForHepatitisCaseDatamart, cases, this::checkResult);
+                executeDmProc(HEP100,
+                        invRepository::executeStoredProcForHep100, cases, this::checkResult);
                 processLdfLegacy(ldfType, cases);
                 break;
             case PERTUSSIS_CASE:
@@ -339,17 +341,10 @@ public class ProcessDatamartData {
             String provString = listToParameterString(dmMulti.get(PROVIDER.getEntityName()));
             String orgString = listToParameterString(dmMulti.get(ORGANIZATION.getEntityName()));
 
-            int totalLengthHep100 = invString.length() + patString.length() + provString.length() + orgString.length();
             int totalLengthInvSummary = invString.length() + notifString.length() + obsString.length();
             int totalLengthMorbReportDM = obsString.length() + patString.length() + provString.length() + orgString.length() + invString.length();
 
             try {
-                if (totalLengthHep100 > 0) {
-                    procRepository.executeStoredProcForHep100(invString, patString, provString, orgString);
-                } else {
-                    logger.info("No updates to HEP100 Datamart");
-                }
-
                 if (totalLengthInvSummary > 0) {
                     //reusing the same DTO class for Dynamic Marts
                     List<DatamartData> dmDataList = procRepository.executeStoredProcForInvSummaryDatamart(invString, notifString, obsString);

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceDmTest.java
@@ -300,14 +300,18 @@ class PostProcessingServiceDmTest {
                 new DatamartTestCase(
                         "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\"," +
                                 "\"datamart\":\"Hepatitis_Case\",\"stored_procedure\":\"sp_hepatitis_case_datamart_postprocessing\"}}",
-                        HEPATITIS_CASE.getEntityName(), HEPATITIS_CASE.getStoredProcedure(), 3,
-                        repo -> verify(repo).executeStoredProcForHepatitisCaseDatamart("123")),
+                        HEPATITIS_CASE.getEntityName(), HEP100.getStoredProcedure(), 5,
+                        repo -> {
+                            verify(repo).executeStoredProcForHepatitisCaseDatamart("123");
+                            verify(repo).executeStoredProcForHep100("123");
+                        }),
                 new DatamartTestCase(
                         "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\"," +
                                 "\"datamart\":\"Hepatitis_Case,LDF_HEPATITIS\",\"stored_procedure\":\"sp_hepatitis_case_datamart_postprocessing\"}}",
-                        "Hepatitis_Case,LDF_HEPATITIS", LDF_HEPATITIS.getStoredProcedure(), 5,
+                        "Hepatitis_Case,LDF_HEPATITIS", LDF_HEPATITIS.getStoredProcedure(), 7,
                         repo -> {
                             verify(repo).executeStoredProcForHepatitisCaseDatamart("123");
+                            verify(repo).executeStoredProcForHep100("123");
                             verify(repo).executeStoredProcForLdfHepatitisDatamart("123");
                         }),
                 new DatamartTestCase(
@@ -350,47 +354,6 @@ class PostProcessingServiceDmTest {
     }
 
     @Test
-    void testPostProcessHep100() {
-
-        String investigationKey1 = "{\"payload\":{\"public_health_case_uid\":126}}";
-        String investigationKey2 = "{\"payload\":{\"public_health_case_uid\":235}}";
-        String patientKey = "{\"payload\":{\"patient_uid\":127}}";
-        String providerKey = "{\"payload\":{\"provider_uid\":130}}";
-        String organizationKey = "{\"payload\":{\"organization_uid\":123}}";
-
-
-        String invTopic = "dummy_investigation";
-        String patTopic = "dummy_patient";
-        String provTopic = "dummy_provider";
-        String orgTopic = "dummy_organization";
-
-        postProcessingServiceMock.processNrtMessage(invTopic, investigationKey1, investigationKey1);
-        postProcessingServiceMock.processNrtMessage(invTopic, investigationKey2, investigationKey2);
-        postProcessingServiceMock.processNrtMessage(patTopic, patientKey, patientKey);
-        postProcessingServiceMock.processNrtMessage(provTopic, providerKey, providerKey);
-        postProcessingServiceMock.processNrtMessage(orgTopic, organizationKey, organizationKey);
-
-        postProcessingServiceMock.processCachedIds();
-        postProcessingServiceMock.processDatamartIds();
-
-        verify(postProcRepositoryMock).executeStoredProcForHep100("126,235", "127", "130", "123");
-    }
-
-    @Test
-    void testPostProcessHep100NoIds() {
-        // Test with an event that doesn't trigger the Hep100 datamart procedure
-        String contactKey = "{\"payload\":{\"contact_uid\":123}}";
-        String crTopic = "dummy_contact";
-        postProcessingServiceMock.processNrtMessage(crTopic, contactKey, contactKey);
-        postProcessingServiceMock.processCachedIds();
-        postProcessingServiceMock.processDatamartIds();
-
-        verify(postProcRepositoryMock, never()).executeStoredProcForHep100(any(),any(),any(),any());
-        List<ILoggingEvent> logs = listAppender.list;
-        assertEquals("No updates to HEP100 Datamart", logs.get(6).getFormattedMessage());
-    }
-
-    @Test
     void testPostProcessInvSummary() {
 
         String investigationKey = "{\"payload\":{\"public_health_case_uid\":126}}";
@@ -423,7 +386,7 @@ class PostProcessingServiceDmTest {
 
         verify(postProcRepositoryMock, never()).executeStoredProcForInvSummaryDatamart(any(),any(),any());
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals("No updates to INV_SUMMARY Datamart", logs.get(7).getFormattedMessage());
+        assertEquals("No updates to INV_SUMMARY Datamart", logs.get(6).getFormattedMessage());
     }
 
     @Test


### PR DESCRIPTION
## Notes

This PR introduces the following changes:
- Call `sp_hep100_datamart_postprocessing` only after `sp_hepatitis_case_datamart_postprocessing` has been called
- Change `sp_hep100_datamart_postprocessing` to only accept public health case uid's now that the other dimensions are processed separately

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2722)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?