### PR TITLE
CNDE-3096: Additional permissions to person and org service users

### DIFF
--- a/liquibase-service/src/main/resources/db/003-odse/routines/999-odse_database_object_permission_grants-001.sql
+++ b/liquibase-service/src/main/resources/db/003-odse/routines/999-odse_database_object_permission_grants-001.sql
@@ -80,9 +80,9 @@ IF EXISTS (SELECT * FROM sys.database_principals WHERE name = @OrgUserName)
         EXEC sp_executesql @GrantExecPHCDatamartUpdateSQL;
         PRINT 'Granted EXECUTE permission on [dbo].[sp_public_health_case_fact_datamart_update] to [' + @OrgUserName + ']';
 
-        DECLARE @GrantWritePHCFactSQL NVARCHAR(MAX) = 'GRANT INSERT, UPDATE, DELETE ON [dbo].[PublicHealthCaseFact] TO [' + @OrgUserName + ']';
+        DECLARE @GrantWritePHCFactSQL NVARCHAR(MAX) = 'GRANT UPDATE ON [dbo].[PublicHealthCaseFact] TO [' + @OrgUserName + ']';
         EXEC sp_executesql @GrantWritePHCFactSQL;
-        PRINT 'Granted write permissions on [dbo].[PublicHealthCaseFact] to [' + @OrgUserName + ']';
+        PRINT 'Granted UPDATE permissions on [dbo].[PublicHealthCaseFact] to [' + @OrgUserName + ']';
     END
 PRINT 'Organization service user permission grants completed.';
 
@@ -121,14 +121,13 @@ IF EXISTS (SELECT * FROM sys.database_principals WHERE name = @PersonUserName)
         EXEC sp_executesql @GrantExecPHCDatamartUpdateSQL;
         PRINT 'Granted EXECUTE permission on [dbo].[sp_public_health_case_fact_datamart_update] to [' + @PersonUserName + ']';
 
-        -- Grant write permissions on specific tables for investigation service
-        DECLARE @GrantWriteSubjectRaceSQL NVARCHAR(MAX) = 'GRANT INSERT, UPDATE, DELETE ON [dbo].[SubjectRaceInfo] TO [' + @PersonUserName + ']';
+        DECLARE @GrantWriteSubjectRaceSQL NVARCHAR(MAX) = 'GRANT UPDATE ON [dbo].[SubjectRaceInfo] TO [' + @PersonUserName + ']';
         EXEC sp_executesql @GrantWriteSubjectRaceSQL;
-        PRINT 'Granted write permissions on [dbo].[SubjectRaceInfo] to [' + @PersonUserName + ']';
+        PRINT 'Granted UPDATE permissions on [dbo].[SubjectRaceInfo] to [' + @PersonUserName + ']';
 
-        DECLARE @GrantWritePHCFactSQL NVARCHAR(MAX) = 'GRANT INSERT, UPDATE, DELETE ON [dbo].[PublicHealthCaseFact] TO [' + @PersonUserName + ']';
+        DECLARE @GrantWritePHCFactSQL NVARCHAR(MAX) = 'GRANT UPDATE ON [dbo].[PublicHealthCaseFact] TO [' + @PersonUserName + ']';
         EXEC sp_executesql @GrantWritePHCFactSQL;
-        PRINT 'Granted write permissions on [dbo].[PublicHealthCaseFact] to [' + @PersonUserName + ']';
+        PRINT 'Granted UPDATE permissions on [dbo].[PublicHealthCaseFact] to [' + @PersonUserName + ']';
     END
 
 PRINT 'Person service user permission grants completed.';


### PR DESCRIPTION
## Notes

This PR updates permissions for pre-processing service users.

- **investigation_service_rdb**: `sp_public_health_case_fact_datamart_update`
- **organization_service_rdb**: `sp_public_health_case_fact_datamart_update` + `PublicHealthCaseFact`
- **person_service_rdb**: `sp_public_health_case_fact_datamart_update` + `PublicHealthCaseFact` + `SubjectRaceInfo`


## JIRA

- **Related story**: [CNDE-3096](https://cdc-nbs.atlassian.net/browse/CNDE-3096)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?