### PR TITLE
CNDE-3138: Add feature flag to disable PHCF datamart

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -77,6 +77,9 @@ public class InvestigationService {
     @Value("${spring.kafka.output.topic-name-reporting}")
     private String investigationTopicReporting;
 
+    @Value("${featureFlag.phc-datamart-disable}")
+    private boolean phcDatamartDisable;
+
     private final InvestigationRepository investigationRepository;
     private final NotificationRepository notificationRepository;
     private final InterviewRepository interviewRepository;
@@ -172,7 +175,9 @@ public class InvestigationService {
             try {
                 final String phcUid = publicHealthCaseUid = extractUid(value, "public_health_case_uid");
 
-                CompletableFuture.runAsync(() -> processDataUtil.processPhcFactDatamart(phcUid), phcExecutor);
+                if (!phcDatamartDisable) {
+                    CompletableFuture.runAsync(() -> processDataUtil.processPhcFactDatamart(phcUid), phcExecutor);
+                }
 
                 logger.info(topicDebugLog, "Investigation", publicHealthCaseUid, investigationTopic);
                 Optional<Investigation> investigationData = investigationRepository.computeInvestigations(publicHealthCaseUid);
@@ -237,7 +242,9 @@ public class InvestigationService {
         try {
             final String notfUid = notificationUid = extractUid(value, "notification_uid");
 
-            CompletableFuture.runAsync(() -> processDataUtil.processPhcFactDatamart("NOTF", notfUid), phcExecutor);
+            if (!phcDatamartDisable) {
+                CompletableFuture.runAsync(() -> processDataUtil.processPhcFactDatamart("NOTF", notfUid), phcExecutor);
+            }
 
             logger.info(topicDebugLog, "Notification", notificationUid, notificationTopic);
 

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -46,6 +46,8 @@ spring:
     url: ${DB_ODSE_URL:jdbc:sqlserver://${DB_SERVER:localhost:1433};databaseName=:NBS_ODSE;encrypt=true;trustServerCertificate=true;}
   liquibase:
     change-log: db/changelog/db.changelog-master.yaml
+featureFlag:
+  phc-datamart-disable: ${FF_PHC_DM_DISABLE:false}
 server:
   port: '8093'
 

--- a/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/service/OrganizationService.java
+++ b/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/service/OrganizationService.java
@@ -66,6 +66,9 @@ public class OrganizationService {
     @Value("${featureFlag.elastic-search-enable}")
     private boolean elasticSearchEnable;
 
+    @Value("${featureFlag.phc-datamart-disable}")
+    private boolean phcDatamartDisable;
+
     private final OrgRepository orgRepository;
     private final PlaceRepository placeRepository;
     private final DataTransformers transformer;
@@ -133,7 +136,9 @@ public class OrganizationService {
                 final String orgUid = organizationUid = extractUid(message, "organization_uid");
                 log.info(topicDebugLog, "Organization", organizationUid, topic);
 
-                CompletableFuture.runAsync(() -> processPhcFactDatamart(orgUid), rtrExecutor);
+                if (!phcDatamartDisable) {
+                    CompletableFuture.runAsync(() -> processPhcFactDatamart(orgUid), rtrExecutor);
+                }
 
                 Set<OrganizationSp> organizations = orgRepository.computeAllOrganizations(organizationUid);
                 if (organizations.isEmpty()) {

--- a/organization-service/src/main/resources/application.yaml
+++ b/organization-service/src/main/resources/application.yaml
@@ -38,6 +38,7 @@ spring:
     change-log: db/changelog/db.changelog-master.yaml
 featureFlag:
   elastic-search-enable: ${FF_ES_ENABLE:false}
+  phc-datamart-disable: ${FF_PHC_DM_DISABLE:false}
 server:
   port: '8092'
 

--- a/organization-service/src/test/java/gov/cdc/etldatapipeline/organization/service/OrganizationServiceTest.java
+++ b/organization-service/src/test/java/gov/cdc/etldatapipeline/organization/service/OrganizationServiceTest.java
@@ -194,6 +194,19 @@ class OrganizationServiceTest {
         assertTrue(log.getFormattedMessage().contains(ERROR_MSG));
     }
 
+    @Test
+    void testProcessPhcFactDatamartDisabled() {
+        OrganizationSp orgSp = new OrganizationSp();
+        orgSp.setOrganizationUid(10036000L);
+        when(orgRepository.computeAllOrganizations(anyString())).thenReturn(Set.of(orgSp));
+
+        String changeData = "{\"payload\": {\"after\": {\"organization_uid\": \"123456789\"}}}";
+        organizationService.setPhcDatamartDisable(true);
+        organizationService.processMessage(changeData, orgTopic);
+
+        verify(orgRepository, never()).updatePhcFact(anyString(), anyString());
+    }
+
     private void validateOrgTransformation() throws JsonProcessingException {
         String changeData = readFileData("orgcdc/OrgChangeData.json");
         String expectedKey = readFileData("orgtransformed/OrgKey.json");

--- a/person-service/src/main/java/gov/cdc/etldatapipeline/person/service/PersonService.java
+++ b/person-service/src/main/java/gov/cdc/etldatapipeline/person/service/PersonService.java
@@ -81,6 +81,9 @@ public class PersonService {
     @Value("${featureFlag.elastic-search-enable}")
     private boolean elasticSearchEnable;
 
+    @Value("${featureFlag.phc-datamart-disable}")
+    private boolean phcDatamartDisable;
+
     private static int nProc = Runtime.getRuntime().availableProcessors();
     private ExecutorService rtrExecutor = Executors.newFixedThreadPool(nProc*2, new CustomizableThreadFactory("rtr-"));
 
@@ -179,7 +182,9 @@ public class PersonService {
                 .map(ProviderSp::getPersonUid).map(String::valueOf)
                 .collect(Collectors.joining(","));
 
-        CompletableFuture.runAsync(() -> processPhcFactDatamart("PRV", uids), rtrExecutor);
+        if (!phcDatamartDisable) {
+            CompletableFuture.runAsync(() -> processPhcFactDatamart("PRV", uids), rtrExecutor);
+        }
 
         providerData.forEach(provider -> {
             String reportingKey = transformer.buildProviderKey(provider);
@@ -204,7 +209,9 @@ public class PersonService {
                 .map(PatientSp::getPersonUid).map(String::valueOf)
                 .collect(Collectors.joining(","));
 
-        CompletableFuture.runAsync(() -> processPhcFactDatamart("PAT", uids), rtrExecutor);
+        if (!phcDatamartDisable) {
+            CompletableFuture.runAsync(() -> processPhcFactDatamart("PAT", uids), rtrExecutor);
+        }
 
         patientData.forEach(personData -> {
             String reportingKey = transformer.buildPatientKey(personData);

--- a/person-service/src/main/resources/application.yaml
+++ b/person-service/src/main/resources/application.yaml
@@ -40,6 +40,7 @@ spring:
     change-log: db/changelog/db.changelog-master.yaml
 featureFlag:
   elastic-search-enable: ${FF_ES_ENABLE:false}
+  phc-datamart-disable: ${FF_PHC_DM_DISABLE:false}
 server:
   port: '8091'
 

--- a/person-service/src/test/java/gov/cdc/etldatapipeline/person/service/PersonServiceTest.java
+++ b/person-service/src/test/java/gov/cdc/etldatapipeline/person/service/PersonServiceTest.java
@@ -194,6 +194,31 @@ class PersonServiceTest {
     }
 
     @Test
+    void testProcessPatientDataPhcFactDisabled() {
+        PatientSp patientSp = PatientSp.builder().personUid(10000001L).build();
+        Mockito.when(patientRepository.computePatients(anyString())).thenReturn(List.of(patientSp));
+
+        String patientData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
+
+        personService.setPhcDatamartDisable(true);
+        personService.processMessage(patientData, inputTopicPerson);
+        verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
+    }
+
+    @Test
+    void testProcessProviderDataPhcFactDisabled() {
+        ProviderSp providerSp = ProviderSp.builder().personUid(10000001L).build();
+        Mockito.when(patientRepository.computePatients(anyString())).thenReturn(new ArrayList<>());
+        Mockito.when(providerRepository.computeProviders(anyString())).thenReturn(List.of(providerSp));
+
+        String providerData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PRV\"}}}";
+
+        personService.setPhcDatamartDisable(true);
+        personService.processMessage(providerData, inputTopicPerson);
+        verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
+    }
+
+    @Test
     void testProcessUserData() throws JsonProcessingException {
         String payload = "{\"payload\": {\"after\": {\"auth_user_uid\": \"11\"}}}";
 


### PR DESCRIPTION
## Notes

Introduces a feature to bypass PHCF stored procedure(s) execution. Applies to
- investigation-service
- organizrion-service
- person-service

## JIRA

- **Related story**: [CNDE-3138](https://cdc-nbs.atlassian.net/browse/CNDE-3138)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?