### PR TITLE
Add the max.poll.records as a configurable parameter to the kafka consumer micro-services

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConsumerConfig.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConsumerConfig.java
@@ -29,6 +29,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -34,6 +34,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 300000
+      maxPollRecs: 200
       enable-auto-commit: false
     admin:
       auto-create: true

--- a/investigation-service/src/main/resources/application.yaml
+++ b/investigation-service/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 300000
-      maxPollRecs: 200
+      maxPollRecs: ${KAFKA_CONSUMER_MAX_POLL_RECS:200}
       enable-auto-commit: false
     admin:
       auto-create: true

--- a/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/config/KafkaConsumerConfig.java
+++ b/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/config/KafkaConsumerConfig.java
@@ -29,6 +29,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 

--- a/ldfdata-service/src/main/resources/application.yaml
+++ b/ldfdata-service/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
-      maxPollRecs: 200
+      maxPollRecs: ${KAFKA_CONSUMER_MAX_POLL_RECS:200}
     admin:
       auto-create: true
   application:

--- a/ldfdata-service/src/main/resources/application.yaml
+++ b/ldfdata-service/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
+      maxPollRecs: 200
     admin:
       auto-create: true
   application:

--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConsumerConfig.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConsumerConfig.java
@@ -29,6 +29,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 

--- a/observation-service/src/main/resources/application.yaml
+++ b/observation-service/src/main/resources/application.yaml
@@ -21,6 +21,7 @@ spring:
     consumer:
         max-retry: 3
         maxPollIntervalMs: 30000
+        maxPollRecs: 200
     admin:
       auto-create: true
   application:

--- a/observation-service/src/main/resources/application.yaml
+++ b/observation-service/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ spring:
     consumer:
         max-retry: 3
         maxPollIntervalMs: 30000
-        maxPollRecs: 200
+        maxPollRecs: ${KAFKA_CONSUMER_MAX_POLL_RECS:200}
     admin:
       auto-create: true
   application:

--- a/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/config/KafkaConsumerConfig.java
+++ b/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/config/KafkaConsumerConfig.java
@@ -29,6 +29,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 

--- a/organization-service/src/main/resources/application.yaml
+++ b/organization-service/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
-      maxPollRecs: 200
+      maxPollRecs: ${KAFKA_CONSUMER_MAX_POLL_RECS:200}
       key-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     admin:

--- a/organization-service/src/main/resources/application.yaml
+++ b/organization-service/src/main/resources/application.yaml
@@ -24,6 +24,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
+      maxPollRecs: 200
       key-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     admin:

--- a/person-service/src/main/java/gov/cdc/etldatapipeline/person/config/KafkaConsumerConfig.java
+++ b/person-service/src/main/java/gov/cdc/etldatapipeline/person/config/KafkaConsumerConfig.java
@@ -29,6 +29,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 

--- a/person-service/src/main/resources/application.yaml
+++ b/person-service/src/main/resources/application.yaml
@@ -26,6 +26,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
+      maxPollRecs: 200
       key-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     admin:

--- a/person-service/src/main/resources/application.yaml
+++ b/person-service/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ spring:
     consumer:
       max-retry: 3
       maxPollIntervalMs: 30000
-      maxPollRecs: 200
+      maxPollRecs: ${KAFKA_CONSUMER_MAX_POLL_RECS:200}
       key-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     admin:

--- a/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/config/KafkaConsumerConfig.java
+++ b/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/config/KafkaConsumerConfig.java
@@ -30,6 +30,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 
+    @Value("${spring.kafka.consumer.maxPollRecs}")
+    private String maxPollRecords = "";
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         final Map<String, Object> config = new HashMap<>();
@@ -38,6 +41,7 @@ public class KafkaConsumerConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
+        config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 


### PR DESCRIPTION
Add the max.poll.records as a configurable parameter to the kafka consumer micro-services