### PR TITLE
CNDE-3152: Configurable thread pool for OrganizationService

### DIFF
--- a/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/service/OrganizationService.java
+++ b/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/service/OrganizationService.java
@@ -83,7 +83,7 @@ public class OrganizationService {
     private ExecutorService orgExecutor;
 
     private static String topicDebugLog = "Received {} with id: {} from topic: {}";
-    private static String ORG = "Organization";
+    private static String organization = "Organization";
 
     private static final String SERVICE_NAME = "organization-reporting";
 
@@ -144,7 +144,7 @@ public class OrganizationService {
             String organizationUid = "";
             try {
                 final String orgUid = organizationUid = extractUid(message, "organization_uid");
-                log.info(topicDebugLog, ORG, organizationUid, topic);
+                log.info(topicDebugLog, organization, organizationUid, topic);
 
                 if (!phcDatamartDisable) {
                     CompletableFuture.runAsync(() -> processPhcFactDatamart(orgUid), rtrExecutor);
@@ -176,7 +176,7 @@ public class OrganizationService {
                 throw new NoDataException(ex.getMessage(), ex);
             } catch (Exception e) {
                 msgFailure.increment();
-                throw new DataProcessingException(errorMessage(ORG, organizationUid, e), e);
+                throw new DataProcessingException(errorMessage(organization, organizationUid, e), e);
             }
         },"service", SERVICE_NAME);
     }

--- a/organization-service/src/main/resources/application.yaml
+++ b/organization-service/src/main/resources/application.yaml
@@ -40,6 +40,8 @@ spring:
 featureFlag:
   elastic-search-enable: ${FF_ES_ENABLE:false}
   phc-datamart-disable: ${FF_PHC_DM_DISABLE:false}
+  thread-pool-size: ${FF_THREAD_POOL_SIZE:1}
+
 server:
   port: '8092'
 


### PR DESCRIPTION
## Notes

Introduce a configurable thread pool for the RTR Organization pre-processing service to allow parallel execution of organization data processing tasks.

## JIRA

- **Related story**: [CNDE-3152](https://cdc-nbs.atlassian.net/browse/CNDE-3152)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?