### PR TITLE
CNDE-3156: RTR - Kafka - Enable async acks for future-returning listeners

### DIFF
--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConsumerConfig.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConsumerConfig.java
@@ -51,6 +51,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAsyncAcks(true);
         return  factory;
     }
 }

--- a/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -15,7 +15,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.modelmapper.ModelMapper;
@@ -148,8 +147,7 @@ public class InvestigationService {
                     "${spring.kafka.input.topic-name-ar}"
             }
     )
-    public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> rec,
-                               Consumer<?,?> consumer) {
+    public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> rec) {
         final String topic = rec.topic();
         final String message = rec.value();
         final long batchId = toBatchId.applyAsLong(rec);
@@ -172,11 +170,7 @@ public class InvestigationService {
                 } else if (topic.equals(actRelationshipTopic) && message != null) {
                     processActRelationship(message);
                 }
-            }, invExecutor).whenComplete((res, ex) -> {
-                if (ex == null) {
-                    consumer.commitSync();
-                }
-            });
+            }, invExecutor);
     }
 
     public void processInvestigation(String value, long batchId) {

--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConsumerConfig.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConsumerConfig.java
@@ -51,6 +51,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAsyncAcks(true);
         return  factory;
     }
 }

--- a/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/config/KafkaConsumerConfig.java
+++ b/organization-service/src/main/java/gov/cdc/etldatapipeline/organization/config/KafkaConsumerConfig.java
@@ -51,6 +51,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAsyncAcks(true);
         return  factory;
     }
 }

--- a/person-service/src/main/java/gov/cdc/etldatapipeline/person/config/KafkaConsumerConfig.java
+++ b/person-service/src/main/java/gov/cdc/etldatapipeline/person/config/KafkaConsumerConfig.java
@@ -51,6 +51,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAsyncAcks(true);
         return  factory;
     }
 }


### PR DESCRIPTION
## Notes

Spring Kafka warns when a `@KafkaListener` returns `Future/CompletableFuture` but the container is not configured for async acks, leading to immediate ack before async work completes.
Set `factory.getContainerProperties().setAsyncAcks(true)` on the kafkaListenerContainerFactory to defer commits until the future completes.

## JIRA

- **Related story**: [CNDE-3156](https://cdc-nbs.atlassian.net/browse/CNDE-3156)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?