### PR TITLE
APP-299: Resolve NULL for D_ORGANIZATION in RTR

### DIFF
--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/051-sp_organization_event-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/051-sp_organization_event-001.sql
@@ -144,8 +144,8 @@ BEGIN
                                                   ei.assigning_authority_cd,
                                                   case
                                                       when (ei.type_cd = 'FI' and ei.assigning_authority_cd is not null)
-                                                          then (select *
-                                                                from dbo.fn_get_value_by_cvg(ei.assigning_authority_cd, 'EI_AUTH_ORG'))
+                                                          then COALESCE(NULLIF(TRIM((select *
+                                                                from dbo.fn_get_value_by_cvg(ei.assigning_authority_cd, 'EI_AUTH_ORG'))), ''), ei.assigning_authority_cd)
                                                       end             as facility_id_auth
                                            FROM nbs_odse.dbo.Entity_id ei WITH (NOLOCK)
                                            WHERE ei.entity_uid = o.organization_uid


### PR DESCRIPTION
This fix combines both Eli and Michael's approaches in order to cover both a missing entry in CVG _and_ an empty string in CVG. Just the `COALESCE` would likely work, but a little extra caution couldn't hurt.

## JIRA

- **Related story**: [APP-299](https://cdc-nbs.atlassian.net/browse/APP-299)

## Checklist

- [x] PR focuses on a single story.
- [x] Service has been tested in local and it works as expected.

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix

## Testing

I manually reproduced this bug by creating an Organization in the UI and examining the result in RDB_MODERN. Then, I updated the stored procedure with this fix, and verified that creating a new Organization resulted in this column being populated.

Side note: of the various types of "Identification," in the Organization edit flow, this _must_ be a "Facility Id." Per the CASE statement in the line above where I've added this fix, no other ID type will be populated into these columns.