### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/Build-and-deploy-reporting-services.yaml
+++ b/.github/workflows/Build-and-deploy-reporting-services.yaml
@@ -5,6 +5,7 @@ on:
       - main
       - master
       - rel-**
+      - meh/dep-updates
     #      Uncomment the following line only to test the build and deploy from private branches.
     #      - CNDIT-*
     #      - CNDE-*

--- a/.github/workflows/Build-and-deploy-reporting-services.yaml
+++ b/.github/workflows/Build-and-deploy-reporting-services.yaml
@@ -5,7 +5,6 @@ on:
       - main
       - master
       - rel-**
-      - meh/dep-updates
     #      Uncomment the following line only to test the build and deploy from private branches.
     #      - CNDIT-*
     #      - CNDE-*

--- a/common-util/build.gradle
+++ b/common-util/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -48,6 +48,12 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator'
+}
+
+dependencyManagement {
+    dependencies {
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+    }
 }
 
 tasks.named('test') {

--- a/investigation-service/build.gradle
+++ b/investigation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -50,7 +50,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.kafka:spring-kafka:3.3.1'
-    implementation 'org.apache.kafka:kafka-clients:3.9.1'
+    implementation 'org.apache.kafka:kafka-clients:3.9.2'
     implementation 'org.apache.kafka:connect-api:3.9.1'
 
     implementation 'io.debezium:debezium-core:2.4.1.Final'
@@ -85,9 +85,10 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
     }
 }
 

--- a/ldfdata-service/build.gradle
+++ b/ldfdata-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '3.5.6'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'jacoco'
 	id 'org.sonarqube' version '4.2.1.3168'
@@ -78,10 +78,12 @@ dependencies {
 
 dependencyManagement {
 	dependencies {
-		dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-		dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-		dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
-	}
+		dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+		dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+		dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+        dependency 'org.apache.kafka:kafka-clients:3.9.2'
+    }
 }
 
 tasks.named('test') {

--- a/liquibase-service/build.gradle
+++ b/liquibase-service/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.liquibase.gradle' version '2.2.2'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -53,9 +53,10 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
     }
 }
 

--- a/observation-service/build.gradle
+++ b/observation-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -79,9 +79,11 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+        dependency 'org.apache.kafka:kafka-clients:3.9.2'
     }
 }
 

--- a/organization-service/build.gradle
+++ b/organization-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -77,9 +77,11 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+        dependency 'org.apache.kafka:kafka-clients:3.9.2'
     }
 }
 

--- a/person-service/build.gradle
+++ b/person-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -80,9 +80,11 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+        dependency 'org.apache.kafka:kafka-clients:3.9.2'
     }
 }
 

--- a/post-processing-service/build.gradle
+++ b/post-processing-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -101,9 +101,11 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
+        dependency 'org.apache.kafka:kafka-clients:3.9.2'
     }
 }
 

--- a/reporting-hydration-service/build.gradle
+++ b/reporting-hydration-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '4.2.1.3168'
@@ -52,7 +52,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.kafka:spring-kafka:3.3.1'
-    implementation 'org.apache.kafka:kafka-clients:3.9.1'
+    implementation 'org.apache.kafka:kafka-clients:3.9.2'
     implementation 'org.apache.kafka:connect-api:3.9.1'
     implementation 'io.debezium:debezium-core:2.4.1.Final'
 
@@ -89,9 +89,10 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.10'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.10'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
+        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
+        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
     }
 }
 


### PR DESCRIPTION
## Description
Ensure our containers are not using dependencies that have been flagged by Trivy. Due to the short time frame I mainly used the dependency management plugin to control versions of the offending transitive dependencies instead of doing major version upgrades of the direct dependencies.

## Related Issue
https://github.com/CDCgov/NEDSS-DataReporting/security/code-scanning

## Additional Notes
`org.lz4:lz4-java` is no longer being maintained. CVE-2025-66566 is fixed in `at.yawk.lz4:lz4-java:1.10.1`, which we move to by bumping `kafka-clients` to `3.9.2`.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~I have updated the documentation, if applicable.~
- [ ] ~I have added or updated test cases to cover my changes, if applicable.~
 
