### PR TITLE
Fix topic name in Observation Service

### DIFF
--- a/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/service/ObservationService.java
+++ b/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/service/ObservationService.java
@@ -109,7 +109,7 @@ public class ObservationService {
         NoDataException.class
       })
   @KafkaListener(
-      topics = {"${spring.kafka.input.topic-name-person}", "${spring.kafka.input.topic-name-ar}"})
+      topics = {"${spring.kafka.input.topic-name}", "${spring.kafka.input.topic-name-ar}"})
   public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> rec) {
 
     long batchId = toBatchId.applyAsLong(rec);


### PR DESCRIPTION
## Description
The observation service is failing to start with the following error:
```
Could not resolve placeholder 'spring.kafka.input.topic-name-person' in value "${spring.kafka.input.topic-name-person}"
```
It looks like the topic name placeholder was accidentally changed in #696.

## Related Issue
#696 

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~I have updated the documentation, if applicable.~
- [ ] ~I have added or updated test cases to cover my changes, if applicable.~
 
