### PR TITLE
fix(kafka-connect): use correct password env var

### DIFF
--- a/containers/kafka-connect/initialize/mssql-connector.json
+++ b/containers/kafka-connect/initialize/mssql-connector.json
@@ -7,7 +7,7 @@
     "batch.size": "200",
     "connection.url": "${env:DB_URL}",
     "connection.user": "${env:DB_USERNAME}",
-    "connection.password": "${env:DB_USERNAME}",
+    "connection.password": "${env:DB_PASSWORD}",
     "connection.pool.min_size": "1",
     "connection.pool.max_size": "5",
     "connection.pool.acquire_increment": "1",


### PR DESCRIPTION
## Description
Update the mssql-connector configuration to use the DB_PASSWORD environment variable for authentication instead of incorrectly referencing DB_USERNAME.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
