### PR TITLE
[APP-455] update CI workflows to only build / test reporting pipeline service

### DIFF
--- a/.github/workflows/Build-and-deploy-reporting-services.yaml
+++ b/.github/workflows/Build-and-deploy-reporting-services.yaml
@@ -1,115 +1,38 @@
-name: Build and push data-reporting-service image to ECR
+name: Build and push reporting-pipeline-service image to ECR
 on:
   push:
     branches:
       - main
-      - master
       - rel-**
     #      Uncomment the following line only to test the build and deploy from private branches.
     #      - CNDIT-*
     #      - CNDE-*
-    paths-ignore:
-      - "docker-compose.yml"
-      - "**.md"
+    paths:
+      - "reporting-pipeline-service/**"
+      - "liquibase-service/**"
+      - "common-util/**"
+      - "build.gradle"
+      - "settings.gradle"
+      - "gradle/**"
+      - ".github/workflows/Build-and-deploy-reporting-services.yaml"
+
 jobs:
-  # person-reporting-microservice
-  call-build-person-reporting-microservice-container-workflow:
+  call-build-reporting-pipeline-service-container-workflow:
     permissions:
       id-token: write
       contents: read
       security-events: write
-    name: Build Person Reporting Service Container
+    name: Build Reporting Pipeline Service Container
     uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
     with:
-      microservice_name: nbs7-person-reporting
-      dockerfile_relative_path: -f ./person-service/Dockerfile .
+      microservice_name: nbs7-reporting-pipeline
+      dockerfile_relative_path: -f ./reporting-pipeline-service/Dockerfile .
       environment_classifier: SNAPSHOT
       java_version: "21"
     secrets:
       NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
 
-  # organization-reporting-microservice
-  call-build-organization-reporting-microservice-container-workflow:
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    name: Build Organization Reporting Service Container
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs7-organization-reporting
-      dockerfile_relative_path: -f ./organization-service/Dockerfile .
-      environment_classifier: SNAPSHOT
-      java_version: "21"
-    secrets:
-      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
-
-  # investigation-reporting-microservice
-  call-build-investigation-reporting-microservice-container-workflow:
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    name: Build Investigation Reporting Service Container
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs7-investigation-reporting
-      dockerfile_relative_path: -f ./investigation-service/Dockerfile .
-      environment_classifier: SNAPSHOT
-      java_version: "21"
-    secrets:
-      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
-
-  # post-processing-reporting-microservice
-  call-build-post-processing-reporting-microservice-container-workflow:
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    name: Build post-processing Reporting Service Container
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs7-post-processing-reporting
-      dockerfile_relative_path: -f ./post-processing-service/Dockerfile .
-      environment_classifier: SNAPSHOT
-      java_version: "21"
-    secrets:
-      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
-
-  # observation-reporting-microservice
-  call-build-observation-reporting-microservice-container-workflow:
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    name: Build Observation Reporting Service Container
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs7-observation-reporting
-      dockerfile_relative_path: -f ./observation-service/Dockerfile .
-      environment_classifier: SNAPSHOT
-      java_version: "21"
-    secrets:
-      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
-
-  # LdfData-reporting-microservice
-  call-build-ldfdata-reporting-microservice-container-workflow:
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    name: Build LdfData Reporting Service Container
-    uses: CDCgov/NEDSS-Workflows/.github/workflows/Build-gradle-microservice-container.yaml@main
-    with:
-      microservice_name: nbs7-ldf-data-reporting
-      dockerfile_relative_path: -f ./ldfdata-service/Dockerfile .
-      environment_classifier: SNAPSHOT
-      java_version: "21"
-    secrets:
-      NBS_ACCOUNTID: ${{secrets.NBS_ACCOUNTID}}
-
-  # liquibase-microservice
-  call-build-liquibase-microservice-container-workflow:
+  call-build-liquibase-service-container-workflow:
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/run-functional-tests.yaml
+++ b/.github/workflows/run-functional-tests.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run reporting-pipeline-service functional tests
+    name: Run functional tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -46,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: reporting-pipeline-service/build
+          path: reporting-pipeline-service/build/reports

--- a/.github/workflows/run-functional-tests.yaml
+++ b/.github/workflows/run-functional-tests.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - "reporting-pipeline-service/**"
+      - "liquibase-service/**"
+      - "common-util/**"
       - "build.gradle"
       - "settings.gradle"
       - "gradle/**"
@@ -10,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run functional tests
+    name: Run reporting-pipeline-service functional tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -44,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: ./**/build/reports
+          path: reporting-pipeline-service/build

--- a/.github/workflows/run-functional-tests.yaml
+++ b/.github/workflows/run-functional-tests.yaml
@@ -9,6 +9,7 @@ on:
       - "settings.gradle"
       - "gradle/**"
       - "docker-compose.yaml"
+      - ".github/workflows/**"
 
 jobs:
   pipeline:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,6 +9,7 @@ on:
       - "settings.gradle"
       - "gradle/**"
       - "docker-compose.yaml"
+      - ".github/workflows/**"
 
 jobs:
   pipeline:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run reporting-pipeline-service JUnit tests
+    name: Run JUnit tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -46,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: reporting-pipeline-service/build
+          path: reporting-pipeline-service/build/reports

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -40,11 +40,11 @@ jobs:
       - name: Build and analyze
         working-directory: ./
         run: |
-          ./gradlew clean reporting-pipeline-service:test reporting-pipeline-service:jacocoTestReport --continue
+          ./gradlew clean build jacocoTestReport --continue
 
       - name: Publish Testing Reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: reporting-pipeline-service/build/reports
+          path: ./**/build/reports

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,13 +2,9 @@ name: Application Tests
 on:
   pull_request:
     paths:
-      - "investigation-service/**"
-      - "ldfdata-service/**"
-      - "person-service/**"
       - "reporting-pipeline-service/**"
-      - "post-processing-service/**"
-      - "observation-service/**"
-      - "organization-service/**"
+      - "liquibase-service/**"
+      - "common-util/**"
       - "build.gradle"
       - "settings.gradle"
       - "gradle/**"
@@ -16,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run JUnit Tests
+    name: Run reporting-pipeline-service JUnit tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -43,11 +39,11 @@ jobs:
       - name: Build and analyze
         working-directory: ./
         run: |
-          ./gradlew clean build jacocoTestReport --continue
+          ./gradlew clean reporting-pipeline-service:test reporting-pipeline-service:jacocoTestReport --continue
 
       - name: Publish Testing Reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: ./**/build/reports
+          path: reporting-pipeline-service/build

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - "reporting-pipeline-service/**"
+      - "liquibase-service/**"
+      - "common-util/**"
       - "build.gradle"
       - "settings.gradle"
       - "gradle/**"
@@ -10,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run stored procedure unit tests
+    name: Run reporting-pipeline-service stored procedure unit tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -44,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: ./**/build/reports
+          path: reporting-pipeline-service/build

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -9,6 +9,7 @@ on:
       - "settings.gradle"
       - "gradle/**"
       - "docker-compose.yaml"
+      - ".github/workflows/**"
 
 jobs:
   pipeline:

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pipeline:
-    name: Run reporting-pipeline-service stored procedure unit tests
+    name: Run stored procedure unit tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -46,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: testing
-          path: reporting-pipeline-service/build
+          path: reporting-pipeline-service/build/reports


### PR DESCRIPTION
## Description
Consolidate GitHub Actions workflows to reflect the consolidation work from individual reporting microservices to the unified reporting-pipeline-service.

## Related Issue
[APP-455](https://cdc-nbs.atlassian.net/browse/APP-455)

## Additional Notes
- Streamline `Build-and-deploy-reporting-services.yaml` by replacing individual service jobs with a single reporting-pipeline job.
- Update test workflows (`run-tests.yaml`, `run-unit-tests.yaml`, `run-functional-tests.yaml`) to target specific gradle tasks for the reporting-pipeline-service.
- Refine path triggers to include `common-util`, `liquibase-service`, and core build files.
- Adjust artifact publication paths to capture reports from the consolidated service directory.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
