### PR TITLE
Refactor FunctionalTest to use docker-compose.override.yaml if available

### DIFF
--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
@@ -22,10 +22,14 @@ public abstract class FunctionalTest {
   private static final Slf4jLogConsumer consumer = new Slf4jLogConsumer(logger);
   private static boolean started = false;
 
+  private static final File base = new File("../docker-compose.yaml");
+  private static final File override = new File("../docker-compose.override.yaml");
+
   @SuppressWarnings("resource")
   private static final ComposeContainer environment =
-      new ComposeContainer(
-              DockerImageName.parse("docker:25.0.5"), new File("../docker-compose.yaml"))
+      (override.exists()
+              ? new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
+          : new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base))
           // List specific services to prevent launching wildfly container
           .withServices("nbs-mssql", "liquibase", "kafka", "debezium", "kafka-connect")
           .waitingFor("debezium", Wait.forHealthcheck())

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
@@ -29,7 +29,7 @@ public abstract class FunctionalTest {
   private static final ComposeContainer environment =
       (override.exists()
               ? new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
-          : new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base))
+              : new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base))
           // List specific services to prevent launching wildfly container
           .withServices("nbs-mssql", "liquibase", "kafka", "debezium", "kafka-connect")
           .waitingFor("debezium", Wait.forHealthcheck())


### PR DESCRIPTION
## Description
Updated the functional test `ComposeContainer` setup to conditionally include `../docker-compose.override.yaml` when that file is present.

Previously, the test setup always initialized `ComposeContainer` with only `../docker-compose.yaml`, so local override settings were ignored even when a `docker-compose.override.yaml` file existed alongside it.

With this change:
- if `docker-compose.override.yaml` exists, it is passed to `ComposeContainer` along with the base compose file
- if `docker-compose.override.yaml` does not exist, the behavior remains unchanged and only `docker-compose.yaml` is used

This allows developers to use local compose overrides without affecting teammates who do not have an override file.

## Related Issue
N/A

## Additional Notes
Tested in both scenarios:
- with `docker-compose.override.yaml` present: Gradle/Testcontainers used the override settings
- without `docker-compose.override.yaml` present: Gradle/Testcontainers behaved exactly as before

This change is backward-compatible and intended to support local development flexibility without requiring any repository-wide test setup changes.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- ~~[ ] I have updated the documentation, if applicable.~~
- ~~[ ] I have added or updated test cases to cover my changes, if applicable.~~
 
