### PR TITLE
Fix fetch_changes_for_captures to check for table existence before querying CDC changes

### DIFF
--- a/local-db-tracing/tracing_capture.py
+++ b/local-db-tracing/tracing_capture.py
@@ -265,18 +265,21 @@ def fetch_changes_for_captures(
         capture_table_name = f"cdc.{quote_identifier(capture.capture_instance + '_CT')}"
         statement_parts.extend(
             [
-                "IF EXISTS (",
-                f"    SELECT TOP (1) 1 FROM {capture_table_name} ct",
-                f"    WHERE ct.__$start_lsn > {start_lsn}",
-                f"      AND ct.__$start_lsn <= {end_lsn}",
-                ")",
+                "IF OBJECT_ID(N'" + capture_table_name + "') IS NOT NULL",
                 "BEGIN",
-                "    INSERT INTO #changed_captures (schema_name, table_name, capture_instance)",
-                "    VALUES (",
-                f"        N'{sql_quote(capture.schema_name)}',",
-                f"        N'{sql_quote(capture.table_name)}',",
-                f"        N'{sql_quote(capture.capture_instance)}'",
-                "    );",
+                "    IF EXISTS (",
+                f"        SELECT TOP (1) 1 FROM {capture_table_name} ct",
+                f"        WHERE ct.__$start_lsn > {start_lsn}",
+                f"          AND ct.__$start_lsn <= {end_lsn}",
+                "    )",
+                "    BEGIN",
+                "        INSERT INTO #changed_captures (schema_name, table_name, capture_instance)",
+                "        VALUES (",
+                f"            N'{sql_quote(capture.schema_name)}',",
+                f"            N'{sql_quote(capture.table_name)}',",
+                f"            N'{sql_quote(capture.capture_instance)}'",
+                "        );",
+                "    END;",
                 "END;",
             ]
         )
@@ -286,6 +289,7 @@ def fetch_changes_for_captures(
         statement_parts.extend(
             [
                 f"IF EXISTS (SELECT 1 FROM #changed_captures WHERE capture_instance = N'{sql_quote(capture.capture_instance)}')",
+                "  AND OBJECT_ID(N'" + capture_table_name + "') IS NOT NULL",
                 "BEGIN",
                 "INSERT INTO #cdc_changes (",
                 "    schema_name,",


### PR DESCRIPTION
The tracer is querying the CDC metadata (`cdc.change_tables`) to get a list of all enabled capture instances, and it found `dbo_D_INVESTIGATION_REPEAT_INC` as an enabled capture. However, when it tried to query the actual CDC change table (`cdc.dbo_D_INVESTIGATION_REPEAT_INC_CT`), that table doesn't exist in the database.

This typically occurs when:

1. CDC metadata is stale - The capture was disabled but the metadata cleanup failed
2. CDC change table was manually deleted - Someone dropped the table without properly disabling CDC
3. Migration/schema sync issue - CDC is registered on one database but the actual tables weren't created on the other

Considering the dual-database setup, this likely happened because the two databases (`NBS_ODSE` and `RDB_MODERN`) got out of sync during migrations.

## Description
The cleanest solution is to add error handling to the tracer to gracefully skip capture instances whose change tables don't exist.

## Related Issue
N/A

## Additional Notes
When disabling CDC on the tables after my testing, I received many Cleanup failures detected:
```
- dbo.D_INVESTIGATION_REPEAT_INC: Change data capture instance 'dbo_D_INVESTIGATION_REPEAT_INC' has not been enabled for the source table 'dbo.D_INVESTIGATION_REPEAT_INC'. Use sys.sp_cdc_help_change_data_capture to verify the capture instance name and retry the operation.
- dbo.L_INVESTIGATION_REPEAT_INC: Change data capture instance 'dbo_L_INVESTIGATION_REPEAT_INC' has not been enabled for the source table 'dbo.L_INVESTIGATION_REPEAT_INC'. Use sys.sp_cdc_help_change_data_capture to verify the capture instance name and retry the operation.
```

This leads me to believe the capture tool instructs SQL Server to turn on CDC and logs that it was turned on, when SQL Server was not successful in turning on CDC. This needs to be investigated further.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] ~~I have added or updated test cases to cover my changes, if applicable.~~
 
