### PR TITLE
Better alignment of tracer tools with functional testing framework

### DIFF
--- a/local-db-tracing/README.md
+++ b/local-db-tracing/README.md
@@ -32,6 +32,53 @@ python local-db-tracing/validate_rdb_selects.py --input-file local-db-tracing/ou
 
 8. Review pass/fail details in `local-db-tracing/output/<paired-run>/rdb-selects-results.md`.
 
+### Step-By-Step Checks
+
+Dual capture runs also generate per-step artifacts so you can replay and validate one step at a time.
+
+For a paired run such as `local-db-tracing/output/<paired-run>/`:
+
+- replay SQL for each source step is written under `cdc-<database>/step-<N>/setup.sql`
+- target verification SQL for each target step is written under `logical-<database>/step-<N>/query.sql`
+- each `query.sql` is cumulative through that step, so step 2 reflects the expected target state after both step 1 and step 2 have been applied
+
+Manual step-by-step workflow:
+
+1. Run `cdc-<database>/step-1/setup.sql` against the source database.
+2. Wait for `nedss-datareporting-reporting-pipeline-service-1` to have "No ids to process from the topics."
+3. Run:
+
+```powershell
+python local-db-tracing/validate_rdb_selects.py --input-file local-db-tracing/output/<paired-run>/logical-<database>/step-1/query.sql
+```
+
+4. Review the generated Markdown report for step 1, `local-db-tracing/output/<paired-run>/logical-<database>/step-1/rdb-selects-results.md`.
+5. Run `cdc-<database>/step-2/setup.sql`.
+6. Run:
+
+```powershell
+python local-db-tracing/validate_rdb_selects.py --input-file local-db-tracing/output/<paired-run>/logical-<database>/step-2/query.sql
+```
+
+7. Review the generated Markdown report for step 2, `local-db-tracing/output/<paired-run>/logical-<database>/step-2/rdb-selects-results.md`.
+8. Repeat for later steps.
+
+Example validator command for a step query file:
+
+```powershell
+python local-db-tracing/validate_rdb_selects.py --input-file local-db-tracing/output/<paired-run>/logical-RDB_MODERN/step-2/query.sql
+```
+
+When only `--input-file` is provided, the validator writes results next to that step query file using default names:
+
+- `rdb-selects-results.json`
+- `rdb-selects-results.md`
+
+For example, validating `logical-RDB_MODERN/step-2/query.sql` writes:
+
+- `logical-RDB_MODERN/step-2/rdb-selects-results.json`
+- `logical-RDB_MODERN/step-2/rdb-selects-results.md`
+
 ## Overview
 
 This toolkit supports two goals:
@@ -275,7 +322,9 @@ Dual-capture run (example `.../20260408-111218-NBS_ODSE-to-RDB_MODERN/`):
 
 - `combined-manifest.json`: pointers to source/target artifacts for the action window
 - `cdc-<database>/`: CDC artifacts for source database
+- `cdc-<database>/step-<N>/setup.sql`: replay SQL for individual source steps
 - `logical-<database>/`: logical artifacts for target database
+- `logical-<database>/step-<N>/query.sql`: cumulative verification SQL for each target step
 - `rdb-selects.sql`: generated target verification queries with `-- EXPECTED_ROWS_JSON` comments
 - `rdb-selects-results.json`: machine-readable validation results (when validator is run)
 - `rdb-selects-results.md`: human-readable validation report (when validator is run)

--- a/local-db-tracing/generate_rdb_selects.py
+++ b/local-db-tracing/generate_rdb_selects.py
@@ -28,6 +28,13 @@ LOCAL_ID_EXPRESSION_PATTERN = re.compile(
 VAR_PLUS_OFFSET_PATTERN = re.compile(r"^(?P<left>@[A-Za-z0-9_]+)\s*\+\s*(?P<offset>-?\d+)$")
 OFFSET_PLUS_VAR_PATTERN = re.compile(r"^(?P<offset>-?\d+)\s*\+\s*(?P<right>@[A-Za-z0-9_]+)$")
 
+IGNORED_OUTPUT_COLUMNS = frozenset(
+    {
+        "RDB_LAST_REFRESH_TIME",
+        "LAB_RPT_LAST_UPDATE_DT",
+    }
+)
+
 
 @dataclass(frozen=True)
 class DeclareEntry:
@@ -1076,8 +1083,8 @@ def render_sql(
             if normalize_identifier(s) == normalize_identifier(scaffold.schema_name)
             and normalize_identifier(t) == normalize_identifier(scaffold.table_name)
         )
-        select_excluded_columns = pk_columns | generated_excluded_for_table | auto_excluded_for_table
-        json_excluded_columns = pk_columns | generated_excluded_for_table | auto_excluded_for_table
+        select_excluded_columns = pk_columns | generated_excluded_for_table | auto_excluded_for_table | IGNORED_OUTPUT_COLUMNS
+        json_excluded_columns = pk_columns | generated_excluded_for_table | auto_excluded_for_table | IGNORED_OUTPUT_COLUMNS
         select_columns: list[str] | None = None
         if columns_by_table is not None:
             all_columns = columns_by_table.get(table_key)

--- a/local-db-tracing/generate_rdb_selects.py
+++ b/local-db-tracing/generate_rdb_selects.py
@@ -878,6 +878,65 @@ def build_scaffolds(
     return sorted(finalized, key=lambda item: (item.schema_name.lower(), item.table_name.lower(), item.where_fields))
 
 
+def logical_change_step(change: dict[str, object]) -> int | None:
+    metadata = change.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    step_value = metadata.get("step")
+    try:
+        return int(step_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def step_numbers_from_manifest_or_changes(
+    manifest: dict[str, object],
+    logical_changes: list[dict[str, object]],
+) -> list[int]:
+    ordered_steps: list[int] = []
+    seen: set[int] = set()
+
+    manifest_steps = manifest.get("steps")
+    if isinstance(manifest_steps, list):
+        for step in manifest_steps:
+            if not isinstance(step, dict):
+                continue
+            step_value = step.get("step")
+            try:
+                step_number = int(step_value)
+            except (TypeError, ValueError):
+                continue
+            if step_number not in seen:
+                seen.add(step_number)
+                ordered_steps.append(step_number)
+
+    for change in logical_changes:
+        step_number = logical_change_step(change)
+        if step_number is None or step_number in seen:
+            continue
+        seen.add(step_number)
+        ordered_steps.append(step_number)
+
+    return ordered_steps
+
+
+def build_renderable_scaffolds(
+    logical_changes_obj: list[dict[str, object]],
+    declare_entries: list[DeclareEntry],
+) -> list[SelectScaffold]:
+    scaffolds = build_scaffolds(logical_changes_obj, declare_entries)
+    known_lookup_keys_file = Path(__file__).with_name("known_lookup_keys.json")
+    if known_lookup_keys_file.exists():
+        try:
+            known_lookup_keys_obj = json.loads(known_lookup_keys_file.read_text(encoding="utf-8"))
+            if isinstance(known_lookup_keys_obj, dict):
+                scaffolds = apply_known_lookup_keys(scaffolds, known_lookup_keys_obj.get("known_tables"))
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"Warning: Could not load {known_lookup_keys_file}: {error}", file=sys.stderr)
+    scaffolds = consolidate_fk_scaffolds(scaffolds)
+    return [s for s in scaffolds if not s.table_name.lower().startswith("nrt_")]
+
+
 def apply_known_lookup_keys(
     scaffolds: list[SelectScaffold],
     known_lookup_keys: dict[str, dict[str, object]] | None,
@@ -1005,6 +1064,41 @@ def display_path(path_value: str) -> str:
         return path_value.replace("\\", "/")
 
 
+def write_step_query_files(
+    logical_output_dir: Path,
+    manifest: dict[str, object],
+    logical_changes_obj: list[dict[str, object]],
+    declare_lines: list[str],
+    declare_entries: list[DeclareEntry],
+    columns_by_table: dict[tuple[str, str], list[str]] | None,
+    primary_keys_by_table: dict[tuple[str, str], frozenset[str]] | None,
+    foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]] | None,
+    generated_always_columns: set[tuple[str, str, str]] | None,
+    auto_datetime_defaults: set[tuple[str, str, str]] | None,
+) -> None:
+    for step_number in step_numbers_from_manifest_or_changes(manifest, logical_changes_obj):
+        step_dir = logical_output_dir / f"step-{step_number}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        cumulative_changes = [
+            change
+            for change in logical_changes_obj
+            if (logical_change_step(change) or 0) <= step_number
+        ]
+        step_scaffolds = build_renderable_scaffolds(cumulative_changes, declare_entries)
+        step_sql = render_sql(
+            manifest,
+            declare_lines,
+            declare_entries,
+            step_scaffolds,
+            columns_by_table,
+            primary_keys_by_table,
+            foreign_keys_by_source,
+            generated_always_columns,
+            auto_datetime_defaults,
+        )
+        (step_dir / "query.sql").write_text(step_sql, encoding="utf-8")
+
+
 def render_sql(
     manifest: dict[str, object],
     declare_lines: list[str],
@@ -1123,17 +1217,7 @@ def generate_rdb_selects_from_manifest(
 
     declare_lines = extract_declare_block(inserts_text)
     declare_entries = parse_declare_entries(declare_lines)
-    scaffolds = build_scaffolds(logical_changes_obj, declare_entries)
-    known_lookup_keys_file = Path(__file__).with_name("known_lookup_keys.json")
-    if known_lookup_keys_file.exists():
-        try:
-            known_lookup_keys_obj = json.loads(known_lookup_keys_file.read_text(encoding="utf-8"))
-            if isinstance(known_lookup_keys_obj, dict):
-                scaffolds = apply_known_lookup_keys(scaffolds, known_lookup_keys_obj.get("known_tables"))
-        except (OSError, json.JSONDecodeError) as error:
-            print(f"Warning: Could not load {known_lookup_keys_file}: {error}", file=sys.stderr)
-    scaffolds = consolidate_fk_scaffolds(scaffolds)
-    scaffolds = [s for s in scaffolds if not s.table_name.lower().startswith("nrt_")]
+    scaffolds = build_renderable_scaffolds(logical_changes_obj, declare_entries)
     logical_database = str(manifest.get("logical_database") or "RDB_MODERN")
     columns_by_table, primary_keys_by_table, foreign_keys_by_source, generated_always_columns, auto_datetime_defaults = load_rdb_column_metadata(logical_database)
     output_sql = render_sql(
@@ -1141,6 +1225,19 @@ def generate_rdb_selects_from_manifest(
         declare_lines,
         declare_entries,
         scaffolds,
+        columns_by_table,
+        primary_keys_by_table,
+        foreign_keys_by_source,
+        generated_always_columns,
+        auto_datetime_defaults,
+    )
+
+    write_step_query_files(
+        logical_changes_path.parent,
+        manifest,
+        logical_changes_obj,
+        declare_lines,
+        declare_entries,
         columns_by_table,
         primary_keys_by_table,
         foreign_keys_by_source,

--- a/local-db-tracing/test_generate_rdb_selects.py
+++ b/local-db-tracing/test_generate_rdb_selects.py
@@ -491,6 +491,94 @@ class GenerateRdbSelectsTest(unittest.TestCase):
 
         self.assertIn("-- Steps: 1, 2", sql)
 
+    def test_generate_rdb_selects_writes_cumulative_step_query_files(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            paired_dir = root / "20260408-143320-NBS_ODSE-to-RDB_MODERN"
+            cdc_dir = paired_dir / "cdc-NBS_ODSE"
+            logical_dir = paired_dir / "logical-RDB_MODERN"
+            cdc_dir.mkdir(parents=True)
+            logical_dir.mkdir(parents=True)
+
+            summary_path = cdc_dir / "summary.txt"
+            summary_path.write_text(
+                """Reconstructed SQL written to: inserts.sql\nRun inserts.sql directly against the source database to replay captured writes.\n""",
+                encoding="utf-8",
+            )
+            inserts_path = cdc_dir / "inserts.sql"
+            inserts_path.write_text(
+                """USE [NBS_ODSE];\nDECLARE @dbo_Entity_entity_uid bigint = -1000;\nDECLARE @dbo_Person_local_id nvarchar(40) = N'PSN1000GA01';\n\n-- STEP 1: Create patient\n-- step: 1\nINSERT INTO [dbo].[Person] ([person_uid]) VALUES (@dbo_Entity_entity_uid);\n""",
+                encoding="utf-8",
+            )
+
+            logical_changes_path = logical_dir / "logical-changes.json"
+            logical_changes_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "schema_name": "dbo",
+                            "table_name": "D_PATIENT",
+                            "operation": "insert",
+                            "stable_identity": {
+                                "strategy": "business_keys",
+                                "eligible_for_comparison": True,
+                                "fields": {"PATIENT_LOCAL_ID": "PSN1000GA01"},
+                            },
+                            "primary_key_values": {"PATIENT_KEY": 9},
+                            "after": {"PATIENT_KEY": 9, "PATIENT_LOCAL_ID": "PSN1000GA01", "PATIENT_LAST_NAME": "Alpha"},
+                            "metadata": {"step": 1},
+                        },
+                        {
+                            "schema_name": "dbo",
+                            "table_name": "D_PATIENT",
+                            "operation": "update",
+                            "stable_identity": {
+                                "strategy": "business_keys",
+                                "eligible_for_comparison": True,
+                                "fields": {"PATIENT_LOCAL_ID": "PSN1000GA01"},
+                            },
+                            "primary_key_values": {"PATIENT_KEY": 9},
+                            "after": {"PATIENT_KEY": 9, "PATIENT_LOCAL_ID": "PSN1000GA01", "PATIENT_LAST_NAME": "Beta"},
+                            "metadata": {"step": 2},
+                        },
+                    ],
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            manifest_path = paired_dir / "combined-manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "logical_database": "TEST_DB_NO_CACHE",
+                        "cdc_summary_file": str(summary_path),
+                        "cdc_inserts_file": str(inserts_path),
+                        "logical_changes_file": str(logical_changes_path),
+                        "steps": [
+                            {"step": 1, "description": "Create patient"},
+                            {"step": 2, "description": "Update patient"},
+                        ],
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output_path, scaffold_count = generate_rdb_selects.generate_rdb_selects_from_manifest(manifest_path)
+
+            step1_sql = (logical_dir / "step-1" / "query.sql").read_text(encoding="utf-8")
+            step2_sql = (logical_dir / "step-2" / "query.sql").read_text(encoding="utf-8")
+            final_sql = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(scaffold_count, 1)
+        self.assertIn('"PATIENT_LAST_NAME":"Alpha"', step1_sql)
+        self.assertNotIn('"PATIENT_LAST_NAME":"Beta"', step1_sql)
+        self.assertIn('"PATIENT_LAST_NAME":"Beta"', step2_sql)
+        self.assertIn('"PATIENT_LAST_NAME":"Beta"', final_sql)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/local-db-tracing/test_generate_rdb_selects.py
+++ b/local-db-tracing/test_generate_rdb_selects.py
@@ -295,6 +295,63 @@ class GenerateRdbSelectsTest(unittest.TestCase):
         self.assertNotIn("[updated_dttm]", sql)
         self.assertIn('-- EXPECTED_ROWS_JSON:\n-- [{"patient_uid":1234}]', sql)
 
+    def test_known_refresh_timestamps_are_excluded_from_select_and_expected_json(self) -> None:
+        declare_entries = generate_rdb_selects.parse_declare_entries(
+            [
+                "DECLARE @dbo_Person_local_id nvarchar(40) = N'PSN1234GA01';",
+            ]
+        )
+        scaffolds = generate_rdb_selects.build_scaffolds(
+            [
+                {
+                    "schema_name": "dbo",
+                    "table_name": "LAB_REPORT",
+                    "operation": "insert",
+                    "stable_identity": {
+                        "strategy": "business_keys",
+                        "eligible_for_comparison": True,
+                        "fields": {"PATIENT_LOCAL_ID": "PSN1234GA01"},
+                    },
+                    "primary_key_values": {},
+                    "after": {
+                        "PATIENT_LOCAL_ID": "PSN1234GA01",
+                        "RDB_LAST_REFRESH_TIME": "2026-04-23T12:34:56",
+                        "LAB_RPT_LAST_UPDATE_DT": "2026-04-23T12:35:56",
+                        "RESULT_STATUS": "FINAL",
+                    },
+                }
+            ],
+            declare_entries,
+        )
+
+        sql = generate_rdb_selects.render_sql(
+            {
+                "logical_database": "RDB_MODERN",
+                "cdc_summary_file": str(generate_rdb_selects.REPO_ROOT / "summary.txt"),
+                "logical_changes_file": str(generate_rdb_selects.REPO_ROOT / "logical-changes.json"),
+            },
+            ["DECLARE @dbo_Person_local_id nvarchar(40) = N'PSN1234GA01';"],
+            declare_entries,
+            scaffolds,
+            columns_by_table={
+                ("dbo", "LAB_REPORT"): [
+                    "PATIENT_LOCAL_ID",
+                    "RDB_LAST_REFRESH_TIME",
+                    "LAB_RPT_LAST_UPDATE_DT",
+                    "RESULT_STATUS",
+                ],
+            },
+        )
+
+        self.assertIn("SELECT", sql)
+        self.assertIn("    [PATIENT_LOCAL_ID],", sql)
+        self.assertIn("    [RESULT_STATUS]", sql)
+        self.assertNotIn("[RDB_LAST_REFRESH_TIME]", sql)
+        self.assertNotIn("[LAB_RPT_LAST_UPDATE_DT]", sql)
+        self.assertIn('-- EXPECTED_ROWS_JSON:\n-- [{"PATIENT_LOCAL_ID":"PSN1234GA01","RESULT_STATUS":"FINAL"}]', sql)
+        self.assertNotIn("RDB_LAST_REFRESH_TIME", sql)
+        self.assertNotIn("LAB_RPT_LAST_UPDATE_DT", sql)
+
     def test_expected_rows_json_maps_ambiguous_entity_uid_candidates_deterministically(self) -> None:
         declare_entries = generate_rdb_selects.parse_declare_entries(
             [

--- a/local-db-tracing/test_replay.py
+++ b/local-db-tracing/test_replay.py
@@ -386,6 +386,73 @@ class ReplaySqlTest(unittest.TestCase):
         self.assertLess(steps_pos, database_pos)
         self.assertNotIn("Actions performed in NBS:", summary)
 
+    def test_write_summary_creates_per_step_setup_sql_files(self) -> None:
+        manifest = {
+            "database": "NBS_ODSE",
+            "start_time_utc": "2026-04-07T14:08:36+00:00",
+            "end_time_utc": "2026-04-07T14:09:47+00:00",
+            "start_lsn": "0x01",
+            "end_lsn": "0x02",
+            "initially_tracked_table_count": 20,
+            "enabled_tables": [],
+            "skipped_tables": [],
+        }
+        nbs_steps = [
+            {"step": 1, "description": "Create patient"},
+            {"step": 2, "description": "Add address"},
+        ]
+        step_changes = [
+            {
+                "schema_name": "dbo",
+                "table_name": "Entity",
+                "operation": "insert",
+                "start_lsn": "0x01",
+                "seqval": "0x02",
+                "operation_code": 2,
+                "_step": 1,
+                "row": {"entity_uid": 10009297, "class_cd": "PSN"},
+            },
+            {
+                "schema_name": "dbo",
+                "table_name": "Postal_locator",
+                "operation": "insert",
+                "start_lsn": "0x02",
+                "seqval": "0x04",
+                "operation_code": 2,
+                "_step": 2,
+                "row": {"postal_locator_uid": 10009298, "state_cd": "13"},
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            summary_path = Path(temp_dir) / "summary.txt"
+            write_summary(
+                summary_path,
+                [],
+                manifest,
+                step_changes,
+                self.primary_keys_by_table,
+                self.identity_columns_by_table,
+                self.foreign_keys_by_source,
+                self.column_sql_types,
+                self.generated_always_columns,
+                self.uid_generator_entries,
+                self.known_associations,
+                nbs_steps=nbs_steps,
+            )
+
+            step1_sql = (Path(temp_dir) / "step-1" / "setup.sql").read_text(encoding="utf-8")
+            step2_sql = (Path(temp_dir) / "step-2" / "setup.sql").read_text(encoding="utf-8")
+
+        self.assertIn("USE [NBS_ODSE];", step1_sql)
+        self.assertIn("-- STEP 1: Create patient", step1_sql)
+        self.assertIn("INSERT INTO [dbo].[Entity]", step1_sql)
+        self.assertNotIn("INSERT INTO [dbo].[Postal_locator]", step1_sql)
+        self.assertIn("USE [NBS_ODSE];", step2_sql)
+        self.assertIn("-- STEP 2: Add address", step2_sql)
+        self.assertIn("INSERT INTO [dbo].[Postal_locator]", step2_sql)
+        self.assertNotIn("INSERT INTO [dbo].[Entity]", step2_sql)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/local-db-tracing/tracing_output.py
+++ b/local-db-tracing/tracing_output.py
@@ -17,6 +17,76 @@ from tracing_replay import (
 from tracing_sql import quote_identifier
 
 
+def step_numbers_from_changes(
+    changes: list[dict[str, object]],
+    nbs_steps: list[dict[str, object]] | None = None,
+) -> list[int]:
+    ordered_steps: list[int] = []
+    seen: set[int] = set()
+
+    if nbs_steps:
+        for step in nbs_steps:
+            step_value = step.get("step")
+            try:
+                step_number = int(step_value)
+            except (TypeError, ValueError):
+                continue
+            if step_number not in seen:
+                seen.add(step_number)
+                ordered_steps.append(step_number)
+
+    for change in changes:
+        step_value = change.get("_step")
+        try:
+            step_number = int(step_value)
+        except (TypeError, ValueError):
+            continue
+        if step_number not in seen:
+            seen.add(step_number)
+            ordered_steps.append(step_number)
+
+    return ordered_steps
+
+
+def write_step_setup_files(
+    output_dir: Path,
+    database: str,
+    replay_changes: list[dict[str, object]],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    identity_columns_by_table: dict[tuple[str, str], list[str]],
+    foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
+    column_sql_types: dict[tuple[str, str, str], str],
+    generated_always_columns: set[tuple[str, str, str]],
+    uid_generator_entries: list[UidGeneratorEntry],
+    known_associations: list[KnownAssociation],
+    nbs_steps: list[dict[str, object]] | None,
+    superuser_id: int,
+    starting_uid: int,
+) -> None:
+    for step_number in step_numbers_from_changes(replay_changes, nbs_steps):
+        step_dir = output_dir / f"step-{step_number}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        step_changes = [change for change in replay_changes if change.get("_step") == step_number]
+        step_sql = reconstruct_sql_statements(
+            step_changes,
+            primary_keys_by_table,
+            identity_columns_by_table,
+            foreign_keys_by_source,
+            column_sql_types,
+            generated_always_columns,
+            uid_generator_entries,
+            known_associations,
+            superuser_id=superuser_id,
+            starting_uid=starting_uid,
+            nbs_steps=nbs_steps,
+        )
+        if step_sql:
+            lines = [f"USE {quote_identifier(database)};", *step_sql]
+        else:
+            lines = [f"USE {quote_identifier(database)};", f"-- No replayable SQL generated for step {step_number}."]
+        (step_dir / "setup.sql").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 
 def summarize_row_identifier(record: dict[str, object]) -> str:
     """Build a concise identifier string for one captured CDC row.
@@ -312,6 +382,22 @@ def write_summary(
         lines.append("Tables excluded from reconstructed SQL (core replay):")
         for table_name in ignored_replay_table_names:
             lines.append(f"- {table_name}")
+    if nbs_steps or any(record.get("_step") is not None for record in replay_changes):
+        write_step_setup_files(
+            path.parent,
+            str(manifest["database"]),
+            replay_changes,
+            primary_keys_by_table,
+            identity_columns_by_table,
+            foreign_keys_by_source,
+            column_sql_types,
+            generated_always_columns,
+            uid_generator_entries,
+            known_associations,
+            nbs_steps,
+            superuser_id,
+            starting_uid,
+        )
     if reconstructed_sql:
         inserts_path = path.parent / "inserts.sql"
         inserts_lines = [f"USE {quote_identifier(str(manifest['database']))};", *reconstructed_sql]


### PR DESCRIPTION
## Description
1. In the `cdc-` directory, subdirectories are now created for each step (`step-1`, `step-2`, etc). In these directories, a `setup.sql` file is created which includes the SQL commands to run against the `ODSE` database for that step.
2. In the `logical-` directory, subdirectories are now created for each step (`step-1`, `step-2`, etc). In these directories, a `query.sql` file is created which includes the SQL commands to run against the `RDB(_MODERN)` database for that step.
3. Specific fields (`RDB_LAST_REFRESH_TIME`, `LAB_RPT_LAST_UPDATE_DT`) are ignored in `query.sql` as they are not being picked up via other methods and are auto-updated timestamp fields which will always fail on comparison.
4. `README.md` updates to reflect these changes

## Related Issue
N/A

## Additional Notes
These changes better align with the workflow of the functional testing framework. See "Manual step-by-step workflow" in `README.md`

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [ ] ~~I have added or updated test cases to cover my changes, if applicable.~~
 
