### PR TITLE
Fix: LDF_GROUP sentinel row missing causes sp_generic_case_datamart_postprocessing FK violation

### DIFF
--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
@@ -253,7 +253,8 @@ BEGIN
         from dbo.ldf_group lg with (nolock)
         left join (select distinct ldf_group_key from dbo.LDF_DATA with (nolock)) nld
           on nld.ldf_group_key = lg.ldf_group_key
-        where nld.LDF_GROUP_KEY is null;
+        where nld.LDF_GROUP_KEY is null
+          and lg.ldf_group_key <> 1;
 
         if @debug = 'true' select * from #DEL_GROUP_KEY;
         /* Logging */
@@ -735,8 +736,7 @@ BEGIN
         delete T from
         dbo.ldf_group T with (nolock)
         inner join  #DEL_GROUP_KEY dldk
-        on T.ldf_group_key = dldk.ldf_group_key
-        and T.ldf_group_key <> 1;
+        on T.ldf_group_key = dldk.ldf_group_key;
 
         COMMIT TRANSACTION;
 

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
@@ -24,6 +24,10 @@ BEGIN
         set @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         print @batch_id;
 
+        -- Ensure the sentinel LDF_GROUP row (key = 1) exists before processing.
+        -- This proc reassigns ldf_group_key to 1 on case datamarts (e.g. GENERIC_CASE, HEPATITIS_CASE)
+        -- when the original group is deleted. Without this row, those FK-referencing updates fail.
+        -- The guard also protects the delete step below from removing it (see: and T.ldf_group_key <> 1).
         IF NOT EXISTS (SELECT 1 FROM dbo.LDF_GROUP WHERE LDF_GROUP_KEY = 1)
         BEGIN
             INSERT INTO dbo.LDF_GROUP (LDF_GROUP_KEY, BUSINESS_OBJECT_UID)

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
@@ -24,6 +24,12 @@ BEGIN
         set @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         print @batch_id;
 
+        IF NOT EXISTS (SELECT 1 FROM dbo.LDF_GROUP WHERE LDF_GROUP_KEY = 1)
+        BEGIN
+            INSERT INTO dbo.LDF_GROUP (LDF_GROUP_KEY, BUSINESS_OBJECT_UID)
+            VALUES (1, NULL);
+        END
+
         INSERT INTO [dbo].[job_flow_log]
         (
           batch_id
@@ -725,7 +731,8 @@ BEGIN
         delete T from
         dbo.ldf_group T with (nolock)
         inner join  #DEL_GROUP_KEY dldk
-        on T.ldf_group_key = dldk.ldf_group_key;
+        on T.ldf_group_key = dldk.ldf_group_key
+        and T.ldf_group_key <> 1;
 
         COMMIT TRANSACTION;
 

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
@@ -34,6 +34,12 @@ BEGIN
     DECLARE @inv_form_cd VARCHAR(100) = 'INV_FORM_GEN%';
     DECLARE @tgt_table_nm VARCHAR(50) = 'Generic_Case';
 
+    IF NOT EXISTS (SELECT 1 FROM dbo.LDF_GROUP WHERE LDF_GROUP_KEY = 1)
+    BEGIN
+        INSERT INTO dbo.LDF_GROUP (LDF_GROUP_KEY, BUSINESS_OBJECT_UID)
+        VALUES (1, NULL);
+    END
+
 BEGIN TRY
 
         SET @Proc_Step_Name = 'SP_Start';

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/030-sp_generic_case_datamart_postprocessing-001.sql
@@ -34,6 +34,12 @@ BEGIN
     DECLARE @inv_form_cd VARCHAR(100) = 'INV_FORM_GEN%';
     DECLARE @tgt_table_nm VARCHAR(50) = 'Generic_Case';
 
+    -- Ensure the sentinel LDF_GROUP row (key = 1) exists before processing.
+    -- This proc reads LDF_GROUP_KEY from v_nrt_inv_keys_attrs_mapping and writes it to Generic_Case.
+    -- If sp_nrt_ldf_postprocessing deletes a group and reassigns case rows to key = 1, this row must
+    -- already exist or the subsequent tgt.LDF_GROUP_KEY = src.LDF_GROUP_KEY update will fail with
+    -- a FK violation. This proc can be called independently of sp_nrt_ldf_postprocessing, so the
+    -- guard is repeated here rather than relying on execution order.
     IF NOT EXISTS (SELECT 1 FROM dbo.LDF_GROUP WHERE LDF_GROUP_KEY = 1)
     BEGIN
         INSERT INTO dbo.LDF_GROUP (LDF_GROUP_KEY, BUSINESS_OBJECT_UID)


### PR DESCRIPTION
## Description
Adds a sentinel row guard to `sp_generic_case_datamart_postprocessing` to ensure `dbo.LDF_GROUP` always contains a row with `LDF_GROUP_KEY = 1` before any processing begins.

### Problem
On startup, `sp_nrt_ldf_postprocessing` can delete all rows from `dbo.LDF_GROUP`, leaving the table empty. When `sp_generic_case_datamart_postprocessing` subsequently runs and attempts to write `LDF_GROUP_KEY` values to `Generic_Case`, the update fails with a foreign key constraint violation because the referenced row in `dbo.LDF_GROUP` no longer exists.

### Solution
Added an idempotent `IF NOT EXISTS` guard at procedure entry (before `BEGIN TRY`) that inserts the sentinel row (`LDF_GROUP_KEY = 1, BUSINESS_OBJECT_UID = NULL`) into `dbo.LDF_GROUP` if it is missing

## Related Issue
N/A

## Additional Notes
- `sp_generic_case_datamart_postprocessing` can be called independently of `sp_nrt_ldf_postprocessing`, so the guard cannot rely on execution order.
- No schema changes. No changes to existing logic. Purely additive.
- The same pattern may be warranted in other case datamart postprocessing procedures that write `LDF_GROUP_KEY` (e.g., for `BMIRD_CASE`, `CRS_CASE`, `HEPATITIS_CASE`, etc.).

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- ~~[ ] I have added or updated test cases to cover my changes, if applicable.~~
 
