### PR TITLE
Use new Test Database Image

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,24 @@
+services:
+  nbs-mssql: !override
+    image: ghcr.io/cdcgov/nedss-datareporting-mssql:6.0.18.1
+    platform: linux/amd64
+    environment:
+      - DATABASE_VERSION=6.0.18.1
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD:-PizzaIsGood33!}
+    ports:
+      - 3433:1433
+    mem_limit: 2.5G
+
+  kafka-connect:
+    depends_on: !override
+      kafka:
+        condition: service_healthy
+      nbs-mssql:
+        condition: service_healthy
+
+  debezium:
+    depends_on: !override
+      kafka:
+        condition: service_healthy
+      nbs-mssql:
+        condition: service_healthy

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -103,13 +103,12 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    testImplementation 'org.testcontainers:testcontainers:2.0.3'
-    testImplementation 'org.testcontainers:testcontainers-kafka:2.0.3'
-    testImplementation 'org.testcontainers:testcontainers-junit-jupiter:2.0.3'
+    testImplementation 'org.testcontainers:testcontainers:2.0.5'
+    testImplementation 'org.testcontainers:testcontainers-kafka:2.0.5'
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter:2.0.5'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    testImplementation 'org.testcontainers:testcontainers:2.0.3'
 }
 
 dependencyManagement {

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.json.JSONException;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -77,6 +79,7 @@ class DataDrivenFunctionalTests extends FunctionalTest {
    * @throws JSONException
    */
   @ParameterizedTest
+  @Execution(ExecutionMode.CONCURRENT)
   @MethodSource("functionalTestDirectoryProvider")
   void testRunner(Path testDirectory) throws IOException, JSONException {
     System.out.println(

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
@@ -23,20 +23,17 @@ public abstract class FunctionalTest {
   private static boolean started = false;
 
   private static final File base = new File("../docker-compose.yaml");
-  private static final File override = new File("../docker-compose.override.yaml");
+  private static final File override = new File("../docker-compose.test.yaml");
 
   @SuppressWarnings("resource")
   private static final ComposeContainer environment =
-      (override.exists()
-              ? new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
-              : new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base))
+      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
           // List specific services to prevent launching wildfly container
-          .withServices("nbs-mssql", "liquibase", "kafka", "debezium", "kafka-connect")
+          .withServices("nbs-mssql", "kafka", "debezium", "kafka-connect")
           .waitingFor("debezium", Wait.forHealthcheck())
           .waitingFor("kafka-connect", Wait.forHealthcheck())
           // Pull logs from the containers for better debugging
           .withLogConsumer("nbs-mssql", consumer)
-          .withLogConsumer("liquibase", consumer)
           .withLogConsumer("kafka", consumer)
           .withLogConsumer("debezium", consumer)
           .withLogConsumer("kafka-connect", consumer)

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/FunctionalTest.java
@@ -23,11 +23,11 @@ public abstract class FunctionalTest {
   private static boolean started = false;
 
   private static final File base = new File("../docker-compose.yaml");
-  private static final File override = new File("../docker-compose.test.yaml");
+  private static final File testCompose = new File("../docker-compose.test.yaml");
 
   @SuppressWarnings("resource")
   private static final ComposeContainer environment =
-      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
+      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, testCompose)
           // List specific services to prevent launching wildfly container
           .withServices("nbs-mssql", "kafka", "debezium", "kafka-connect")
           .waitingFor("debezium", Wait.forHealthcheck())

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.json.JSONException;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -64,6 +66,7 @@ class DataDrivenUnitTests extends UnitTest {
    * @throws JSONException
    */
   @ParameterizedTest
+  @Execution(ExecutionMode.CONCURRENT)
   @MethodSource("unitTestDirectoryProvider")
   void testRunner(Path testDirectory) throws IOException, JSONException {
     // Parse test data

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
@@ -21,11 +21,11 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class UnitTest {
   private static boolean started = false;
   private static final File base = new File("../docker-compose.yaml");
-  private static final File override = new File("../docker-compose.test.yaml");
+  private static final File testCompose = new File("../docker-compose.test.yaml");
 
   @SuppressWarnings("resource")
   private static final ComposeContainer environment =
-      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
+      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, testCompose)
           .withServices("nbs-mssql")
           .withStartupTimeout(Duration.ofMinutes(5))
           // Set the maximum startup timeout all the waits set are bounded to

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
@@ -11,7 +11,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.ComposeContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @ActiveProfiles("test")
@@ -21,16 +20,14 @@ import org.testcontainers.utility.DockerImageName;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public abstract class UnitTest {
   private static boolean started = false;
+  private static final File base = new File("../docker-compose.yaml");
+  private static final File override = new File("../docker-compose.test.yaml");
 
   @SuppressWarnings("resource")
   private static final ComposeContainer environment =
-      new ComposeContainer(
-              DockerImageName.parse("docker:25.0.5"), new File("../docker-compose.yaml"))
-          .withServices("nbs-mssql", "liquibase")
-          .waitingFor(
-              "liquibase",
-              Wait.forLogMessage("Migrations complete.*", 1)
-                  .withStartupTimeout(Duration.ofMinutes(5)))
+      new ComposeContainer(DockerImageName.parse("docker:25.0.5"), base, override)
+          .withServices("nbs-mssql")
+          .withStartupTimeout(Duration.ofMinutes(5))
           // Set the maximum startup timeout all the waits set are bounded to
           .withStartupTimeout(Duration.ofMinutes(5));
 

--- a/reporting-pipeline-service/src/test/resources/junit-platform.properties
+++ b/reporting-pipeline-service/src/test/resources/junit-platform.properties
@@ -1,0 +1,9 @@
+# Enable parallel execution
+junit.jupiter.execution.parallel.enabled = true
+
+# Should tests within the same class run in parallel - current tests fail if ran concurrently
+junit.jupiter.execution.parallel.mode.default = same_thread
+
+# Should different classes run in parallel - current tests fail if ran concurrently
+junit.jupiter.execution.parallel.mode.classes.default = same_thread
+


### PR DESCRIPTION
## Description
Updates the Unit and Functional tests to leverage the newly published [test database](https://github.com/CDCgov/NEDSS-DataReporting/pkgs/container/nedss-datareporting-mssql).

Also enables parallel processing of unit and functional tests. The application tests cannot be run in parallel due the test structure (class level fields) that cause failures.


## Related Issue
[APP-520](https://cdc-nbs.atlassian.net/browse/APP-520)

## Additional Notes
The TestContainers dependency had to be updated to `2.0.5` to support `!override` in the `docker-compose.test.yaml`

### Local Test  duration before and after changes

|Test Type | Main Branch | Current Branch | 
| ---| --- | --- | 
| Functional | 8m 51s | 4m 35s| 
| Unit | 1m 52s | 1m 05s | 
| Application | 20s | 21s |

### Github workflow test duration before and after changes
|Test Type | Main Branch | Current Branch | 
| ---| --- | --- | 
| Functional | 10m 1s | 7m 43s| 
| Unit | 3m 40s | 3m 04s  | 
| Application | 1m 40s | 1m 46s |

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
