### PR TITLE
Harden lab result and LDF foodborne post-processing SQL against empty/dedup edge cases

### DIFF
--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/017-sp_d_labtest_result_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/017-sp_d_labtest_result_postprocessing-001.sql
@@ -35,6 +35,8 @@ BEGIN
     DECLARE @Proc_Step_Name VARCHAR(200) = '';
     DECLARE @Dataflow_Name VARCHAR(200) = 'D_LABTEST_RESULTS Post-Processing Event';
     DECLARE @Package_Name VARCHAR(200) = 'sp_d_labtest_result_postprocessing';
+	DECLARE @curr_test_result_grp_key BIGINT;
+	DECLARE @max_test_result_grp_key BIGINT;
 
     BEGIN TRY
 
@@ -872,9 +874,19 @@ BEGIN
 			SET @PROC_STEP_NO = @PROC_STEP_NO + 1;
 			SET @PROC_STEP_NAME = 'GENERATING keys for new TEST_RESULT_GROUP ';
 
+			SELECT @curr_test_result_grp_key = CONVERT(BIGINT, IDENT_CURRENT('dbo.nrt_lab_test_result_group_key'));
+			SELECT @max_test_result_grp_key = ISNULL(MAX(TEST_RESULT_GRP_KEY), 0)
+			FROM [dbo].nrt_lab_test_result_group_key WITH (UPDLOCK, HOLDLOCK);
+
+			IF @curr_test_result_grp_key < @max_test_result_grp_key
+				DBCC CHECKIDENT ('[dbo].nrt_lab_test_result_group_key', RESEED, @max_test_result_grp_key);
+
 			INSERT INTO [dbo].nrt_lab_test_result_group_key (LAB_TEST_UID)
-			SELECT lab_test_uid
-			FROM #TEST_Result_Group_N
+			SELECT DISTINCT n.lab_test_uid
+			FROM #TEST_Result_Group_N n
+			LEFT JOIN [dbo].nrt_lab_test_result_group_key ck WITH (NOLOCK)
+				ON ck.LAB_TEST_UID = n.LAB_TEST_UID
+			WHERE ck.LAB_TEST_UID IS NULL
 
 			SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/290-sp_ldf_foodborne_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/290-sp_ldf_foodborne_datamart_postprocessing-001.sql
@@ -890,8 +890,9 @@ BEGIN
         FROM  INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'LDF_FOODBORNE'
             AND COLUMN_NAME NOT IN  ('INVESTIGATION_KEY', 'INVESTIGATION_LOCAL_ID', 'PROGRAM_JURISDICTION_OID', 'PATIENT_KEY', 'PATIENT_LOCAL_ID', 'DISEASE_NAME', 'DISEASE_CD')
             
-        SET  @dynamiccolumnUpdate=substring(@dynamiccolumnUpdate,1,len(@dynamiccolumnUpdate)-1) 
-
+        IF LEN(@dynamiccolumnUpdate) > 0
+        BEGIN
+            SET @dynamiccolumnUpdate = SUBSTRING(@dynamiccolumnUpdate, 1, LEN(@dynamiccolumnUpdate) - 1);
 
             EXEC ('update TBL SET ' +   @dynamiccolumnUpdate + ' FROM  
             dbo.LDF_FOODBORNE TBL inner join  
@@ -902,7 +903,12 @@ BEGIN
             LEFT JOIN (SELECT DISTINCT INVESTIGATION_UID FROM DBO.LDF_DIMENSIONAL_DATA WITH (NOLOCK)) LDF_DIMENSIONAL_DATA 
             ON LDF_DIMENSIONAL_DATA.INVESTIGATION_UID = INV.CASE_UID
             WHERE LDF_DIMENSIONAL_DATA.INVESTIGATION_UID IS NULL;
-        ');
+            ');
+        END
+        ELSE
+        BEGIN
+            SELECT @ROWCOUNT_NO = 0;
+        END
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT; 
         


### PR DESCRIPTION
## Description
This PR fixes two SQL post-processing defects that can fail replay/post-processing under common edge cases.

### Problem

1. LDF_FOODBORNE post-processing could fail with invalid SUBSTRING/length when dynamic update column list is empty.
2. LAB test result post-processing could fail with duplicate key issues in nrt_lab_test_result_group_key when identity and existing data diverge or duplicates are attempted.

### Root Cause

- Missing guard around dynamic SQL string trimming/execution.
- Key-generation flow did not fully protect against identity lag and duplicate LAB_TEST_UID inserts.

### Changes

- In 290-sp_ldf_foodborne_datamart_postprocessing-001.sql:
  - Add guard for empty dynamic column update string before SUBSTRING/EXEC.
  - Set rowcount to 0 when no dynamic update is needed.
- In 017-sp_d_labtest_result_postprocessing-001.sql:
  - Add identity vs max-key check and reseed when needed.
  - Insert TEST_RESULT_GROUP keys with dedup logic (insert only missing LAB_TEST_UID values).

### Validation
SQL routines updated and replay path no longer hits the previously observed failures in local runs.

## Related Issue
Uncovered while working on [APP-530](https://cdc-nbs.atlassian.net/browse/APP-530)

## Additional Notes
N/A

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~~I have updated the documentation, if applicable.~~
- [ ] ~~I have added or updated test cases to cover my changes, if applicable.~~
 
