### PR TITLE
Fix observation key isolation in reporting pipeline observation processing

### DIFF
--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
@@ -90,8 +90,6 @@ public class ObservationService {
   public static final ToLongFunction<ConsumerRecord<String, String>> toBatchId =
       rec -> rec.timestamp() + rec.offset() + rec.partition();
 
-  ObservationKey observationKey = new ObservationKey();
-
   private static final String SERVICE_NAME = "observation-reporting";
 
   private final CustomMetrics metrics;
@@ -170,6 +168,7 @@ public class ObservationService {
                 isFromObservationTopic
                     ? extractUid(value, "observation_uid")
                     : actRelationshipSourceActUid;
+            ObservationKey observationKey = new ObservationKey();
             observationKey.setObservationUid(Long.valueOf(observationUid));
             logger.info(topicDebugLog, observationUid, observationTopic);
             Optional<Observation> observationData =
@@ -181,6 +180,13 @@ public class ObservationService {
                   processObservationDataUtil.transformObservationData(
                       observationData.get(), batchId);
               modelMapper.map(observationTransformed, reportingModel);
+              logger.info(
+                  "Publishing observation message to {} with key observation_uid={} payload observation_uid={} domain={} ctrl_cd_display_form={}",
+                  observationTopicOutputReporting,
+                  observationKey.getObservationUid(),
+                  reportingModel.getObservationUid(),
+                  reportingModel.getObsDomainCdSt1(),
+                  reportingModel.getCtrlCdDisplayForm());
               pushKeyValuePairToKafka(
                   observationKey, reportingModel, observationTopicOutputReporting);
               logger.info(

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/transformer/ProcessObservationDataUtil.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/transformer/ProcessObservationDataUtil.java
@@ -56,8 +56,6 @@ public class ProcessObservationDataUtil {
   @Value("${spring.kafka.topics.nrt.observation-txt}")
   public String txtTopicName;
 
-  ObservationKey observationKey = new ObservationKey();
-
   private static final String SUBJECT_CLASS_CD = "subject_class_cd";
   public static final String TYPE_CD = "type_cd";
   public static final String ENTITY_ID = "entity_id";
@@ -72,7 +70,6 @@ public class ProcessObservationDataUtil {
     observationTransformed.setReportObservationUid(observation.getObservationUid());
     observationTransformed.setBatchId(batchId);
 
-    observationKey.setObservationUid(observation.getObservationUid());
     String obsDomainCdSt1 = observation.getObsDomainCdSt1();
 
     transformPersonParticipations(
@@ -396,10 +393,10 @@ public class ProcessObservationDataUtil {
     try {
       JsonNode observationCodedJsonArray = parseJsonArray(observationCoded);
 
-      ObservationCodedKey codedKey = new ObservationCodedKey();
       for (JsonNode jsonNode : observationCodedJsonArray) {
         ObservationCoded coded = objectMapper.treeToValue(jsonNode, ObservationCoded.class);
         coded.setBatchId(batchId);
+        ObservationCodedKey codedKey = new ObservationCodedKey();
         codedKey.setObservationUid(coded.getObservationUid());
         codedKey.setOvcCode(coded.getOvcCode());
         sendToKafka(
@@ -425,6 +422,8 @@ public class ProcessObservationDataUtil {
       for (JsonNode jsonNode : observationDateJsonArray) {
         ObservationDate obsDate = objectMapper.treeToValue(jsonNode, ObservationDate.class);
         obsDate.setBatchId(batchId);
+        ObservationKey observationKey = new ObservationKey();
+        observationKey.setObservationUid(obsDate.getObservationUid());
         sendToKafka(
             observationKey,
             obsDate,
@@ -470,6 +469,8 @@ public class ProcessObservationDataUtil {
       for (JsonNode jsonNode : observationNumericJsonArray) {
         ObservationNumeric numeric = objectMapper.treeToValue(jsonNode, ObservationNumeric.class);
         numeric.setBatchId(batchId);
+        ObservationKey observationKey = new ObservationKey();
+        observationKey.setObservationUid(numeric.getObservationUid());
         sendToKafka(
             observationKey,
             numeric,
@@ -490,10 +491,10 @@ public class ProcessObservationDataUtil {
     try {
       JsonNode observationReasonsJsonArray = parseJsonArray(observationReasons);
 
-      ObservationReasonKey reasonKey = new ObservationReasonKey();
       for (JsonNode jsonNode : observationReasonsJsonArray) {
         ObservationReason reason = objectMapper.treeToValue(jsonNode, ObservationReason.class);
         reason.setBatchId(batchId);
+        ObservationReasonKey reasonKey = new ObservationReasonKey();
         reasonKey.setObservationUid(reason.getObservationUid());
         reasonKey.setReasonCd(reason.getReasonCd());
         sendToKafka(
@@ -516,10 +517,10 @@ public class ProcessObservationDataUtil {
     try {
       JsonNode observationTxtJsonArray = parseJsonArray(observationTxt);
 
-      ObservationTxtKey txtKey = new ObservationTxtKey();
       for (JsonNode jsonNode : observationTxtJsonArray) {
         ObservationTxt txt = objectMapper.treeToValue(jsonNode, ObservationTxt.class);
         txt.setBatchId(batchId);
+        ObservationTxtKey txtKey = new ObservationTxtKey();
         txtKey.setObservationUid(txt.getObservationUid());
         txtKey.setOvtSeq(txt.getOvtSeq());
         sendToKafka(


### PR DESCRIPTION
## Description
This PR fixes observation message key/state handling in reporting-pipeline-service so each publish uses isolated key objects per message/record. This prevents key/value mismatches and downstream post-processing misclassification.

Testing intermittently produced incorrect observation processing behavior (including missing expected downstream results such as EVENT_METRIC population), caused by mutable key objects being reused across processing paths.

Shared mutable key state existed in singleton components:

- ObservationService.java
- ProcessObservationDataUtil.java
 
### Changes

- Create per-message ObservationKey in ObservationService before publishing nrt_observation.
- Add publish diagnostics logging for key observation_uid vs payload observation_uid.
- Remove shared ObservationKey usage in transformer and localize key creation where needed.

## Related Issue
Uncovered while working on [APP-530](https://cdc-nbs.atlassian.net/browse/APP-530)


## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~~I have updated the documentation, if applicable.~~
- [ ] ~~I have added or updated test cases to cover my changes, if applicable.~~
 
