### PR TITLE
Add setup.sql replay tool and harden local DB tracing/replay workflows

### DIFF
--- a/testing-tools/local-db-tracing/README.md
+++ b/testing-tools/local-db-tracing/README.md
@@ -241,6 +241,12 @@ Build step-level functional test artifacts (`setup.sql`, `query.sql`, `expected.
 python local-db-tracing/build_step_test_artifacts.py --setup-step local-db-tracing/output/20260423-103745-NBS_ODSE-to-RDB_MODERN/cdc-NBS_ODSE/step-3 --logical-step local-db-tracing/output/20260423-103745-NBS_ODSE-to-RDB_MODERN/logical-RDB_MODERN/step-3 --test-step reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/030-Investigate-AddTreatmentStartSalmonella
 ```
 
+Replay an existing functional `setup.sql` against ODSE, optionally rewriting only auto-populated datetime/date columns to current-time expressions:
+
+```powershell
+python local-db-tracing/replay-setup.py --setup-sql reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/010-CreatePatient-AddLabReportManualSalmonella/setup.sql --auto-datetime-mode current
+```
+
 Or run it without arguments and enter paths when prompted:
 
 ```powershell

--- a/testing-tools/local-db-tracing/replay_setup.py
+++ b/testing-tools/local-db-tracing/replay_setup.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+from tracing_env import load_database_connection_defaults, resolve_server_argument
+from tracing_constants import ALWAYS_REPLACE_COLUMN_NAMES
+from tracing_metadata import fetch_auto_datetime_columns, fetch_column_sql_types
+from tracing_sql import SqlCmdClient, require_sqlcmd
+
+
+USE_DATABASE_PATTERN = re.compile(r"^\s*USE\s+\[(?P<database>[^\]]+)\]\s*;\s*$", re.IGNORECASE | re.MULTILINE)
+INSERT_PATTERN = re.compile(
+    r"^(?P<prefix>\s*INSERT\s+INTO\s+\[(?P<schema>[^\]]+)\]\.\[(?P<table>[^\]]+)\]\s*)"
+    r"\((?P<columns>.*?)\)(?P<between>.*?)\bVALUES\s*\((?P<values>.*)\)(?P<suffix>\s*;\s*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+UPDATE_PATTERN = re.compile(
+    r"^(?P<prefix>\s*UPDATE\s+\[(?P<schema>[^\]]+)\]\.\[(?P<table>[^\]]+)\]\s+SET\s+)"
+    r"(?P<assignments>.*?)(?P<suffix>\s+WHERE\s+.*;\s*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+ASSIGNMENT_PATTERN = re.compile(r"^\s*\[(?P<column>[^\]]+)\]\s*=\s*(?P<value>.+?)\s*$", re.DOTALL)
+HARDCODED_DATE_LITERAL_PATTERN = re.compile(
+    r"^N?'\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}:\d{2}(?:\.\d{1,7})?)?'$",
+    re.IGNORECASE,
+)
+
+DATABASE_ENV_KEYS = ("DATABASE_NAME", "DB_ODSE", "ODSE_DATABASE")
+AUTO_DATETIME_MODE_CHOICES = {"current", "preserve"}
+
+# Matches UID DECLARE lines like: DECLARE @dbo_Entity_entity_uid bigint = 14217;
+# Only matches @dbo_-prefixed variables; does NOT match @superuser_id or nvarchar local-id derivations.
+UID_DECLARE_PATTERN = re.compile(
+    r"^(?P<indent>\s*)DECLARE\s+(?P<name>@dbo_[A-Za-z0-9_]+)\s+bigint\s*=\s*(?P<value>-?\d+)\s*;\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    defaults = load_database_connection_defaults()
+
+    parser = argparse.ArgumentParser(
+        description="Run a setup.sql against ODSE, optionally rewriting auto-populated datetime/date literals."
+    )
+    parser.add_argument("--setup-sql", required=True, help="Path to the setup.sql file to execute")
+    parser.add_argument(
+        "--auto-datetime-mode",
+        choices=sorted(AUTO_DATETIME_MODE_CHOICES),
+        help="Choose 'current' to rewrite eligible hardcoded inserted timestamps/dates or 'preserve' to leave the SQL unchanged",
+    )
+    parser.add_argument(
+        "--server",
+        default=resolve_server_argument(defaults),
+        help="SQL Server host and port; defaults to DATABASE_SERVER and DATABASE_PORT from .env",
+    )
+    parser.add_argument(
+        "--database",
+        help="Target database; defaults to --database, then USE [database] in the script, then DATABASE_NAME/DB_ODSE/ODSE_DATABASE, then NBS_ODSE",
+    )
+    parser.add_argument(
+        "--user",
+        default=defaults.get("DATABASE_USERNAME"),
+        help="SQL Server login; defaults to DATABASE_USERNAME from .env",
+    )
+    parser.add_argument(
+        "--password",
+        default=defaults.get("DATABASE_PASSWORD"),
+        help="SQL Server password; defaults to DATABASE_PASSWORD from .env",
+    )
+    parser.add_argument("--sqlcmd", default="sqlcmd", help="sqlcmd executable name or path")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print the SQL that would be executed to stdout without writing to the database",
+    )
+    return parser.parse_args(argv)
+
+
+def prompt_auto_datetime_mode() -> str:
+    while True:
+        response = input("Rewrite eligible inserted timestamps/dates to CURRENT_TIMESTAMP? [y/n]: ").strip().lower()
+        if response in {"y", "yes"}:
+            return "current"
+        if response in {"n", "no"}:
+            return "preserve"
+        print("Please enter y or n.")
+
+
+def prompt_starting_id() -> int | None:
+    """Ask the user for a starting UID. Returns None if they press Enter without input."""
+    response = input("Starting UID for renumbering (press Enter to keep existing IDs): ").strip()
+    if not response:
+        return None
+    try:
+        return int(response)
+    except ValueError:
+        print(f"Invalid integer '{response}', keeping existing IDs.")
+        return None
+
+
+def rewrite_uid_declarations(sql_text: str, starting_id: int) -> tuple[str, int]:
+    """Renumber all bigint UID DECLARE lines sequentially from starting_id."""
+    lines = sql_text.splitlines(keepends=True)
+    counter = starting_id
+    rewrites = 0
+    result: list[str] = []
+    for line in lines:
+        match = UID_DECLARE_PATTERN.match(line.rstrip("\n").rstrip("\r"))
+        if match:
+            new_line = f"{match.group('indent')}DECLARE {match.group('name')} bigint = {counter};\n"
+            counter += 1
+            rewrites += 1
+            result.append(new_line)
+        else:
+            result.append(line)
+    return "".join(result), rewrites
+
+
+def split_top_level_csv(text: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    in_string = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "'":
+            current.append(char)
+            if in_string and index + 1 < len(text) and text[index + 1] == "'":
+                current.append(text[index + 1])
+                index += 2
+                continue
+            in_string = not in_string
+            index += 1
+            continue
+        if not in_string:
+            if char == "(":
+                depth += 1
+            elif char == ")" and depth > 0:
+                depth -= 1
+            elif char == "," and depth == 0:
+                parts.append("".join(current).strip())
+                current = []
+                index += 1
+                continue
+        current.append(char)
+        index += 1
+
+    tail = "".join(current).strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def normalize_column_name(column_token: str) -> str:
+    stripped = column_token.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        return stripped[1:-1]
+    return stripped
+
+
+def replacement_expression(sql_type: str) -> str:
+    lowered = sql_type.lower()
+    if lowered == "date":
+        return "CAST(CURRENT_TIMESTAMP AS date)"
+    if lowered == "time":
+        return "CAST(CURRENT_TIMESTAMP AS time)"
+    if lowered.startswith("datetimeoffset"):
+        return "CAST(CURRENT_TIMESTAMP AS datetimeoffset)"
+    if lowered.startswith("datetime2"):
+        return "CAST(CURRENT_TIMESTAMP AS datetime2)"
+    if lowered.startswith("smalldatetime"):
+        return "CAST(CURRENT_TIMESTAMP AS smalldatetime)"
+    return "CURRENT_TIMESTAMP"
+
+
+def should_replace_literal(value_token: str) -> bool:
+    return bool(HARDCODED_DATE_LITERAL_PATTERN.match(value_token.strip()))
+
+
+def rewrite_insert_statement(
+    statement: str,
+    eligible_columns: set[tuple[str, str, str]],
+    column_types: dict[tuple[str, str, str], str],
+) -> tuple[str, int]:
+    match = INSERT_PATTERN.match(statement)
+    if not match:
+        return statement, 0
+
+    schema_name = match.group("schema")
+    table_name = match.group("table")
+    columns = split_top_level_csv(match.group("columns"))
+    values = split_top_level_csv(match.group("values"))
+    if len(columns) != len(values):
+        return statement, 0
+
+    replacements = 0
+    rewritten_values: list[str] = []
+    for column_token, value_token in zip(columns, values):
+        column_name = normalize_column_name(column_token)
+        column_key = (schema_name, table_name, column_name)
+        rewritten_value = value_token
+        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and should_replace_literal(value_token):
+            sql_type = column_types.get(column_key, "datetime")
+            rewritten_value = replacement_expression(sql_type)
+            replacements += 1
+        rewritten_values.append(rewritten_value)
+
+    if replacements == 0:
+        return statement, 0
+
+    rebuilt = (
+        f"{match.group('prefix')}({match.group('columns')})"
+        f"{match.group('between')}VALUES ({', '.join(rewritten_values)}){match.group('suffix')}"
+    )
+    return rebuilt, replacements
+
+
+def rewrite_update_statement(
+    statement: str,
+    eligible_columns: set[tuple[str, str, str]],
+    column_types: dict[tuple[str, str, str], str],
+) -> tuple[str, int]:
+    match = UPDATE_PATTERN.match(statement)
+    if not match:
+        return statement, 0
+
+    schema_name = match.group("schema")
+    table_name = match.group("table")
+    assignments = split_top_level_csv(match.group("assignments"))
+    replacements = 0
+    rewritten_assignments: list[str] = []
+
+    for assignment in assignments:
+        assignment_match = ASSIGNMENT_PATTERN.match(assignment)
+        if not assignment_match:
+            rewritten_assignments.append(assignment)
+            continue
+
+        column_name = assignment_match.group("column")
+        value_token = assignment_match.group("value")
+        column_key = (schema_name, table_name, column_name)
+        rewritten_assignment = assignment
+        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and should_replace_literal(value_token):
+            sql_type = column_types.get(column_key, "datetime")
+            rewritten_assignment = f"[{column_name}] = {replacement_expression(sql_type)}"
+            replacements += 1
+        rewritten_assignments.append(rewritten_assignment)
+
+    if replacements == 0:
+        return statement, 0
+
+    rebuilt = f"{match.group('prefix')}{', '.join(rewritten_assignments)}{match.group('suffix')}"
+    return rebuilt, replacements
+
+
+def rewrite_setup_sql(
+    sql_text: str,
+    eligible_columns: set[tuple[str, str, str]],
+    column_types: dict[tuple[str, str, str], str],
+) -> tuple[str, int]:
+    rewritten_lines: list[str] = []
+    replacements = 0
+    for line in sql_text.splitlines():
+        updated_line, line_replacements = rewrite_insert_statement(line, eligible_columns, column_types)
+        if line_replacements == 0:
+            updated_line, line_replacements = rewrite_update_statement(line, eligible_columns, column_types)
+        rewritten_lines.append(updated_line)
+        replacements += line_replacements
+    rewritten_sql = "\n".join(rewritten_lines)
+    if sql_text.endswith("\n"):
+        rewritten_sql += "\n"
+    return rewritten_sql, replacements
+
+
+def resolve_database_name(explicit_database: str | None, defaults: dict[str, str], sql_text: str) -> str:
+    if explicit_database:
+        return explicit_database
+
+    match = USE_DATABASE_PATTERN.search(sql_text)
+    if match:
+        return match.group("database")
+
+    for key in DATABASE_ENV_KEYS:
+        value = defaults.get(key) or os.environ.get(key)
+        if value:
+            return value
+
+    return "NBS_ODSE"
+
+
+def execute_setup_sql(args: argparse.Namespace) -> int:
+    defaults = load_database_connection_defaults()
+    setup_path = Path(args.setup_sql).expanduser().resolve()
+    if not setup_path.is_file():
+        raise SystemExit(f"setup.sql file not found: {setup_path}")
+
+    mode = args.auto_datetime_mode or prompt_auto_datetime_mode()
+    starting_id = prompt_starting_id()
+    sql_text = setup_path.read_text(encoding="utf-8")
+    database = resolve_database_name(args.database, defaults, sql_text)
+
+    if starting_id is not None:
+        sql_text, uid_rewrites = rewrite_uid_declarations(sql_text, starting_id)
+    else:
+        uid_rewrites = 0
+
+    if args.debug:
+        sql_to_run = sql_text
+        replacement_count = 0
+        if mode == "current":
+            executable = require_sqlcmd(args.sqlcmd)
+            client = SqlCmdClient(executable, args.server, database, args.user or "", args.password or "")
+            eligible_columns = fetch_auto_datetime_columns(client)
+            column_types = fetch_column_sql_types(client)
+            sql_to_run, replacement_count = rewrite_setup_sql(sql_text, eligible_columns, column_types)
+        print(f"-- DEBUG: would execute against database '{database}' (auto-datetime mode '{mode}')")
+        if uid_rewrites:
+            print(f"-- DEBUG: {uid_rewrites} UID declaration(s) renumbered starting from {starting_id}")
+        if mode == "current":
+            print(f"-- DEBUG: {replacement_count} eligible hardcoded datetime/date literal(s) would be replaced")
+        print(sql_to_run, end="")
+        return 0
+
+    if not args.user:
+        raise SystemExit("--user is required unless DATABASE_USERNAME is set in .env or the environment")
+    if not args.password:
+        raise SystemExit("--password is required unless DATABASE_PASSWORD is set in .env or the environment")
+
+    executable = require_sqlcmd(args.sqlcmd)
+    client = SqlCmdClient(executable, args.server, database, args.user, args.password)
+
+    sql_to_run = sql_text
+    replacement_count = 0
+    if mode == "current":
+        eligible_columns = fetch_auto_datetime_columns(client)
+        column_types = fetch_column_sql_types(client)
+        sql_to_run, replacement_count = rewrite_setup_sql(sql_text, eligible_columns, column_types)
+
+    client.query(sql_to_run, database=database)
+    print(f"Executed {setup_path} against {database} using auto-datetime mode '{mode}'.")
+    if uid_rewrites:
+        print(f"Renumbered {uid_rewrites} UID declaration(s) starting from {starting_id}.")
+    if mode == "current":
+        print(f"Replaced {replacement_count} eligible hardcoded datetime/date literal(s).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return execute_setup_sql(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/testing-tools/local-db-tracing/test_replay.py
+++ b/testing-tools/local-db-tracing/test_replay.py
@@ -338,6 +338,82 @@ class ReplaySqlTest(unittest.TestCase):
         self.assertNotIn("-- STEP", sql)
         self.assertNotIn("-- step:", sql)
 
+    def test_step_specific_sql_rewrites_prior_step_variable_in_where_clause(self) -> None:
+        step1_insert = {
+            "schema_name": "dbo",
+            "table_name": "NBS_act_entity",
+            "operation": "insert",
+            "start_lsn": "0x01",
+            "seqval": "0x01",
+            "operation_code": 2,
+            "_step": 1,
+            "row": {
+                "nbs_act_entity_uid": 9001,
+                "act_uid": 3300008,
+                "entity_uid": 3300013,
+                "type_cd": "SubjOfPHC",
+            },
+        }
+        step2_update_before = {
+            "schema_name": "dbo",
+            "table_name": "NBS_act_entity",
+            "operation": "update_before",
+            "start_lsn": "0x02",
+            "seqval": "0x01",
+            "operation_code": 3,
+            "_step": 2,
+            "row": {
+                "nbs_act_entity_uid": 9001,
+                "act_uid": 3300008,
+                "entity_uid": 3300013,
+                "type_cd": "SubjOfPHC",
+                "last_chg_time": "2026-05-06T22:21:08.813",
+            },
+        }
+        step2_update_after = {
+            "schema_name": "dbo",
+            "table_name": "NBS_act_entity",
+            "operation": "update_after",
+            "start_lsn": "0x02",
+            "seqval": "0x01",
+            "operation_code": 4,
+            "_step": 2,
+            "row": {
+                "nbs_act_entity_uid": 9001,
+                "act_uid": 3300008,
+                "entity_uid": 3300013,
+                "type_cd": "SubjOfPHC",
+                "last_chg_time": "2026-05-06T22:21:08.900",
+            },
+        }
+        nbs_steps = [
+            {"step": 1, "description": "Create NBS act entity"},
+            {"step": 2, "description": "Update NBS act entity"},
+        ]
+
+        sql = "\n".join(
+            reconstruct_sql_statements(
+                [step1_insert, step2_update_before, step2_update_after],
+                {("dbo", "NBS_act_entity"): ["nbs_act_entity_uid"]},
+                {("dbo", "NBS_act_entity"): ["nbs_act_entity_uid"]},
+                {},
+                {("dbo", "NBS_act_entity", "nbs_act_entity_uid"): "bigint", ("dbo", "NBS_act_entity", "act_uid"): "bigint", ("dbo", "NBS_act_entity", "entity_uid"): "bigint", ("dbo", "NBS_act_entity", "type_cd"): "nvarchar(50)", ("dbo", "NBS_act_entity", "last_chg_time"): "datetime"},
+                set(),
+                self.uid_generator_entries,
+                self.known_associations,
+                nbs_steps=nbs_steps,
+                emit_only_step=2,
+            )
+        )
+
+        self.assertIn("-- STEP 2: Update NBS act entity", sql)
+        self.assertIn("SELECT TOP 1 [nbs_act_entity_uid] FROM [dbo].[NBS_act_entity]", sql)
+        self.assertIn("WHERE [nbs_act_entity_uid] = (SELECT TOP 1 [nbs_act_entity_uid] FROM [dbo].[NBS_act_entity]", sql)
+        self.assertNotIn("WHERE [nbs_act_entity_uid] = @dbo_NBS_act_entity_nbs_act_entity_uid", sql)
+        self.assertNotIn("AND [add_time] =", sql)
+        self.assertNotIn("AND [last_chg_time] =", sql)
+        self.assertNotIn("AND [record_status_time] =", sql)
+
     def test_summary_lists_steps_at_top(self) -> None:
         """summary.txt starts with ordered Steps section when nbs_steps provided."""
         manifest = {

--- a/testing-tools/local-db-tracing/test_replay_setup.py
+++ b/testing-tools/local-db-tracing/test_replay_setup.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import replay_setup
+
+
+class ReplaySetupTest(unittest.TestCase):
+    def test_rewrite_setup_sql_updates_only_eligible_columns(self) -> None:
+        sql = (
+            "INSERT INTO [dbo].[Person] ([person_uid], [add_time], [birth_time], [last_chg_time], [record_status_time]) "
+            "VALUES (1, N'2026-04-23T14:16:11.967', N'1985-03-17T00:00:00', N'2026-04-23T14:16:11.967', N'2026-04-23T14:16:11.967');\n"
+            "INSERT INTO [dbo].[Person_name] ([person_uid], [as_of_date], [add_time]) "
+            "VALUES (1, N'2026-04-23T00:00:00', N'2026-04-23T14:16:11.960');\n"
+            "UPDATE [dbo].[Person] SET [last_chg_time] = N'2026-04-23T14:16:37.777', [birth_time] = N'1985-03-17T00:00:00' WHERE [person_uid] = 1;\n"
+        )
+
+        eligible_columns = {
+            ("dbo", "Person", "add_time"),
+            ("dbo", "Person", "last_chg_time"),
+            ("dbo", "Person", "record_status_time"),
+            ("dbo", "Person_name", "as_of_date"),
+            ("dbo", "Person_name", "add_time"),
+        }
+        column_types = {
+            ("dbo", "Person", "add_time"): "datetime2",
+            ("dbo", "Person", "last_chg_time"): "datetime2",
+            ("dbo", "Person", "record_status_time"): "datetime2",
+            ("dbo", "Person_name", "as_of_date"): "date",
+            ("dbo", "Person_name", "add_time"): "datetime",
+        }
+
+        rewritten_sql, replacement_count = replay_setup.rewrite_setup_sql(sql, eligible_columns, column_types)
+
+        self.assertEqual(replacement_count, 6)
+        self.assertIn("VALUES (1, CAST(CURRENT_TIMESTAMP AS datetime2), N'1985-03-17T00:00:00', CAST(CURRENT_TIMESTAMP AS datetime2), CAST(CURRENT_TIMESTAMP AS datetime2));", rewritten_sql)
+        self.assertIn("VALUES (1, CAST(CURRENT_TIMESTAMP AS date), CURRENT_TIMESTAMP);", rewritten_sql)
+        self.assertIn("SET [last_chg_time] = CAST(CURRENT_TIMESTAMP AS datetime2), [birth_time] = N'1985-03-17T00:00:00'", rewritten_sql)
+        self.assertIn("N'1985-03-17T00:00:00'", rewritten_sql)
+
+    def test_resolve_database_name_prefers_use_then_env(self) -> None:
+        defaults = {"DB_ODSE": "ENV_ODSE"}
+        self.assertEqual(
+            replay_setup.resolve_database_name(None, defaults, "USE [NBS_ODSE];\nSELECT 1;\n"),
+            "NBS_ODSE",
+        )
+        self.assertEqual(
+            replay_setup.resolve_database_name(None, defaults, "SELECT 1;\n"),
+            "ENV_ODSE",
+        )
+        self.assertEqual(
+            replay_setup.resolve_database_name("CLI_ODSE", defaults, "SELECT 1;\n"),
+            "CLI_ODSE",
+        )
+
+    @patch.object(replay_setup, "fetch_column_sql_types", return_value={("dbo", "Person", "add_time"): "datetime"})
+    @patch.object(replay_setup, "fetch_auto_datetime_columns", return_value={("dbo", "Person", "add_time")})
+    @patch.object(replay_setup, "require_sqlcmd", return_value="sqlcmd")
+    @patch.object(replay_setup, "SqlCmdClient")
+    @patch.object(
+        replay_setup,
+        "load_database_connection_defaults",
+        return_value={
+            "DATABASE_SERVER": "dbhost",
+            "DATABASE_PORT": "1544",
+            "DATABASE_USERNAME": "trace_user",
+            "DATABASE_PASSWORD": "secret",
+            "DB_ODSE": "ENV_ODSE",
+        },
+    )
+    def test_execute_setup_sql_prompts_for_mode_when_omitted(
+        self,
+        _: object,
+        client_cls: object,
+        __: object,
+        ___: object,
+        ____: object,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            setup_path = Path(temp_dir) / "setup.sql"
+            setup_path.write_text(
+                "INSERT INTO [dbo].[Person] ([person_uid], [add_time]) VALUES (1, N'2026-04-23T14:16:11.967');\n",
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                setup_sql=str(setup_path),
+                auto_datetime_mode=None,
+                server="dbhost,1544",
+                database=None,
+                user="trace_user",
+                password="secret",
+                sqlcmd="sqlcmd",
+            )
+            client = client_cls.return_value
+
+            with patch("builtins.input", return_value="y"):
+                exit_code = replay_setup.execute_setup_sql(args)
+
+        self.assertEqual(exit_code, 0)
+        client_cls.assert_called_once_with("sqlcmd", "dbhost,1544", "ENV_ODSE", "trace_user", "secret")
+        client.query.assert_called_once()
+        executed_sql = client.query.call_args.args[0]
+        self.assertIn("CURRENT_TIMESTAMP", executed_sql)
+        self.assertEqual(client.query.call_args.kwargs["database"], "ENV_ODSE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing-tools/local-db-tracing/test_validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/test_validate_rdb_selects.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -92,6 +94,50 @@ SELECT [id] FROM [dbo].[TableB] WHERE [id] = @id FOR JSON PATH;
         self.assertEqual(pass_result["status"], "pass")
         self.assertEqual(fail_result["status"], "fail")
         self.assertIn("does not match", str(fail_result.get("error")))
+
+    def test_parse_cases_from_expected_json_accepts_plain_selects(self) -> None:
+        sql_text = """
+USE [RDB];
+
+-- dbo.TableA | operations: insert
+SELECT [id] FROM [dbo].[TableA] WHERE [id] = 1;
+
+-- dbo.TableB | operations: insert
+SELECT [id] FROM [dbo].[TableB] WHERE [id] = 2;
+""".strip()
+
+        with TemporaryDirectory() as temp_dir:
+            expected_json_path = Path(temp_dir) / "expected.json"
+            expected_json_path.write_text(
+                json.dumps({"0": [{"id": 1}], "1": [{"id": 2}]}, indent=2),
+                encoding="utf-8",
+            )
+
+            statements, cases = validate_rdb_selects.parse_cases_from_expected_json(sql_text, expected_json_path)
+
+        self.assertEqual(len(statements), 3)
+        self.assertEqual(len(cases), 2)
+        self.assertEqual(cases[0].label, "dbo.TableA | operations: insert")
+        self.assertEqual(cases[0].expected_json, [{"id": 1}])
+        self.assertEqual(cases[1].label, "dbo.TableB | operations: insert")
+        self.assertEqual(cases[1].expected_json, [{"id": 2}])
+
+    def test_compare_case_wraps_plain_select_in_for_json_path(self) -> None:
+        case = validate_rdb_selects.SelectCase(
+            case_index=1,
+            label="plain-select-case",
+            query_sql="SELECT [id] FROM [dbo].[T] WHERE [id] = 1;",
+            query_start_line=5,
+            expected_json=[{"id": 1}],
+        )
+        client = FakeSqlClient([
+            'JSON_F52E2B61-18A1-11d1-B105-00805F49916B\n[{"id":1}]\n',
+        ])
+
+        result = validate_rdb_selects.compare_case(client, "USE [RDB];", case)
+
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("FOR JSON PATH;", client.calls[0])
 
     def test_value_level_diff_highlighting(self) -> None:
         expected = [{"id": 1, "name": "Alice"}]

--- a/testing-tools/local-db-tracing/trace_db_cdc.py
+++ b/testing-tools/local-db-tracing/trace_db_cdc.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from tracing_capture import (
     disable_managed_tables,
     enable_table_cdc,
+    fetch_cdc_enabled_tables,
     fetch_changes_for_captures,
     fetch_max_lsn,
 )
@@ -301,7 +302,12 @@ def main() -> int:
         print(f"Tracer-managed tables already recorded: {len(managed_tables)}")
 
     try:
+        cdc_enabled = fetch_cdc_enabled_tables(client)
         for table in to_enable:
+            if (table.schema_name, table.table_name) in cdc_enabled:
+                skipped_tables.append({"schema_name": table.schema_name, "table_name": table.table_name, "detail": "Already enabled"})
+                print(f"Already enabled: {table.schema_name}.{table.table_name}")
+                continue
             enabled, detail = enable_table_cdc(client, table.schema_name, table.table_name)
             entry = {"schema_name": table.schema_name, "table_name": table.table_name, "detail": detail}
             if enabled:

--- a/testing-tools/local-db-tracing/trace_db_dual_capture.py
+++ b/testing-tools/local-db-tracing/trace_db_dual_capture.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from tracing_capture import (
     disable_managed_tables,
     enable_table_cdc,
+    fetch_cdc_enabled_tables,
     fetch_changes_for_captures,
     fetch_max_lsn,
 )
@@ -250,7 +251,12 @@ def enable_missing_tables(plan: TracePlan, tables_to_enable: list[object]) -> No
     if plan.managed_tables:
         print(f"{plan_prefix(plan)} Tracer-managed tables already recorded: {len(plan.managed_tables)}")
 
+    cdc_enabled = fetch_cdc_enabled_tables(plan.client)
     for table in tables_to_enable:
+        if (table.schema_name, table.table_name) in cdc_enabled:
+            plan.skipped_tables.append({"schema_name": table.schema_name, "table_name": table.table_name, "detail": "Already enabled"})
+            print(f"{plan_prefix(plan)} Already enabled: {table.schema_name}.{table.table_name}")
+            continue
         enabled, detail = enable_table_cdc(plan.client, table.schema_name, table.table_name)
         entry = {"schema_name": table.schema_name, "table_name": table.table_name, "detail": detail}
         if enabled:

--- a/testing-tools/local-db-tracing/trace_db_logical_changes.py
+++ b/testing-tools/local-db-tracing/trace_db_logical_changes.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from tracing_capture import (
     disable_managed_tables,
     enable_table_cdc,
+    fetch_cdc_enabled_tables,
     fetch_changes_for_captures,
     fetch_max_lsn,
 )
@@ -223,7 +224,12 @@ def main() -> int:
     print(f"Tables to attempt enabling: {len(to_enable)}")
 
     try:
+        cdc_enabled = fetch_cdc_enabled_tables(client)
         for table in to_enable:
+            if (table.schema_name, table.table_name) in cdc_enabled:
+                skipped_tables.append({"schema_name": table.schema_name, "table_name": table.table_name, "detail": "Already enabled"})
+                print(f"Already enabled: {table.schema_name}.{table.table_name}")
+                continue
             enabled, detail = enable_table_cdc(client, table.schema_name, table.table_name)
             entry = {"schema_name": table.schema_name, "table_name": table.table_name, "detail": detail}
             if enabled:

--- a/testing-tools/local-db-tracing/trace_rdb_vs_rdb_modern_compare.py
+++ b/testing-tools/local-db-tracing/trace_rdb_vs_rdb_modern_compare.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 from compare_logical_changes import write_compare_markdown
-from tracing_capture import disable_managed_tables, enable_table_cdc, fetch_changes_for_captures, fetch_max_lsn
+from tracing_capture import disable_managed_tables, enable_table_cdc, fetch_cdc_enabled_tables, fetch_changes_for_captures, fetch_max_lsn
 from tracing_constants import LOCAL_TRACING_DIR
 from tracing_env import load_database_connection_defaults, resolve_server_argument
 from tracing_logical_changes import build_logical_changes, write_logical_changes
@@ -107,7 +107,12 @@ def capture_logical_window(
     print(f"[{database}] Initial CDC-enabled tables: {sum(1 for item in table_statuses if item.is_tracked_by_cdc)}")
     print(f"[{database}] Tables to attempt enabling: {len(to_enable)}")
 
+    cdc_enabled = fetch_cdc_enabled_tables(client)
     for table in to_enable:
+        if (table.schema_name, table.table_name) in cdc_enabled:
+            skipped_tables.append({"schema_name": table.schema_name, "table_name": table.table_name, "detail": "Already enabled"})
+            print(f"[{database}] Already enabled: {table.schema_name}.{table.table_name}")
+            continue
         enabled, detail = enable_table_cdc(client, table.schema_name, table.table_name)
         entry = {"schema_name": table.schema_name, "table_name": table.table_name, "detail": detail}
         if enabled:

--- a/testing-tools/local-db-tracing/tracing_capture.py
+++ b/testing-tools/local-db-tracing/tracing_capture.py
@@ -102,6 +102,23 @@ END CATCH;
 
 
 
+def fetch_cdc_enabled_tables(client: SqlCmdClient) -> set[tuple[str, str]]:
+    """Return the set of (schema_name, table_name) tuples that currently have CDC enabled.
+
+    Uses sys.sp_cdc_help_change_data_capture to discover which tables are
+    currently tracked, so callers can avoid trying to disable tables that are
+    already off.
+    """
+
+    sql = """
+SET NOCOUNT ON;
+EXEC sys.sp_cdc_help_change_data_capture;
+"""
+    rows = list(read_tsv(client.query(sql)))
+    # The stored procedure returns rows with source_schema (col 0) and source_table (col 1).
+    return {(row[0].strip(), row[1].strip()) for row in rows if len(row) >= 2}
+
+
 def disable_managed_tables(client: SqlCmdClient, managed_tables: list[dict[str, str]]) -> list[dict[str, str]]:
     """Disable all tracer-managed tables and keep only failed cleanup entries.
 
@@ -114,26 +131,32 @@ def disable_managed_tables(client: SqlCmdClient, managed_tables: list[dict[str, 
     """
 
     remaining_tables: list[dict[str, str]] = []
+    cdc_enabled = fetch_cdc_enabled_tables(client)
     for entry in managed_tables:
-        disabled, detail = disable_table_cdc(client, entry["schema_name"], entry["table_name"])
+        schema_name = entry["schema_name"]
+        table_name = entry["table_name"]
+        if (schema_name, table_name) not in cdc_enabled:
+            print(f"Already disabled: {schema_name}.{table_name}")
+            continue
+        disabled, detail = disable_table_cdc(client, schema_name, table_name)
         if disabled:
-            print(f"Disabled CDC: {entry['schema_name']}.{entry['table_name']}")
+            print(f"Disabled CDC: {schema_name}.{table_name}")
             continue
 
         message = detail.strip()
         lowered = message.lower()
         if "is not enabled for change data capture" in lowered or "does not have change data capture enabled" in lowered:
-            print(f"Already disabled: {entry['schema_name']}.{entry['table_name']}")
+            print(f"Already disabled: {schema_name}.{table_name}")
             continue
 
         remaining_tables.append(
             {
-                "schema_name": entry["schema_name"],
-                "table_name": entry["table_name"],
+                "schema_name": schema_name,
+                "table_name": table_name,
                 "detail": message,
             }
         )
-        print(f"Cleanup failed: {entry['schema_name']}.{entry['table_name']} | {message}")
+        print(f"Cleanup failed: {schema_name}.{table_name} | {message}")
     return remaining_tables
 
 

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -75,3 +75,15 @@ GENERIC_LOCAL_ID_PATTERN = re.compile(r"^(?P<prefix>[^0-9]+)(?P<number>\d+)(?P<s
 REPLAY_DATETIME_LITERAL_PATTERN = re.compile(
     r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
 )
+
+# These column names are always rewritten to CURRENT_TIMESTAMP when auto-datetime mode is 'current',
+# regardless of whether the DB metadata reports them as having a function-based DEFAULT.
+ALWAYS_REPLACE_COLUMN_NAMES: frozenset[str] = frozenset({
+    "last_chg_time",
+    "record_status_time",
+    "status_time",
+    "add_time",
+    "activity_to_time",
+    "rpt_to_state_time",
+    "as_of_date"
+})

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -88,3 +88,11 @@ ALWAYS_REPLACE_COLUMN_NAMES: frozenset[str] = frozenset({
     "rpt_to_state_time",
     "as_of_date"
 })
+
+# Used by step-scoped replay lookup subqueries that re-find NBS_act_entity rows when prior-step UID vars are unavailable.
+# Timestamp audit fields are ignored because when recreating with CURRENT_TIMESTAMP, these would be invalid.
+NBS_ACT_ENTITY_LOOKUP_EXCLUDED_COLUMNS: frozenset[str] = frozenset({
+    "add_time",
+    "last_chg_time",
+    "record_status_time",
+})

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -44,6 +44,7 @@ EXCLUDED_ARTIFACT_TABLES = {
 
 # These table prefixes are excluded from query.sql and expected.json
 EXCLUDED_ARTIFACT_TABLE_PREFIXES = {
+    "LOOKUP_TABLE_N_"
 }
 
 # These columns are excluded from query.sql and expected.json (no matter the table)

--- a/testing-tools/local-db-tracing/tracing_replay.py
+++ b/testing-tools/local-db-tracing/tracing_replay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime
 
 from tracing_constants import (
@@ -11,6 +12,7 @@ from tracing_constants import (
     DEFAULT_STARTING_UID,
     DEFAULT_UID_BLOCK_SIZE_BY_CLASS,
     GENERIC_LOCAL_ID_PATTERN,
+    NBS_ACT_ENTITY_LOOKUP_EXCLUDED_COLUMNS,
 )
 from tracing_models import KnownAssociation, UidAllocation, UidGeneratorEntry
 from tracing_paths import (
@@ -34,6 +36,14 @@ LOCAL_ID_EXPRESSION_PATTERN = re.compile(
 )
 VAR_PLUS_OFFSET_PATTERN = re.compile(r"^(?P<left>@[A-Za-z0-9_]+)\s*\+\s*(?P<offset>-?\d+)$")
 OFFSET_PLUS_VAR_PATTERN = re.compile(r"^(?P<offset>-?\d+)\s*\+\s*(?P<right>@[A-Za-z0-9_]+)$")
+
+
+@dataclass(frozen=True)
+class VariableSource:
+    table_key: tuple[str, str]
+    column_name: str
+    row: dict[str, object]
+    step: int | None
 
 
 
@@ -771,6 +781,83 @@ def resolve_variable_reference(
     return resolve_suffix_variable_reference(column_name, value, variable_registry)
 
 
+def lookup_columns_for_variable_source(
+    table_key: tuple[str, str],
+    source_column: str,
+    row: dict[str, object],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+) -> list[str]:
+    excluded_columns = set()
+    if table_key[0].lower() == "dbo" and table_key[1].lower() == "nbs_act_entity":
+        excluded_columns = NBS_ACT_ENTITY_LOOKUP_EXCLUDED_COLUMNS
+
+    primary_key_columns = [
+        column_name
+        for column_name in primary_keys_by_table.get(table_key, [])
+        if column_name in row
+        and column_name != source_column
+        and column_name.lower() not in excluded_columns
+        and not is_generated_always_column(table_key, column_name, generated_always_columns)
+    ]
+    if primary_key_columns:
+        return primary_key_columns
+
+    return [
+        column_name
+        for column_name in data_columns(row)
+        if column_name != source_column
+        and column_name.lower() not in excluded_columns
+        and not is_generated_always_column(table_key, column_name, generated_always_columns)
+    ]
+
+
+def resolve_variable_lookup_expression(
+    variable_name: str,
+    variable_sources_by_name: dict[str, VariableSource],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_registry: dict[tuple[str, str, str, str], str],
+    foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
+    known_associations: list[KnownAssociation],
+    emit_only_step: int | None,
+) -> str:
+    if emit_only_step is None:
+        return variable_name
+
+    source = variable_sources_by_name.get(variable_name)
+    if source is None or source.step is None or source.step >= emit_only_step:
+        return variable_name
+
+    lookup_columns = lookup_columns_for_variable_source(
+        source.table_key,
+        source.column_name,
+        source.row,
+        primary_keys_by_table,
+        generated_always_columns,
+    )
+    if not lookup_columns:
+        return variable_name
+
+    predicates: list[str] = []
+    for column_name in lookup_columns:
+        value = source.row.get(column_name)
+        if value is None:
+            predicates.append(f"{quote_identifier(column_name)} IS NULL")
+        else:
+            predicates.append(
+                f"{quote_identifier(column_name)} = {sql_value_expression(source.table_key, source.row, column_name, value, None, variable_registry, foreign_keys_by_source, known_associations, primary_keys_by_table, generated_always_columns, variable_sources_by_name, emit_only_step)}"
+            )
+
+    if not predicates:
+        return variable_name
+
+    return (
+        f"(SELECT TOP 1 {quote_identifier(source.column_name)} FROM {quote_identifier(source.table_key[0])}.{quote_identifier(source.table_key[1])} "
+        f"WHERE {' AND '.join(predicates)})"
+    )
+
+
 def local_id_numeric_expression(
     table_key: tuple[str, str],
     row: dict[str, object],
@@ -822,6 +909,10 @@ def sql_value_expression(
     variable_registry: dict[tuple[str, str, str, str], str],
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     variable_reference = resolve_variable_reference(
         table_key,
@@ -833,7 +924,16 @@ def sql_value_expression(
         known_associations,
     )
     if variable_reference:
-        return variable_reference
+        return resolve_variable_lookup_expression(
+            variable_reference,
+            variable_sources_by_name,
+            primary_keys_by_table,
+            generated_always_columns,
+            variable_registry,
+            foreign_keys_by_source,
+            known_associations,
+            emit_only_step,
+        )
     return sql_literal(value)
 
 
@@ -848,6 +948,10 @@ def sql_replay_assignment_expression(
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
     superuser_id: int,
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     if is_user_id_column(column_name):
         return SUPERUSER_ID_VARIABLE
@@ -860,6 +964,10 @@ def sql_replay_assignment_expression(
         variable_registry,
         foreign_keys_by_source,
         known_associations,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
     )
 
 
@@ -871,11 +979,25 @@ def build_version_lookup_predicates(
     variable_registry: dict[tuple[str, str, str, str], str],
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     key_columns = [column_name for column_name in primary_keys_by_table.get(table_key, []) if not is_version_column(column_name)]
     if not key_columns:
         key_columns = [column_name for column_name in data_columns(row) if not is_version_column(column_name)]
-    return build_where_clause(table_key, row, key_columns, variable_registry, foreign_keys_by_source, known_associations)
+    return build_where_clause(
+        table_key,
+        row,
+        key_columns,
+        variable_registry,
+        foreign_keys_by_source,
+        known_associations,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
+    )
 
 
 
@@ -890,6 +1012,9 @@ def sql_insert_assignment_expression(
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
     superuser_id: int,
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     if is_version_column(column_name) and is_history_table(table_key):
         predicates = build_version_lookup_predicates(
@@ -899,6 +1024,9 @@ def sql_insert_assignment_expression(
             variable_registry,
             foreign_keys_by_source,
             known_associations,
+            generated_always_columns,
+            variable_sources_by_name,
+            emit_only_step,
         )
         return (
             f"(SELECT ISNULL(MAX({quote_identifier(column_name)}), 0) + 1 "
@@ -915,6 +1043,10 @@ def sql_insert_assignment_expression(
         foreign_keys_by_source,
         known_associations,
         superuser_id,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
     )
 
 
@@ -929,6 +1061,10 @@ def sql_update_assignment_expression(
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
     superuser_id: int,
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     if is_version_column(column_name):
         return f"ISNULL({quote_identifier(column_name)}, 0) + 1"
@@ -942,6 +1078,10 @@ def sql_update_assignment_expression(
         foreign_keys_by_source,
         known_associations,
         superuser_id,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
     )
 
 
@@ -970,6 +1110,10 @@ def build_where_clause(
     variable_registry: dict[tuple[str, str, str, str], str],
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str:
     predicates: list[str] = []
     for column_name in key_columns:
@@ -978,7 +1122,7 @@ def build_where_clause(
             predicates.append(f"{quote_identifier(column_name)} IS NULL")
         else:
             predicates.append(
-                f"{quote_identifier(column_name)} = {sql_value_expression(table_key, row, column_name, value, None, variable_registry, foreign_keys_by_source, known_associations)}"
+                f"{quote_identifier(column_name)} = {sql_value_expression(table_key, row, column_name, value, None, variable_registry, foreign_keys_by_source, known_associations, primary_keys_by_table, generated_always_columns, variable_sources_by_name, emit_only_step)}"
             )
     return " AND ".join(predicates) if predicates else "1 = 0"
 
@@ -1024,6 +1168,8 @@ def reconstruct_insert_sql(
     id_state: dict[str, int],
     superuser_id: int,
     top_level_declarations: list[str],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str | None:
     row = record.get("row")
     if not isinstance(row, dict):
@@ -1073,6 +1219,12 @@ def reconstruct_insert_sql(
         output_table_name = output_table_name_for_variable(variable_name)
         sql_type = column_sql_types.get((table_key[0], table_key[1], generated_primary_key), "int")
         variable_registry[(table_key[0], table_key[1], generated_primary_key, value_key(generated_value))] = variable_name
+        variable_sources_by_name[variable_name] = VariableSource(
+            table_key=table_key,
+            column_name=generated_primary_key,
+            row=row,
+            step=int(record.get("_step")) if record.get("_step") is not None else None,
+        )
         prelude_lines.extend([
             f"DECLARE {variable_name} {sql_type};",
             f"DECLARE {output_table_name} TABLE ([value] {sql_type});",
@@ -1125,6 +1277,9 @@ def reconstruct_insert_sql(
             foreign_keys_by_source,
             known_associations,
             superuser_id,
+            generated_always_columns,
+            variable_sources_by_name,
+            emit_only_step,
         )
         for column_name in columns
     )
@@ -1152,13 +1307,28 @@ def reconstruct_delete_sql(
     variable_registry: dict[tuple[str, str, str, str], str],
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    generated_always_columns: set[tuple[str, str, str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str | None:
     row = record.get("row")
     if not isinstance(row, dict):
         return None
     table_key = (str(record["schema_name"]), str(record["table_name"]))
     key_columns = select_key_columns(row, primary_key_columns)
-    where_clause = build_where_clause(table_key, row, key_columns, variable_registry, foreign_keys_by_source, known_associations)
+    where_clause = build_where_clause(
+        table_key,
+        row,
+        key_columns,
+        variable_registry,
+        foreign_keys_by_source,
+        known_associations,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
+    )
     return f"DELETE FROM {quote_identifier(str(record['schema_name']))}.{quote_identifier(str(record['table_name']))} WHERE {where_clause};"
 
 
@@ -1173,6 +1343,9 @@ def reconstruct_update_sql(
     foreign_keys_by_source: dict[tuple[str, str, str], tuple[str, str, str]],
     known_associations: list[KnownAssociation],
     superuser_id: int,
+    primary_keys_by_table: dict[tuple[str, str], list[str]],
+    variable_sources_by_name: dict[str, VariableSource],
+    emit_only_step: int | None,
 ) -> str | None:
     before_row = before_record.get("row")
     after_row = after_record.get("row")
@@ -1190,11 +1363,22 @@ def reconstruct_update_sql(
         return None
 
     set_clause = ", ".join(
-        f"{quote_identifier(column_name)} = {sql_update_assignment_expression(table_key, after_row, column_name, after_row.get(column_name), replay_now_window, variable_registry, foreign_keys_by_source, known_associations, superuser_id)}"
+        f"{quote_identifier(column_name)} = {sql_update_assignment_expression(table_key, after_row, column_name, after_row.get(column_name), replay_now_window, variable_registry, foreign_keys_by_source, known_associations, superuser_id, primary_keys_by_table, generated_always_columns, variable_sources_by_name, emit_only_step)}"
         for column_name in changed_columns
     )
     key_columns = select_key_columns(before_row, primary_key_columns)
-    where_clause = build_where_clause(table_key, before_row, key_columns, variable_registry, foreign_keys_by_source, known_associations)
+    where_clause = build_where_clause(
+        table_key,
+        before_row,
+        key_columns,
+        variable_registry,
+        foreign_keys_by_source,
+        known_associations,
+        primary_keys_by_table,
+        generated_always_columns,
+        variable_sources_by_name,
+        emit_only_step,
+    )
     return f"UPDATE {quote_identifier(str(after_record['schema_name']))}.{quote_identifier(str(after_record['table_name']))} SET {set_clause} WHERE {where_clause};"
 
 
@@ -1242,6 +1426,7 @@ def reconstruct_sql_statements(
     ]
     pending_updates: dict[tuple[str, str, int | None], dict[str, object]] = {}
     variable_registry: dict[tuple[str, str, str, str], str] = {}
+    variable_sources_by_name: dict[str, VariableSource] = {}
     variable_name_counts: dict[str, int] = {}
     id_state = {"next_value": starting_uid}
     last_table_key: tuple[str, str] | None = None
@@ -1301,6 +1486,8 @@ def reconstruct_sql_statements(
                 id_state,
                 superuser_id,
                 top_level_declarations,
+                variable_sources_by_name,
+                emit_only_step,
             )
             if sql_statement:
                 tagged = f"-- step: {current_step}\n{sql_statement}" if current_step is not None else sql_statement
@@ -1315,6 +1502,10 @@ def reconstruct_sql_statements(
                 variable_registry,
                 foreign_keys_by_source,
                 known_associations,
+                primary_keys_by_table,
+                generated_always_columns,
+                variable_sources_by_name,
+                emit_only_step,
             )
             if sql_statement:
                 tagged = f"-- step: {current_step}\n{sql_statement}" if current_step is not None else sql_statement
@@ -1344,6 +1535,9 @@ def reconstruct_sql_statements(
                 foreign_keys_by_source,
                 known_associations,
                 superuser_id,
+                primary_keys_by_table,
+                variable_sources_by_name,
+                emit_only_step,
             )
             if sql_statement:
                 tagged = f"-- step: {current_step}\n{sql_statement}" if current_step is not None else sql_statement

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -18,6 +18,7 @@ from tracing_sql import SqlCmdClient, require_sqlcmd
 USE_DATABASE_PATTERN = re.compile(r"^\s*USE\s+\[(?P<database>[^\]]+)\]\s*;\s*$", re.IGNORECASE)
 EXPECTED_MARKER = "-- EXPECTED_ROWS_JSON:"
 JSON_HEADER_PREFIX = "JSON_F52E2B61"
+SELECT_STATEMENT_PREFIX_PATTERN = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
 
 MISSING = object()
 
@@ -168,6 +169,24 @@ def parse_use_database(statements: list[SqlStatement]) -> str | None:
     return None
 
 
+def statement_returns_json(sql: str) -> bool:
+    return "FOR JSON PATH" in sql.upper()
+
+
+def is_select_statement(sql: str) -> bool:
+    return SELECT_STATEMENT_PREFIX_PATTERN.match(sql) is not None
+
+
+def ensure_query_returns_json(sql: str) -> str:
+    if statement_returns_json(sql):
+        return sql
+
+    stripped = sql.rstrip()
+    if stripped.endswith(";"):
+        stripped = stripped[:-1].rstrip()
+    return f"{stripped}\nFOR JSON PATH;"
+
+
 def parse_cases(sql_text: str) -> tuple[list[SqlStatement], list[SelectCase]]:
     lines = sql_text.splitlines()
     statements = split_sql_statements(sql_text)
@@ -202,7 +221,7 @@ def parse_cases_from_expected_json(sql_text: str, expected_json_path: Path) -> t
 
     lines = sql_text.splitlines()
     statements = split_sql_statements(sql_text)
-    select_statements = [s for s in statements if "FOR JSON PATH" in s.sql.upper()]
+    select_statements = [s for s in statements if is_select_statement(s.sql)]
     cases: list[SelectCase] = []
 
     for index, statement in enumerate(select_statements):
@@ -655,7 +674,7 @@ def compare_case(client: SqlCmdClient, prelude_sql: str, case: SelectCase) -> di
     sql_batch_parts = ["SET NOCOUNT ON;"]
     if prelude_sql.strip():
         sql_batch_parts.append(prelude_sql)
-    sql_batch_parts.append(case.query_sql)
+    sql_batch_parts.append(ensure_query_returns_json(case.query_sql))
     sql_batch = "\n\n".join(sql_batch_parts)
 
     try:


### PR DESCRIPTION
## Description
This PR expands local tracing/replay tooling to make functional-test setup replay safer and more repeatable, and improves SQL replay robustness for step-scoped scenarios.

### What changed
- Added a new setup replay workflow that can execute an existing functional `setup.sql` directly against ODSE.
- Added optional auto-datetime rewriting mode that replaces eligible hardcoded date/time literals with `CURRENT_TIMESTAMP` expressions.
- Added optional UID renumbering prompt to rewrite `@dbo_*` bigint declaration values from a user-provided starting ID.
- Improved database resolution precedence for replay (--database → `USE [db]` in script → env defaults → fallback).

### Replay/SQL generation improvements
- Improved step-specific replay SQL generation so references to prior-step variables can be resolved via lookup subqueries when needed.
- Added targeted handling for `NBS_act_entity` lookup predicates to avoid unstable audit timestamp fields in matching logic.

### CDC capture reliability improvements
- Added detection of currently CDC-enabled tables via `sp_cdc_help_change_data_capture`.
- Updated capture flows to skip already-enabled tables during enable operations.
- Updated cleanup flows to skip already-disabled tables during disable operations.

### Validation improvements
- Enhanced RDB select validation to support plain `SELECT/WITH` statements by ensuring JSON output (`FOR JSON PATH`) before comparison.
- Added expected-json parsing coverage for plain-select scenarios.

### Constants and artifact filtering
- Added `LOOKUP_TABLE_N_` to excluded artifact table prefixes.
- Added explicit always-rewrite datetime/date column-name set for replay rewriting.

### Documentation
- Updated local tracing README with replay-setup usage examples for functional `setup.sql`.

## Related Issue
N/A

## Additional Notes


## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
