### PR TITLE
Functional test vs RDB tool updates

### DIFF
--- a/testing-tools/local-db-tracing/test_validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/test_validate_rdb_selects.py
@@ -53,6 +53,25 @@ SELECT [id] FROM [dbo].[TableB] WHERE [id] = @id FOR JSON PATH;
         self.assertIn("USE [RDB_MODERN];", prelude)
         self.assertIn("DECLARE @id bigint = 1;", prelude)
 
+    def test_build_prelude_sql_strips_leading_use_when_requested(self) -> None:
+        sql_text = """
+USE [RDB];
+
+DECLARE @id bigint = 1;
+
+-- dbo.TableA | operations: insert
+SELECT [id] FROM [dbo].[TableA] WHERE [id] = @id FOR JSON PATH;
+-- EXPECTED_ROWS_JSON:
+-- [{"id":1}]
+""".strip()
+
+        statements, cases = validate_rdb_selects.parse_cases(sql_text)
+
+        prelude = validate_rdb_selects.build_prelude_sql(statements, cases[0], strip_leading_use=True)
+
+        self.assertNotIn("USE [RDB];", prelude)
+        self.assertIn("DECLARE @id bigint = 1;", prelude)
+
     def test_compare_case_handles_sql_error_without_raising(self) -> None:
         case = validate_rdb_selects.SelectCase(
             case_index=1,
@@ -164,6 +183,7 @@ SELECT [id] FROM [dbo].[TableB] WHERE [id] = 2;
 
     def test_markdown_report_contains_error_style_and_spans(self) -> None:
         summary = {
+            "database": "RDB_Modern",
             "case_count": 2,
             "pass_count": 1,
             "warning_count": 0,
@@ -198,6 +218,7 @@ SELECT [id] FROM [dbo].[TableB] WHERE [id] = 2;
         )
 
         self.assertIn("<style>", report)
+        self.assertIn("# RDB_Modern Select Validation Results", report)
         self.assertIn('.error {', report)
         self.assertIn('.warning {', report)
         self.assertIn('| <span class="ok">Passes</span> | 1 |', report)

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -320,6 +320,23 @@ def field_name_is_warning_exception(field_name: str) -> bool:
     return upper_name == "RDB_LAST_REFRESH_TIME"
 
 
+def normalize_trailing_zero_millis(value: object) -> object:
+    """Normalize datetime strings where only trailing .000 milliseconds differ."""
+    if not isinstance(value, str):
+        return value
+
+    # Matches: 2026-05-08T14:22:20.000, with optional timezone suffix like Z or +00:00.
+    return re.sub(r"(?<=\d)\.000(?=(?:Z|[+-]\d{2}:?\d{2})?$)", "", value)
+
+
+def is_datetime_zero_millis_mismatch(expected: object, actual: object) -> bool:
+    if not (isinstance(expected, str) and isinstance(actual, str)):
+        return False
+    if expected == actual:
+        return False
+    return normalize_trailing_zero_millis(expected) == normalize_trailing_zero_millis(actual)
+
+
 def is_warning_mismatch(
     field_name: str,
     expected_has: bool,
@@ -332,6 +349,8 @@ def is_warning_mismatch(
     if expected_value == actual_value:
         return False
     if is_null_vs_empty_mismatch(expected_value, actual_value):
+        return True
+    if is_datetime_zero_millis_mismatch(expected_value, actual_value):
         return True
     if field_name_is_warning_exception(field_name):
         return True
@@ -717,8 +736,8 @@ def compare_case(client: SqlCmdClient, prelude_sql: str, case: SelectCase) -> di
             elif status == "warning":
                 result["error"] = (
                     "JSON matches except for warning-level differences "
-                    "(null vs empty string, *_ID/*_UID/*_KEY value mismatches, "
-                    "and/or RDB_LAST_REFRESH_TIME mismatch)"
+                    "(null vs empty string, datetime values differing only by .000, "
+                    "*_ID/*_UID/*_KEY value mismatches, and/or RDB_LAST_REFRESH_TIME mismatch)"
                 )
             else:
                 result["error"] = "Expected JSON does not match actual query result"

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -269,7 +269,7 @@ def clean_sqlcmd_output(raw_output: str) -> str:
             continue
         if set(stripped) <= {"-", " ", "\t"}:
             continue
-        cleaned_lines.append(stripped)
+        cleaned_lines.append(raw_line)
     return "".join(cleaned_lines)
 
 

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -169,6 +169,10 @@ def parse_use_database(statements: list[SqlStatement]) -> str | None:
     return None
 
 
+def is_use_database_statement(sql: str) -> bool:
+    return USE_DATABASE_PATTERN.match(sql.strip()) is not None
+
+
 def statement_returns_json(sql: str) -> bool:
     return "FOR JSON PATH" in sql.upper()
 
@@ -241,8 +245,15 @@ def parse_cases_from_expected_json(sql_text: str, expected_json_path: Path) -> t
     return statements, cases
 
 
-def build_prelude_sql(statements: list[SqlStatement], first_case: SelectCase) -> str:
-    prelude = [statement.sql for statement in statements if statement.end_line < first_case.query_start_line]
+def build_prelude_sql(
+    statements: list[SqlStatement],
+    first_case: SelectCase,
+    strip_leading_use: bool = False,
+) -> str:
+    prelude_statements = [statement.sql for statement in statements if statement.end_line < first_case.query_start_line]
+    if strip_leading_use and prelude_statements and is_use_database_statement(prelude_statements[0]):
+        prelude_statements = prelude_statements[1:]
+    prelude = prelude_statements
     return "\n\n".join(prelude)
 
 
@@ -528,8 +539,14 @@ def render_markdown_report(
     summary: dict[str, object],
     results: list[dict[str, object]],
 ) -> str:
+    database_name = str(summary.get("database") or "").strip()
+    report_title = (
+        f"# {database_name} Select Validation Results"
+        if database_name
+        else "# RDB Select Validation Results"
+    )
     lines: list[str] = [
-        "# RDB Select Validation Results",
+        report_title,
         "",
         f"Input file: {input_file}",
         f"JSON results: {output_file}",
@@ -792,7 +809,7 @@ def main() -> int:
     )
     executable = require_sqlcmd(args.sqlcmd)
     client = SqlCmdClient(executable, args.server, database, args.user, args.password)
-    prelude_sql = build_prelude_sql(statements, cases[0])
+    prelude_sql = build_prelude_sql(statements, cases[0], strip_leading_use=args.database is not None)
     use_color = colors_enabled(args.no_color)
 
     print(f"Input file: {input_file}")


### PR DESCRIPTION
## Description
As we're going through validating a functional test against RDB, some changes to the tooling have come up. This PR includes:
- Add normalization for datetime strings with trailing zero milliseconds (if dates differ by ".000" show as a warning in each `rdb-selects-results.md`, not an error)
- `validate_rdb_selects.py` fully uses the `--database` argument
- @hawley-skylight fix: '"United States" turns into "UnitedStates" when there is a line break in the json between the two words, and the stripped version loses the space'

## Related Issue
N/A

## Additional Notes


## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
