### PR TITLE
Improvements to functional testing tools

### DIFF
--- a/testing-tools/local-db-tracing/replay_setup.py
+++ b/testing-tools/local-db-tracing/replay_setup.py
@@ -189,25 +189,26 @@ def value_has_midnight_time(value_token: str) -> bool:
 
 
 def replacement_expression(sql_type: str, has_midnight_time: bool = False) -> str:
+    sql_current_date = "CAST(CURRENT_TIMESTAMP AS date)"
     lowered = sql_type.lower()
     if lowered == "date":
-        return "CURRENT_DATE"
+        return sql_current_date
     if lowered == "time":
         return "CAST(CURRENT_TIMESTAMP AS time)"
     if lowered.startswith("datetimeoffset"):
         if has_midnight_time:
-            return "CAST(CURRENT_DATE AS datetimeoffset)"
+            return f"CAST({sql_current_date} AS datetimeoffset)"
         return "CAST(CURRENT_TIMESTAMP AS datetimeoffset)"
     if lowered.startswith("datetime2"):
         if has_midnight_time:
-            return "CAST(CURRENT_DATE AS datetime2)"
+            return f"CAST({sql_current_date} AS datetime2)"
         return "CAST(CURRENT_TIMESTAMP AS datetime2)"
     if lowered.startswith("smalldatetime"):
         if has_midnight_time:
-            return "CAST(CURRENT_DATE AS smalldatetime)"
+            return f"CAST({sql_current_date} AS smalldatetime)"
         return "CAST(CURRENT_TIMESTAMP AS smalldatetime)"
     if has_midnight_time:
-        return "CURRENT_DATE"
+        return sql_current_date
     return "CURRENT_TIMESTAMP"
 
 

--- a/testing-tools/local-db-tracing/replay_setup.py
+++ b/testing-tools/local-db-tracing/replay_setup.py
@@ -162,18 +162,52 @@ def normalize_column_name(column_token: str) -> str:
     return stripped
 
 
-def replacement_expression(sql_type: str) -> str:
+def value_has_midnight_time(value_token: str) -> bool:
+    """Check if a date/datetime literal has a midnight time component (00:00:00)."""
+    stripped = value_token.strip()
+    # Remove quotes and N prefix if present
+    if stripped.startswith("N'"):
+        stripped = stripped[2:-1]
+    elif stripped.startswith("'"):
+        stripped = stripped[1:-1]
+    else:
+        return False
+    
+    # Check for time component: T or space followed by 00:00:00
+    if 'T' in stripped:
+        # Format: 2026-04-23T00:00:00 or 2026-04-23T00:00:00.000
+        parts = stripped.split('T')
+        if len(parts) == 2 and parts[1].startswith('00:00:00'):
+            return True
+    elif ' ' in stripped:
+        # Format: 2026-04-23 00:00:00 or 2026-04-23 00:00:00.000
+        parts = stripped.split(' ')
+        if len(parts) == 2 and parts[1].startswith('00:00:00'):
+            return True
+    
+    return False
+
+
+def replacement_expression(sql_type: str, has_midnight_time: bool = False) -> str:
     lowered = sql_type.lower()
     if lowered == "date":
-        return "CAST(CURRENT_TIMESTAMP AS date)"
+        return "CURRENT_DATE"
     if lowered == "time":
         return "CAST(CURRENT_TIMESTAMP AS time)"
     if lowered.startswith("datetimeoffset"):
+        if has_midnight_time:
+            return "CAST(CURRENT_DATE AS datetimeoffset)"
         return "CAST(CURRENT_TIMESTAMP AS datetimeoffset)"
     if lowered.startswith("datetime2"):
+        if has_midnight_time:
+            return "CAST(CURRENT_DATE AS datetime2)"
         return "CAST(CURRENT_TIMESTAMP AS datetime2)"
     if lowered.startswith("smalldatetime"):
+        if has_midnight_time:
+            return "CAST(CURRENT_DATE AS smalldatetime)"
         return "CAST(CURRENT_TIMESTAMP AS smalldatetime)"
+    if has_midnight_time:
+        return "CURRENT_DATE"
     return "CURRENT_TIMESTAMP"
 
 
@@ -219,7 +253,8 @@ def rewrite_insert_statement(
         rewritten_value = value_token
         if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
-            rewritten_value = replacement_expression(sql_type)
+            has_midnight = value_has_midnight_time(value_token)
+            rewritten_value = replacement_expression(sql_type, has_midnight)
             replacements += 1
         rewritten_values.append(rewritten_value)
 
@@ -260,7 +295,8 @@ def rewrite_update_statement(
         rewritten_assignment = assignment
         if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
-            rewritten_assignment = f"[{column_name}] = {replacement_expression(sql_type)}"
+            has_midnight = value_has_midnight_time(value_token)
+            rewritten_assignment = f"[{column_name}] = {replacement_expression(sql_type, has_midnight)}"
             replacements += 1
         rewritten_assignments.append(rewritten_assignment)
 

--- a/testing-tools/local-db-tracing/replay_setup.py
+++ b/testing-tools/local-db-tracing/replay_setup.py
@@ -221,11 +221,15 @@ def should_exclude_from_replacement(schema_name: str, table_name: str, column_na
     
     Returns True if the column matches either a table-specific or table-agnostic exclusion.
     """
+    normalized_schema = schema_name.lower()
+    normalized_table = table_name.lower()
+    normalized_column = column_name.lower()
+
     # Check table-specific exclusion
-    if (schema_name, table_name, column_name) in DO_NOT_REPLACE_COLUMNS_BY_TABLE:
+    if (normalized_schema, normalized_table, normalized_column) in DO_NOT_REPLACE_COLUMNS_BY_TABLE:
         return True
     # Check generic column name exclusion (applies to all tables)
-    if column_name in DO_NOT_REPLACE_COLUMNS_ANY_TABLE:
+    if normalized_column in DO_NOT_REPLACE_COLUMNS_ANY_TABLE:
         return True
     return False
 
@@ -252,7 +256,8 @@ def rewrite_insert_statement(
         column_name = normalize_column_name(column_token)
         column_key = (schema_name, table_name, column_name)
         rewritten_value = value_token
-        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
+        normalized_column_name = column_name.lower()
+        if (column_key in eligible_columns or normalized_column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
             has_midnight = value_has_midnight_time(value_token)
             rewritten_value = replacement_expression(sql_type, has_midnight)
@@ -294,7 +299,8 @@ def rewrite_update_statement(
         value_token = assignment_match.group("value")
         column_key = (schema_name, table_name, column_name)
         rewritten_assignment = assignment
-        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
+        normalized_column_name = column_name.lower()
+        if (column_key in eligible_columns or normalized_column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
             has_midnight = value_has_midnight_time(value_token)
             rewritten_assignment = f"[{column_name}] = {replacement_expression(sql_type, has_midnight)}"

--- a/testing-tools/local-db-tracing/replay_setup.py
+++ b/testing-tools/local-db-tracing/replay_setup.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from tracing_env import load_database_connection_defaults, resolve_server_argument
-from tracing_constants import ALWAYS_REPLACE_COLUMN_NAMES
+from tracing_constants import ALWAYS_REPLACE_COLUMN_NAMES, DO_NOT_REPLACE_COLUMNS_ANY_TABLE, DO_NOT_REPLACE_COLUMNS_BY_TABLE
 from tracing_metadata import fetch_auto_datetime_columns, fetch_column_sql_types
 from tracing_sql import SqlCmdClient, require_sqlcmd
 
@@ -181,6 +181,20 @@ def should_replace_literal(value_token: str) -> bool:
     return bool(HARDCODED_DATE_LITERAL_PATTERN.match(value_token.strip()))
 
 
+def should_exclude_from_replacement(schema_name: str, table_name: str, column_name: str) -> bool:
+    """Check if a column should be excluded from datetime replacement.
+    
+    Returns True if the column matches either a table-specific or table-agnostic exclusion.
+    """
+    # Check table-specific exclusion
+    if (schema_name, table_name, column_name) in DO_NOT_REPLACE_COLUMNS_BY_TABLE:
+        return True
+    # Check generic column name exclusion (applies to all tables)
+    if column_name in DO_NOT_REPLACE_COLUMNS_ANY_TABLE:
+        return True
+    return False
+
+
 def rewrite_insert_statement(
     statement: str,
     eligible_columns: set[tuple[str, str, str]],
@@ -203,7 +217,7 @@ def rewrite_insert_statement(
         column_name = normalize_column_name(column_token)
         column_key = (schema_name, table_name, column_name)
         rewritten_value = value_token
-        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and should_replace_literal(value_token):
+        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
             rewritten_value = replacement_expression(sql_type)
             replacements += 1
@@ -244,7 +258,7 @@ def rewrite_update_statement(
         value_token = assignment_match.group("value")
         column_key = (schema_name, table_name, column_name)
         rewritten_assignment = assignment
-        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and should_replace_literal(value_token):
+        if (column_key in eligible_columns or column_name in ALWAYS_REPLACE_COLUMN_NAMES) and not should_exclude_from_replacement(schema_name, table_name, column_name) and should_replace_literal(value_token):
             sql_type = column_types.get(column_key, "datetime")
             rewritten_assignment = f"[{column_name}] = {replacement_expression(sql_type)}"
             replacements += 1

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -22,57 +22,76 @@ DEFAULT_KNOWN_ASSOCIATIONS_FILE = LOCAL_TRACING_DIR / "known_replay_associations
 REPLAY_METADATA_CACHE_PREFIX = "replay-metadata-"
 REPLAY_METADATA_CACHE_VERSION = 5
 
-# CDC is not turned on for these tables
-EXCLUDED_TRACE_TABLES = {
-    ("dbo", "job_flow_log"),
-}
+# CDC is not turned on for these tables.
+# Keys are normalized to lowercase to support case-insensitive matching.
+EXCLUDED_TRACE_TABLES: frozenset[tuple[str, str]] = frozenset({
+    (schema_name.lower(), table_name.lower())
+    for schema_name, table_name in {
+        ("dbo", "job_flow_log"),
+    }
+})
 
 # CDC is on for these tables, but they are excluded from setup.sql because
-# they are populated as side-effects of replaying other entities
-DEFAULT_CORE_REPLAY_IGNORED_TABLES = {
-    ("dbo", "EDX_entity_match"),
-    ("dbo", "EDX_patient_match"),
-}
+# they are populated as side-effects of replaying other entities.
+# Keys are normalized to lowercase to support case-insensitive matching.
+DEFAULT_CORE_REPLAY_IGNORED_TABLES: frozenset[tuple[str, str]] = frozenset({
+    (schema_name.lower(), table_name.lower())
+    for schema_name, table_name in {
+        ("dbo", "EDX_entity_match"),
+        ("dbo", "EDX_patient_match"),
+    }
+})
 
-# These tables are excluded from query.sql and expected.json
-EXCLUDED_ARTIFACT_TABLES = {
-    ("dbo", "activity_log_detail"),
-    ("dbo", "activity_log_master"),
-    ("dbo", "job_flow_log"),
-    ("dbo", "job_batch_log"),
+# These tables are excluded from query.sql and expected.json.
+# Keys are normalized to lowercase to support case-insensitive matching.
+EXCLUDED_ARTIFACT_TABLES: frozenset[tuple[str, str]] = frozenset({
+    (schema_name.lower(), table_name.lower())
+    for schema_name, table_name in {
+        ("dbo", "activity_log_detail"),
+        ("dbo", "activity_log_master"),
+        ("dbo", "job_flow_log"),
+        ("dbo", "job_batch_log"),
 
-    # See https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
-    ("dbo", "ETL_DQ_LOG"),
-    ("dbo", "ETL_HEALTH_CHECK_PAT_DATA"),
-    ("dbo", "ETL_MISSING_PATIENT"),
-    ("dbo", "ETL_MISSING_RECORD"),
-    ("dbo", "ETL_PROCESS"),
-    ("dbo", "EVENT_METRIC"),
-    ("dbo", "EVENT_METRIC_INC"),
-}
+        # See https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
+        ("dbo", "ETL_DQ_LOG"),
+        ("dbo", "ETL_HEALTH_CHECK_PAT_DATA"),
+        ("dbo", "ETL_MISSING_PATIENT"),
+        ("dbo", "ETL_MISSING_RECORD"),
+        ("dbo", "ETL_PROCESS"),
+        ("dbo", "EVENT_METRIC"),
+        ("dbo", "EVENT_METRIC_INC"),
+    }
+})
 
-# These table prefixes are excluded from query.sql and expected.json
-# Each entry is (schema_name, table_name_prefix); compared case-insensitively in tracing_paths.is_excluded_artifact_table.
-EXCLUDED_ARTIFACT_TABLE_PREFIXES = {
+# These table prefixes are excluded from query.sql and expected.json.
+# Each entry is (schema_name, table_name_prefix) and is normalized to lowercase.
+EXCLUDED_ARTIFACT_TABLE_PREFIXES: frozenset[tuple[str, str]] = frozenset({
+    (schema_name.lower(), table_name_prefix.lower())
+    for schema_name, table_name_prefix in {
     # ("dbo", "LOOKUP_TABLE_N_"),
     # See https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
-    ("dbo", "L_"),
-    ("dbo", "LOOKUP_"),
-    ("dbo", "S_"),
-    ("dbo", "SAS_"),
-    ("dbo", "TEMP_"),
-}
+        ("dbo", "L_"),
+        ("dbo", "LOOKUP_"),
+        ("dbo", "S_"),
+        ("dbo", "SAS_"),
+        ("dbo", "TEMP_"),
+    }
+})
 
-# These columns are excluded from query.sql and expected.json (no matter the table)
-IGNORED_OUTPUT_COLUMNS = {
-    "INVESTIGATION_KEY",
-    "LAB_TEST_KEY",
-    "LAB_RPT_LAST_UPDATE_DT",
-    "PATIENT_KEY",
-    "RDB_LAST_REFRESH_TIME",
-    "RESULTED_LAB_TEST_KEY",
-    "TEST_RESULT_GRP_KEY",
-}
+# These columns are excluded from query.sql and expected.json (no matter the table).
+# Names are normalized to lowercase to support case-insensitive matching.
+IGNORED_OUTPUT_COLUMNS: frozenset[str] = frozenset({
+    column_name.lower()
+    for column_name in {
+        "INVESTIGATION_KEY",
+        "LAB_TEST_KEY",
+        "LAB_RPT_LAST_UPDATE_DT",
+        "PATIENT_KEY",
+        "RDB_LAST_REFRESH_TIME",
+        "RESULTED_LAB_TEST_KEY",
+        "TEST_RESULT_GRP_KEY",
+    }
+})
 
 DEFAULT_UID_BLOCK_SIZE_BY_CLASS = {
     "GA": 1000,
@@ -95,35 +114,50 @@ REPLAY_DATETIME_LITERAL_PATTERN = re.compile(
 
 # These column names are always rewritten to CURRENT_TIMESTAMP when auto-datetime mode is 'current',
 # regardless of whether the DB metadata reports them as having a function-based DEFAULT.
+# Names are normalized to lowercase to support case-insensitive matching.
 ALWAYS_REPLACE_COLUMN_NAMES: frozenset[str] = frozenset({
-    "last_chg_time",
-    "record_status_time",
-    "status_time",
-    "add_time",
-    "activity_to_time",
-    "rpt_to_state_time",
-    "as_of_date"
+    column_name.lower()
+    for column_name in {
+        "last_chg_time",
+        "record_status_time",
+        "status_time",
+        "add_time",
+        "activity_to_time",
+        "rpt_to_state_time",
+        "as_of_date",
+    }
 })
 
 # Column names that should NOT be rewritten to CURRENT_TIMESTAMP, even if they have
 # function-based DEFAULT constraints. They represent business data rather than audit timestamps.
-# Applies to all tables.
+# Applies to all tables. Names are normalized to lowercase.
 DO_NOT_REPLACE_COLUMNS_ANY_TABLE: frozenset[str] = frozenset({
-    "LAB_TEST_DT",  # exclude from all tables
-    "EARLIEST_RPT_TO_STATE_DT",
-    "LAB_RPT_RECEIVED_BY_PH_DT",
+    column_name.lower()
+    for column_name in {
+        "LAB_TEST_DT",  # exclude from all tables
+        "EARLIEST_RPT_TO_STATE_DT",
+        "LAB_RPT_RECEIVED_BY_PH_DT",
+    }
 })
 
 # Table-specific column exclusions (schema, table, column) that should NOT be rewritten.
 # Use when a column name is business data in one table but an audit field in another.
+# Keys are normalized to lowercase to support case-insensitive matching.
 DO_NOT_REPLACE_COLUMNS_BY_TABLE: frozenset[tuple[str, str, str]] = frozenset({
-    # ("dbo", "LAB100", "LAB_TEST_DT"),
+    (schema_name.lower(), table_name.lower(), column_name.lower())
+    for schema_name, table_name, column_name in {
+        # ("dbo", "LAB100", "LAB_TEST_DT"),
+    }
 })
 
 # Used by step-scoped replay lookup subqueries that re-find NBS_act_entity rows when prior-step UID vars are unavailable.
 # Timestamp audit fields are ignored because when recreating with CURRENT_TIMESTAMP, these would be invalid.
+# Names are normalized to lowercase to support case-insensitive matching.
 NBS_ACT_ENTITY_LOOKUP_EXCLUDED_COLUMNS: frozenset[str] = frozenset({
-    "add_time",
-    "last_chg_time",
-    "record_status_time",
+    column_name.lower()
+    for column_name in {
+        "add_time",
+        "last_chg_time",
+        "record_status_time",
+    }
 })

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -110,6 +110,8 @@ ALWAYS_REPLACE_COLUMN_NAMES: frozenset[str] = frozenset({
 # Applies to all tables.
 DO_NOT_REPLACE_COLUMNS_ANY_TABLE: frozenset[str] = frozenset({
     "LAB_TEST_DT",  # exclude from all tables
+    "EARLIEST_RPT_TO_STATE_DT",
+    "LAB_RPT_RECEIVED_BY_PH_DT",
 })
 
 # Table-specific column exclusions (schema, table, column) that should NOT be rewritten.

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -90,6 +90,19 @@ ALWAYS_REPLACE_COLUMN_NAMES: frozenset[str] = frozenset({
     "as_of_date"
 })
 
+# Column names that should NOT be rewritten to CURRENT_TIMESTAMP, even if they have
+# function-based DEFAULT constraints. They represent business data rather than audit timestamps.
+# Applies to all tables.
+DO_NOT_REPLACE_COLUMNS_ANY_TABLE: frozenset[str] = frozenset({
+    "LAB_TEST_DT",  # exclude from all tables
+})
+
+# Table-specific column exclusions (schema, table, column) that should NOT be rewritten.
+# Use when a column name is business data in one table but an audit field in another.
+DO_NOT_REPLACE_COLUMNS_BY_TABLE: frozenset[tuple[str, str, str]] = frozenset({
+    # ("dbo", "LAB100", "LAB_TEST_DT"),
+})
+
 # Used by step-scoped replay lookup subqueries that re-find NBS_act_entity rows when prior-step UID vars are unavailable.
 # Timestamp audit fields are ignored because when recreating with CURRENT_TIMESTAMP, these would be invalid.
 NBS_ACT_ENTITY_LOOKUP_EXCLUDED_COLUMNS: frozenset[str] = frozenset({

--- a/testing-tools/local-db-tracing/tracing_constants.py
+++ b/testing-tools/local-db-tracing/tracing_constants.py
@@ -40,12 +40,27 @@ EXCLUDED_ARTIFACT_TABLES = {
     ("dbo", "activity_log_master"),
     ("dbo", "job_flow_log"),
     ("dbo", "job_batch_log"),
+
+    # See https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
+    ("dbo", "ETL_DQ_LOG"),
+    ("dbo", "ETL_HEALTH_CHECK_PAT_DATA"),
+    ("dbo", "ETL_MISSING_PATIENT"),
+    ("dbo", "ETL_MISSING_RECORD"),
+    ("dbo", "ETL_PROCESS"),
+    ("dbo", "EVENT_METRIC"),
+    ("dbo", "EVENT_METRIC_INC"),
 }
 
 # These table prefixes are excluded from query.sql and expected.json
 # Each entry is (schema_name, table_name_prefix); compared case-insensitively in tracing_paths.is_excluded_artifact_table.
 EXCLUDED_ARTIFACT_TABLE_PREFIXES = {
-    ("dbo", "LOOKUP_TABLE_N_"),
+    # ("dbo", "LOOKUP_TABLE_N_"),
+    # See https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
+    ("dbo", "L_"),
+    ("dbo", "LOOKUP_"),
+    ("dbo", "S_"),
+    ("dbo", "SAS_"),
+    ("dbo", "TEMP_"),
 }
 
 # These columns are excluded from query.sql and expected.json (no matter the table)

--- a/testing-tools/local-db-tracing/tracing_metadata.py
+++ b/testing-tools/local-db-tracing/tracing_metadata.py
@@ -35,7 +35,7 @@ def infer_core_replay_ignored_tables(
     ignored_tables: set[tuple[str, str]] = set()
     for schema_name, table_name in DEFAULT_CORE_REPLAY_IGNORED_TABLES:
         ignored_tables.add(
-            actual_names_by_lower.get((schema_name.lower(), table_name.lower()), (schema_name, table_name))
+            actual_names_by_lower.get((schema_name, table_name), (schema_name, table_name))
         )
     return ignored_tables
 

--- a/testing-tools/local-db-tracing/tracing_paths.py
+++ b/testing-tools/local-db-tracing/tracing_paths.py
@@ -56,11 +56,10 @@ def is_excluded_artifact_table(schema_name: str, table_name: str) -> bool:
     """Keep internal/audit tables out of generated query.sql and expected.json artifacts."""
 
     key = (schema_name.lower(), table_name.lower())
-    excluded_exact_tables = {(schema.lower(), table.lower()) for schema, table in EXCLUDED_ARTIFACT_TABLES}
-    if key in excluded_exact_tables:
+    if key in EXCLUDED_ARTIFACT_TABLES:
         return True
     return any(
-        key[0] == schema.lower() and key[1].startswith(prefix.lower())
+        key[0] == schema and key[1].startswith(prefix)
         for schema, prefix in EXCLUDED_ARTIFACT_TABLE_PREFIXES
     )
 

--- a/testing-tools/local-db-tracing/tracing_paths.py
+++ b/testing-tools/local-db-tracing/tracing_paths.py
@@ -56,7 +56,8 @@ def is_excluded_artifact_table(schema_name: str, table_name: str) -> bool:
     """Keep internal/audit tables out of generated query.sql and expected.json artifacts."""
 
     key = (schema_name.lower(), table_name.lower())
-    if key in EXCLUDED_ARTIFACT_TABLES:
+    excluded_exact_tables = {(schema.lower(), table.lower()) for schema, table in EXCLUDED_ARTIFACT_TABLES}
+    if key in excluded_exact_tables:
         return True
     return any(
         key[0] == schema.lower() and key[1].startswith(prefix.lower())

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -16,6 +16,10 @@ from tracing_sql import SqlCmdClient, require_sqlcmd
 
 
 USE_DATABASE_PATTERN = re.compile(r"^\s*USE\s+\[(?P<database>[^\]]+)\]\s*;\s*$", re.IGNORECASE)
+THREE_PART_OBJECT_PATTERN = re.compile(
+    r"\[(?P<database>[^\]]+)\]\s*\.\s*\[[^\]]+\]\s*\.\s*\[[^\]]+\]",
+    re.IGNORECASE,
+)
 EXPECTED_MARKER = "-- EXPECTED_ROWS_JSON:"
 JSON_HEADER_PREFIX = "JSON_F52E2B61"
 SELECT_STATEMENT_PREFIX_PATTERN = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
@@ -169,6 +173,13 @@ def parse_use_database(statements: list[SqlStatement]) -> str | None:
     return None
 
 
+def parse_database_from_three_part_names(sql_text: str) -> str | None:
+    match = THREE_PART_OBJECT_PATTERN.search(sql_text)
+    if not match:
+        return None
+    return match.group("database")
+
+
 def is_use_database_statement(sql: str) -> bool:
     return USE_DATABASE_PATTERN.match(sql.strip()) is not None
 
@@ -189,6 +200,32 @@ def ensure_query_returns_json(sql: str) -> str:
     if stripped.endswith(";"):
         stripped = stripped[:-1].rstrip()
     return f"{stripped}\nFOR JSON PATH;"
+
+
+def rewrite_query_database(sql: str, source_database: str | None, target_database: str | None) -> str:
+    if not source_database or not target_database:
+        return sql
+    if source_database.strip().lower() == target_database.strip().lower():
+        return sql
+
+    source_escaped = re.escape(source_database.strip())
+    target_bracketed = f"[{target_database.strip()}]."
+
+    # Rewrite bracketed three-part prefixes: [SOURCE].[schema].[table] -> [TARGET].[schema].[table]
+    rewritten = re.sub(
+        rf"\[(?i:{source_escaped})\]\s*\.",
+        target_bracketed,
+        sql,
+    )
+
+    # Rewrite unbracketed three-part prefixes: SOURCE.[schema].[table] -> [TARGET].[schema].[table]
+    rewritten = re.sub(
+        rf"\b(?i:{source_escaped})\b\s*\.",
+        target_bracketed,
+        rewritten,
+    )
+
+    return rewritten
 
 
 def parse_cases(sql_text: str) -> tuple[list[SqlStatement], list[SelectCase]]:
@@ -497,7 +534,18 @@ def comparison_cell(value: object, differs: bool, is_warning: bool = False) -> s
     return text
 
 
-def render_field_comparison_table(expected: object, actual: object) -> list[str]:
+def format_column_label(base_label: str, database_name: str | None) -> str:
+    if database_name and database_name.strip():
+        return f"{base_label} ({database_name.strip()})"
+    return base_label
+
+
+def render_field_comparison_table(
+    expected: object,
+    actual: object,
+    expected_database_name: str | None = None,
+    returned_database_name: str | None = None,
+) -> list[str]:
     # Normalize arrays to ensure consistent ordering for comparison
     expected = normalize_json_arrays(expected)
     actual = normalize_json_arrays(actual)
@@ -506,8 +554,11 @@ def render_field_comparison_table(expected: object, actual: object) -> list[str]
     actual_fields = flatten_json_fields(actual)
     field_names = sorted(set(expected_fields.keys()) | set(actual_fields.keys()), key=numeric_sort_key)
 
+    expected_header = markdown_table_cell(format_column_label("Expected", expected_database_name))
+    returned_header = markdown_table_cell(format_column_label("Returned", returned_database_name))
+
     lines = [
-        "| Field | Expected | Returned |",
+        f"| Field | {expected_header} | {returned_header} |",
         "| --- | --- | --- |",
     ]
 
@@ -540,6 +591,8 @@ def render_markdown_report(
     results: list[dict[str, object]],
 ) -> str:
     database_name = str(summary.get("database") or "").strip()
+    expected_database_name = str(summary.get("expected_database") or "").strip() or None
+    returned_database_name = str(summary.get("returned_database") or database_name).strip() or None
     report_title = (
         f"# {database_name} Select Validation Results"
         if database_name
@@ -602,9 +655,18 @@ def render_markdown_report(
                 lines.append(f"Error: <span class=\"{error_span_class}\">{html.escape(str(result['error']))}</span>")
                 lines.append("")
             if result.get("actual") is not None:
-                lines.extend(render_field_comparison_table(result.get("expected"), result.get("actual")))
+                lines.extend(
+                    render_field_comparison_table(
+                        result.get("expected"),
+                        result.get("actual"),
+                        expected_database_name=expected_database_name,
+                        returned_database_name=returned_database_name,
+                    )
+                )
             else:
-                lines.append("| Field | Expected | Returned |")
+                expected_header = markdown_table_cell(format_column_label("Expected", expected_database_name))
+                returned_header = markdown_table_cell(format_column_label("Returned", returned_database_name))
+                lines.append(f"| Field | {expected_header} | {returned_header} |")
                 lines.append("| --- | --- | --- |")
                 lines.append("| query_error | <span class=\"error\">(query did not return JSON)</span> | <span class=\"error\">missing</span> |")
             lines.append("")
@@ -706,11 +768,18 @@ def render_json_with_mask(value: object, mask: object, use_color: bool, diff_col
     return json.dumps(value, sort_keys=True)
 
 
-def compare_case(client: SqlCmdClient, prelude_sql: str, case: SelectCase) -> dict[str, object]:
+def compare_case(
+    client: SqlCmdClient,
+    prelude_sql: str,
+    case: SelectCase,
+    source_database: str | None = None,
+    target_database: str | None = None,
+) -> dict[str, object]:
     sql_batch_parts = ["SET NOCOUNT ON;"]
     if prelude_sql.strip():
         sql_batch_parts.append(prelude_sql)
-    sql_batch_parts.append(ensure_query_returns_json(case.query_sql))
+    query_sql = rewrite_query_database(case.query_sql, source_database, target_database)
+    sql_batch_parts.append(ensure_query_returns_json(query_sql))
     sql_batch = "\n\n".join(sql_batch_parts)
 
     try:
@@ -797,6 +866,7 @@ def main() -> int:
     if not cases:
         raise SystemExit("No SELECT cases found in the SQL file.")
     inferred_database = parse_use_database(statements)
+    inferred_expected_database = inferred_database or parse_database_from_three_part_names(sql_text)
     database = args.database or inferred_database
     if not database:
         raise SystemExit("Could not determine database from SQL file. Pass --database explicitly.")
@@ -819,7 +889,13 @@ def main() -> int:
 
     case_results: list[dict[str, object]] = []
     for case in cases:
-        result = compare_case(client, prelude_sql, case)
+        result = compare_case(
+            client,
+            prelude_sql,
+            case,
+            source_database=inferred_expected_database,
+            target_database=database,
+        )
         case_results.append(result)
         status = str(result["status"]).upper()
         if status == "PASS":
@@ -846,6 +922,8 @@ def main() -> int:
         "input_file": str(input_file),
         "server": args.server,
         "database": database,
+        "expected_database": inferred_expected_database,
+        "returned_database": database,
         "case_count": len(case_results),
         "pass_count": pass_count,
         "warning_count": warning_count,

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
 import html
 import json
 import os
@@ -381,8 +382,16 @@ def is_iso_datetime_or_date_string(value: object) -> bool:
     """Check if a value looks like an ISO format date or datetime string."""
     if not isinstance(value, str):
         return False
-    # Matches ISO date (YYYY-MM-DD), ISO datetime (YYYY-MM-DDTHH:MM:SS), or with timezone
-    return bool(re.match(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.[\d]+)?(Z|[+-]\d{2}:?\d{2})?)?$", value))
+
+    candidate = value.strip()
+    if not candidate:
+        return False
+
+    try:
+        datetime.fromisoformat(candidate)
+        return True
+    except ValueError:
+        return False
 
 
 def is_midnight_time(value: str) -> bool:
@@ -397,7 +406,7 @@ def is_midnight_mismatch(expected: object, actual: object) -> bool:
         return False
     if not ("T" in expected and "T" in actual):
         return False  # Only check if both have time components
-    
+
     expected_is_midnight = is_midnight_time(expected)
     actual_is_midnight = is_midnight_time(actual)
     # Return True if one is midnight and the other isn't (they differ)
@@ -448,11 +457,11 @@ def normalize_json_arrays(data: object) -> object:
     """
     if isinstance(data, dict):
         return {key: normalize_json_arrays(value) for key, value in data.items()}
-    
+
     if isinstance(data, list):
         # Normalize each element recursively
         normalized_items = [normalize_json_arrays(item) for item in data]
-        
+
         # Sort arrays if they contain objects (dicts) - sort by JSON representation
         if normalized_items and isinstance(normalized_items[0], dict):
             try:
@@ -460,9 +469,9 @@ def normalize_json_arrays(data: object) -> object:
             except (TypeError, ValueError):
                 # If sorting fails, keep original order
                 pass
-        
+
         return normalized_items
-    
+
     return data
 
 
@@ -471,14 +480,14 @@ def count_differences(expected: object, actual: object) -> tuple[int, int]:
     # Normalize arrays to ensure consistent ordering for comparison
     expected = normalize_json_arrays(expected)
     actual = normalize_json_arrays(actual)
-    
+
     expected_fields = flatten_json_fields(expected)
     actual_fields = flatten_json_fields(actual)
     field_names = set(expected_fields.keys()) | set(actual_fields.keys())
-    
+
     warning_count = 0
     failure_count = 0
-    
+
     for field_name in field_names:
         expected_has = field_name in expected_fields
         actual_has = field_name in actual_fields
@@ -492,7 +501,7 @@ def count_differences(expected: object, actual: object) -> tuple[int, int]:
             warning_count += 1
         else:
             failure_count += 1
-    
+
     return warning_count, failure_count
 
 
@@ -511,16 +520,16 @@ def numeric_sort_key(field_name: str) -> tuple:
     Returns a tuple where array indices are integers for proper numeric sorting.
     """
     parts: list = []
-    
+
     # Pattern to match either array indices [N] or field names
     pattern = r'\[(\d+)\]|([^\[\]]+)'
-    
+
     for match in re.finditer(pattern, field_name):
         if match.group(1):  # Array index
             parts.append((1, int(match.group(1))))  # Tuple with 1 for array, then numeric index
         elif match.group(2):  # Field name
             parts.append((0, match.group(2)))  # Tuple with 0 for field, then string
-    
+
     return tuple(parts) if parts else ((0, field_name),)
 
 
@@ -584,7 +593,7 @@ def render_field_comparison_table(
     # Normalize arrays to ensure consistent ordering for comparison
     expected = normalize_json_arrays(expected)
     actual = normalize_json_arrays(actual)
-    
+
     expected_fields = flatten_json_fields(expected)
     actual_fields = flatten_json_fields(actual)
     field_names = sorted(set(expected_fields.keys()) | set(actual_fields.keys()), key=numeric_sort_key)
@@ -678,7 +687,7 @@ def render_markdown_report(
     failing_results = [result for result in results if result["status"] == "fail"]
     warning_results = [result for result in results if result["status"] == "warning"]
     details_results = failing_results + warning_results
-    
+
     if details_results:
         lines.extend(["", "## Details", ""])
         for result in details_results:
@@ -840,7 +849,7 @@ def compare_case(
                 status = "warning"
             else:
                 status = "fail"
-        
+
         result: dict[str, object] = {
             "case_index": case.case_index,
             "label": case.label,

--- a/testing-tools/local-db-tracing/validate_rdb_selects.py
+++ b/testing-tools/local-db-tracing/validate_rdb_selects.py
@@ -377,6 +377,33 @@ def normalize_trailing_zero_millis(value: object) -> object:
     return re.sub(r"(?<=\d)\.000(?=(?:Z|[+-]\d{2}:?\d{2})?$)", "", value)
 
 
+def is_iso_datetime_or_date_string(value: object) -> bool:
+    """Check if a value looks like an ISO format date or datetime string."""
+    if not isinstance(value, str):
+        return False
+    # Matches ISO date (YYYY-MM-DD), ISO datetime (YYYY-MM-DDTHH:MM:SS), or with timezone
+    return bool(re.match(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.[\d]+)?(Z|[+-]\d{2}:?\d{2})?)?$", value))
+
+
+def is_midnight_time(value: str) -> bool:
+    """Check if an ISO datetime string has a midnight time component (00:00:00)."""
+    # Match times that are exactly 00:00:00 or 00:00:00.000, etc.
+    return bool(re.search(r"T00:00:00(\.0+)?(Z|[+-]\d{2}:?\d{2})?$", value))
+
+
+def is_midnight_mismatch(expected: object, actual: object) -> bool:
+    """Check if one datetime is midnight and the other isn't."""
+    if not (isinstance(expected, str) and isinstance(actual, str)):
+        return False
+    if not ("T" in expected and "T" in actual):
+        return False  # Only check if both have time components
+    
+    expected_is_midnight = is_midnight_time(expected)
+    actual_is_midnight = is_midnight_time(actual)
+    # Return True if one is midnight and the other isn't (they differ)
+    return expected_is_midnight != actual_is_midnight
+
+
 def is_datetime_zero_millis_mismatch(expected: object, actual: object) -> bool:
     if not (isinstance(expected, str) and isinstance(actual, str)):
         return False
@@ -400,6 +427,14 @@ def is_warning_mismatch(
         return True
     if is_datetime_zero_millis_mismatch(expected_value, actual_value):
         return True
+    # Check if both are date/datetime values - if so, it's a warning (unless midnight mismatch)
+    if isinstance(expected_value, str) and isinstance(actual_value, str):
+        if is_iso_datetime_or_date_string(expected_value) and is_iso_datetime_or_date_string(actual_value):
+            # If one is midnight and the other isn't, it's an error (not a warning)
+            if is_midnight_mismatch(expected_value, actual_value):
+                return False
+            # Otherwise, date/datetime differences are warnings
+            return True
     if field_name_is_warning_exception(field_name):
         return True
     return field_name_ends_with_id_uid_or_key(field_name)


### PR DESCRIPTION
## Description
Handful of changes that improve the testing process (in particular, RDB vs. RDB_Modern and vice versa) including:
- Add logic to handle midnight time in datetime replacements
- Adding tables to ignore as per https://cdc-nbs.atlassian.net/wiki/spaces/NE/pages/2136506371/RTR+reporting+differences#RDB-Tables-Not-Considered-for-Comparison
- Refactor exclusion logic for artifact tables to ensure case-insensitivity
- When validating data, if the difference is a date or datetime and both sides have a value, treat it as a warning - not an error. If either side is missing a value (or is NULL), it's an error. Also, if it's a datetime and one side is midnight but the other isn't, it's an error.

## Related Issue
[APP-280](https://cdc-nbs.atlassian.net/browse/APP-280)

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
