### PR TITLE
Fix sp_nrt_ldf_postprocessing: read ld.record_status_cd not metadata_record_status_cd

### DIFF
--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/015-sp_nrt_ldf_postprocessing-001.sql
@@ -871,7 +871,7 @@ BEGIN
             ld.label_txt,
             ld.ldf_oid,
             ld.nnd_ind,
-            ld.metadata_record_status_cd
+            ld.record_status_cd
         into #tmp_ldf_data
         from dbo.nrt_ldf_data ld
                  left join dbo.nrt_ldf_data_key nldk with (nolock) ON ld.ldf_uid = nldk.ldf_uid and ld.business_object_uid = nldk.business_object_uid
@@ -1014,7 +1014,7 @@ BEGIN
           ,label_txt = ld.label_txt
           ,ldf_oid = ld.ldf_oid
           ,nnd_ind = ld.nnd_ind
-          ,record_status_cd = ld.metadata_record_status_cd
+          ,record_status_cd = ld.record_status_cd
         FROM #tmp_ldf_data ld
                  inner join dbo.ldf_data k with (nolock) ON ld.ldf_data_key = k.ldf_data_key
             and ld.ldf_group_key = k.ldf_group_key
@@ -1140,7 +1140,7 @@ BEGIN
              ,tld.label_txt
              ,tld.ldf_oid
              ,tld.nnd_ind
-             ,tld.metadata_record_status_cd
+             ,tld.record_status_cd
         FROM #tmp_ldf_data tld
                  join dbo.nrt_ldf_data_key k with (nolock) on tld.ldf_uid = k.ldf_uid
             and tld.business_object_uid = k.business_object_uid

--- a/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/expected.json
@@ -1,0 +1,7 @@
+{
+  "0": [
+    {
+      "RECORD_STATUS_CD": "ACTIVE"
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/query.sql
@@ -1,0 +1,6 @@
+SELECT
+    ld.RECORD_STATUS_CD
+FROM RDB_MODERN.dbo.LDF_DATA ld
+JOIN RDB_MODERN.dbo.nrt_ldf_data_key k
+  ON ld.ldf_data_key = k.d_ldf_data_key
+WHERE k.business_object_uid = 96000600;

--- a/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/bug6_ldf_data_truncation/setup.sql
@@ -1,0 +1,65 @@
+USE RDB_MODERN;
+
+-- Disable FK constraints during seed (some baseline tables have FKs back to dimensions).
+EXEC sp_MSforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT ALL';
+
+-- Use a private UID namespace (96xxxxxx) to avoid colliding with baseline data
+-- and other bug-fix tests (bug7 uses 97xxxxxx).
+DECLARE @bo_uid bigint = 96000600;
+DECLARE @ldf_uid bigint = 96001976;
+DECLARE @condition_cd varchar(50) = N'96210';
+
+-- Cleanup any prior remnants from this UID space
+DELETE ld
+FROM dbo.LDF_DATA ld
+JOIN dbo.nrt_ldf_data_key k ON ld.ldf_data_key = k.d_ldf_data_key
+WHERE k.business_object_uid = @bo_uid;
+
+DELETE FROM dbo.nrt_ldf_data_key  WHERE business_object_uid = @bo_uid;
+DELETE FROM dbo.ldf_group         WHERE business_object_uid = @bo_uid;
+DELETE FROM dbo.nrt_ldf_group_key WHERE business_object_uid = @bo_uid;
+DELETE FROM dbo.nrt_ldf_data      WHERE business_object_uid = @bo_uid;
+DELETE FROM dbo.nrt_odse_state_defined_field_metadata WHERE ldf_uid = @ldf_uid;
+
+-- Metadata row: SP inner joins on ldf_uid and filters on active_ind <> 'N'.
+-- record_status_cd here holds the canonical 13-char 'LDF_PROCESSED' value
+-- (this is what the pre-fix SP incorrectly read from nrt_ldf_data and
+-- forwarded into LDF_DATA.RECORD_STATUS_CD varchar(8)).
+INSERT INTO dbo.nrt_odse_state_defined_field_metadata
+    (ldf_uid, active_ind, business_object_nm, code_set_nm, condition_cd, data_type,
+     ldf_page_id, label_txt, class_cd, add_time, record_status_time, record_status_cd)
+VALUES
+    (@ldf_uid, N'Y', N'PHC', N'YNU', @condition_cd, N'CV', N'9952',
+     N'Bug6 LDF answer', N'PHC',
+     '2026-05-17 00:00:00', '2026-05-17 00:00:00', N'LDF_PROCESSED');
+
+-- nrt_ldf_data: the answer row that flows through the SP.
+-- record_status_cd='ACTIVE' (8-char-safe, passes LDF_DATA.RECORD_STATUS_CD
+-- CHECK constraint; this is the column the FIXED SP must read).
+-- metadata_record_status_cd='LDF_PROCESSED' (the 13-char value the BUGGY
+-- SP would have read, causing Msg 2628 truncation).
+INSERT INTO dbo.nrt_ldf_data
+    (ldf_uid, business_object_uid, ldf_field_data_business_object_nm,
+     active_ind, ldf_meta_data_business_object_nm,
+     condition_cd, label_txt, data_type, code_set_nm,
+     ldf_value, ldf_column_type,
+     record_status_cd,
+     metadata_record_status_cd,
+     ldf_data_field_add_time, ldf_data_last_chg_time,
+     metadata_record_status_time, ldf_meta_data_add_time)
+VALUES
+    (@ldf_uid, @bo_uid, N'PHC', N'Y', N'PHC',
+     @condition_cd, N'Bug6 LDF answer', N'CV', N'YNU',
+     N'Y', N'CV',
+     N'ACTIVE',
+     N'LDF_PROCESSED',
+     '2026-05-17 00:00:00', '2026-05-17 00:00:00',
+     '2026-05-17 00:00:00', '2026-05-17 00:00:00');
+
+EXEC sp_MSforeachtable 'ALTER TABLE ? CHECK CONSTRAINT ALL';
+
+-- Invoke the SP. With the fix, LDF_DATA receives one row with
+-- RECORD_STATUS_CD='ACTIVE'. Pre-fix, the SP's INSERT INTO LDF_DATA
+-- aborted with Msg 2628 (varchar(8) truncation) and no row was inserted.
+DECLARE @ldf_uid_list nvarchar(max) = CAST(@ldf_uid AS varchar);
+EXEC dbo.sp_nrt_ldf_postprocessing @ldf_uid_list = @ldf_uid_list, @debug = 0;


### PR DESCRIPTION
## Description
`sp_nrt_ldf_postprocessing` mapped `nrt_ldf_data.metadata_record_status_cd` (typically holds the canonical upstream ETL flag `'LDF_PROCESSED'`, 13 chars) into `LDF_DATA.RECORD_STATUS_CD` (`varchar(8)` with a CHECK constraint for `'ACTIVE'`/`'INACTIVE'`). The INSERT therefore failed with Msg 2628 "String or binary data would be truncated" the first time any LDF data was flowed through.

This was a mapping bug, not a width oversight: the destination column was sized for the lifecycle status (`ACTIVE`/`INACTIVE`), not for the ETL processing flag. The peer column `nrt_ldf_data.record_status_cd` is the LDF-answer's own active/inactive status and is the semantically correct source. The SP already filters on this column at line 873 (`where ld.RECORD_STATUS_CD is not null`) but never selected it.

This PR changes the source column from `metadata_record_status_cd` to `record_status_cd` at all three sites in the SP (SELECT INTO at line 874, UPDATE at line 1017, INSERT at line 1143 — including the SELECT INTO that propagates the column name into a temp table).

Verified locally: post-fix, `LDF_DATA` accepts the inserted row with `RECORD_STATUS_CD='ACTIVE'` (passes CHECK constraint); no Msg 2628 in `job_flow_log`.

## Related Issue
[APP-471](https://cdc-nbs.atlassian.net/browse/APP-471)

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
