### PR TITLE
Attempt to resolve unit test deadlock issue by removing concurrency

### DIFF
--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/support/QueryRunner.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/support/QueryRunner.java
@@ -1,7 +1,5 @@
 package gov.cdc.nbs.report.pipeline.integration.support;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,10 +12,8 @@ public class QueryRunner {
 
   /**
    * Splits the provided sql on the ';' character. Each statement is then executed by the provided
-   * JdbcClient within an {@link Await#waitFor}. An assertion is made to ensure results are returned
-   * within the retry time limit. Results of all queries are compiled into a single {@link HashMap}
-   * where the key is the index of the statement (0,1,...) and the value is a {@literal
-   * List<Map<String, Object>>}
+   * JdbcClient. Results of all queries are compiled into a single {@link HashMap} where the key is
+   * the index of the statement (0,1,...) and the value is a {@literal List<Map<String, Object>>}
    *
    * @param sql A single or multiple SQL queries separated by ';'
    * @param client A JdbcClient for executing the provided sql
@@ -29,9 +25,7 @@ public class QueryRunner {
     int queryIndex = 0;
 
     for (String query : queries) {
-      Optional<List<Map<String, Object>>> result =
-          Await.waitFor(() -> QueryRunner.select(query, client));
-      assertThat(result).isPresent();
+      Optional<List<Map<String, Object>>> result = QueryRunner.select(query, client);
       results.put(String.valueOf(queryIndex), result.get());
       queryIndex++;
     }

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 import org.json.JSONException;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -79,7 +77,6 @@ class DataDrivenUnitTests extends UnitTest {
    * @throws JSONException
    */
   @ParameterizedTest
-  @Execution(ExecutionMode.CONCURRENT)
   @MethodSource("unitTestDirectoryProvider")
   @Transactional(propagation = Propagation.NOT_SUPPORTED)
   void testRunner(Path testDirectory) throws IOException {

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/UnitTest.java
@@ -62,7 +62,7 @@ public abstract class UnitTest {
   }
 
   @BeforeAll
-  void setUp() throws Exception {
+  void setUp() {
     synchronized (UnitTest.class) {
       if (!started) {
         if (environment == null) {
@@ -75,7 +75,7 @@ public abstract class UnitTest {
   }
 
   @AfterAll
-  void tearDown() throws Exception {
+  void tearDown() {
     synchronized (UnitTest.class) {
       if (started) {
         if (environment == null) {

--- a/reporting-pipeline-service/src/test/resources/testData/unit/covidCaseDatamart/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/covidCaseDatamart/setup.sql
@@ -2,8 +2,8 @@ USE RDB_MODERN;
 -----------------------------------------------------------------------
 -- CLEANUPS
 -----------------------------------------------------------------------
-EXEC sp_MSforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT ALL';
 -- Cleanup Modern RDB
+DELETE FROM [RDB_MODERN].[dbo].[CONFIRMATION_METHOD_GROUP]
 DELETE FROM [RDB_MODERN].[dbo].[COVID_CASE_DATAMART]
 DELETE FROM [RDB_MODERN].[dbo].[D_ORGANIZATION]
 DELETE FROM [RDB_MODERN].[dbo].[D_PATIENT]
@@ -35,12 +35,10 @@ DELETE FROM [RDB_MODERN].[dbo].[L_INV_EPIDEMIOLOGY]
 DELETE FROM [RDB_MODERN].[dbo].[L_INV_ADMINISTRATIVE]
 DELETE FROM [RDB_MODERN].[dbo].[nrt_patient_key]
 DELETE FROM [RDB_MODERN].[dbo].[nrt_organization_key]
-DELETE FROM [RDB_MODERN].[dbo].[CONFIRMATION_METHOD_GROUP]
 DELETE FROM [RDB_MODERN].[dbo].[nrt_provider_key]
 DELETE FROM [RDB_MODERN].[dbo].[CASE_COUNT]
 DELETE FROM [RDB_MODERN].[dbo].[JOB_FLOW_LOG]
 
-EXEC sp_MSforeachtable 'ALTER TABLE ? CHECK CONSTRAINT ALL';
 -----------------------------------------------------------------------
 -- SECTION 2: RDB_MODERN SEEDING
 -----------------------------------------------------------------------


### PR DESCRIPTION
## Description
1. Removes concurrent test runs from unit tests
2. Removes Await usage in unit tests (no RTR processing is being done so why wait?) - this change offsets the slowdown from the concurrency removal
3. Cleans up some `throws Exception` where no Exceptions were being thrown
4. Reorders a cleanup in the `covidCaseDatamart` unit test to remove need to drop constraints

## Additional Information
Several PRs have had failing unit test runs due to the following error: 
```
EXEC dbo.sp_nrt_ldf_postprocessing @ldf_uid_list = @ldf_uid_list, @debug = 0;
]; Transaction (Process ID 68) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.
	at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:124)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:107)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:116)
	at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1556)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:677)
	at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:972)
	at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:993)
	at org.springframework.jdbc.core.simple.DefaultJdbcClient$DefaultStatementSpec.update(DefaultJdbcClient.java:238)
	at gov.cdc.nbs.report.pipeline.integration.unit.DataDrivenUnitTests.lambda$testRunner$1(DataDrivenUnitTests.java:100)
	at org.springframework.transaction.support.TransactionOperations.lambda$executeWithoutResult$0(TransactionOperations.java:68)
	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140)
	at org.springframework.transaction.support.TransactionOperations.executeWithoutResult(TransactionOperations.java:67)
	at gov.cdc.nbs.report.pipeline.integration.unit.DataDrivenUnitTests.testRunner(DataDrivenUnitTests.java:94)
```

This PR attempts to resolve that issue.