### PR TITLE
Update mssql driver to newest non-preview

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation 'io.debezium:debezium-core:2.4.1.Final'
 
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.0.jre17-preview'
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
     implementation 'ch.qos.logback:logback-classic:1.5.32'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'com.google.guava:guava:33.5.0-jre'


### PR DESCRIPTION
## Description
Updates the mssql driver used to the newest `non-preview` version.

I noticed we were currently using a preview version when this dependabot PR was created
https://github.com/CDCgov/NEDSS-DataReporting/pull/824

Driver Repository
https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc