### PR TITLE
LAB100.CONDITION_CD Mapping Fixes

### DIFF
--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -1,10 +1,10 @@
-IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_lab100_datamart_postprocessing]')
+IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_lab100_datamart_postprocessing]') 
 	AND OBJECTPROPERTY(id, N'IsProcedure') = 1
 )
 BEGIN
     DROP PROCEDURE [dbo].[sp_lab100_datamart_postprocessing]
 END
-GO
+GO 
 
 CREATE PROCEDURE dbo.[sp_lab100_datamart_postprocessing]
     @labtestuids nvarchar(max), @debug bit = 'false'

--- a/liquibase-service/src/main/resources/db/005-rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/liquibase-service/src/main/resources/db/005-rdb_modern/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -1,10 +1,10 @@
-IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_lab100_datamart_postprocessing]') 
+IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_lab100_datamart_postprocessing]')
 	AND OBJECTPROPERTY(id, N'IsProcedure') = 1
 )
 BEGIN
     DROP PROCEDURE [dbo].[sp_lab100_datamart_postprocessing]
 END
-GO 
+GO
 
 CREATE PROCEDURE dbo.[sp_lab100_datamart_postprocessing]
     @labtestuids nvarchar(max), @debug bit = 'false'
@@ -1189,8 +1189,7 @@ BEGIN
             lt2.LAB_RPT_STATUS,
             lt2.oid_order,
             case
-                when RTRIM(LTRIM(lt2.CONDITION_SHORT_NM))=''
-                    or RTRIM(LTRIM(lt2.CONDITION_SHORT_NM)) is null then lc.condition_cd
+                when lc.condition_cd is not null and RTRIM(LTRIM(lc.condition_cd))<>'' then lc.condition_cd
                 else lt2.CONDITION_CD
                 end as CONDITION_CD,
             lt2.REASON_FOR_TEST_DESC1,
@@ -1361,7 +1360,7 @@ BEGIN
             lt3.oid_order,
             case
                 when TEST_RESULT_VAL_CD   like '%[^0-9]%' and SUBSTRING(TEST_RESULT_VAL_CD,2,1) = '-'
-                    and (lt3.CONDITION_CD='' or lt3.CONDITION_CD is null) then sc.DISEASE_NM
+                    and sc.CONDITION_CD is not null and RTRIM(LTRIM(sc.CONDITION_CD))<>'' then sc.CONDITION_CD
                 else lt3.CONDITION_CD
                 end as CONDITION_CD,
             lt3.REASON_FOR_TEST_DESC1,

--- a/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/010-CreatePatient-AddLabReportManualSalmonella/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/010-CreatePatient-AddLabReportManualSalmonella/expected.json
@@ -117,7 +117,7 @@
             "ADDR_CD_DESC": "HOUSE",
             "ADDR_USE_CD_DESC": "HOME",
             "AGE_REPORTED": 41,
-            "CONDITION_CD": "Salmonellosis",
+            "CONDITION_CD": 50265,
             "CONDITION_SHORT_NM": "Salmonellosis",
             "ELR_IND": "N",
             "EVENT_DATE": "2026-04-01T00:00:00.000",

--- a/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/010-CreatePatient-AddLabReportManualSalmonella/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/010-CreatePatient-AddLabReportManualSalmonella/expected.json
@@ -117,7 +117,7 @@
             "ADDR_CD_DESC": "HOUSE",
             "ADDR_USE_CD_DESC": "HOME",
             "AGE_REPORTED": 41,
-            "CONDITION_CD": 50265,
+            "CONDITION_CD": "50265",
             "CONDITION_SHORT_NM": "Salmonellosis",
             "ELR_IND": "N",
             "EVENT_DATE": "2026-04-01T00:00:00.000",

--- a/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/020-CreateInvestigationSalmonella/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/020-CreateInvestigationSalmonella/expected.json
@@ -264,7 +264,7 @@
             "ADDR_CD_DESC": "HOUSE",
             "ADDR_USE_CD_DESC": "HOME",
             "AGE_REPORTED": 41,
-            "CONDITION_CD": "Salmonellosis",
+            "CONDITION_CD": "50265",
             "CONDITION_SHORT_NM": "Salmonellosis",
             "ELR_IND": "N",
             "EVENT_DATE": "2026-04-01T00:00:00.000",

--- a/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/030-Investigate-AddTreatmentStartSalmonella/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/030-Investigate-AddTreatmentStartSalmonella/expected.json
@@ -361,7 +361,7 @@
             "ADDR_CD_DESC": "HOUSE",
             "ADDR_USE_CD_DESC": "HOME",
             "AGE_REPORTED": 41,
-            "CONDITION_CD": "Salmonellosis",
+            "CONDITION_CD": "50265",
             "CONDITION_SHORT_NM": "Salmonellosis",
             "ELR_IND": "N",
             "EVENT_DATE": "2026-04-01T00:00:00.000",

--- a/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/040-CloseInvestigationSalmonellaAndCreateNotification/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/functional/skipSupervisorReview/040-CloseInvestigationSalmonellaAndCreateNotification/expected.json
@@ -461,7 +461,7 @@
             "ADDR_CD_DESC": "HOUSE",
             "ADDR_USE_CD_DESC": "HOME",
             "AGE_REPORTED": 41,
-            "CONDITION_CD": "Salmonellosis",
+            "CONDITION_CD": "50265",
             "CONDITION_SHORT_NM": "Salmonellosis",
             "ELR_IND": "N",
             "EVENT_DATE": "2026-04-01T00:00:00.000",


### PR DESCRIPTION
## Description
These two changes fix how `LAB100.CONDITION_CD` is populated from `SRTE` lookup tables. The issue was that `CONDITION_CD` was receiving disease names (text like "Salmonellosis") instead of disease codes (numeric like "50265").

### Change 1: LOINC-derived CONDITION_CD
The logic shifted from reactive (only use mapping if current value is missing) to proactive (prefer the mapped numeric code whenever it exists).

Impact: For LOINC-mapped tests, `CONDITION_CD` will now use the authoritative numeric code from `nrt_srte_Loinc_condition.condition_cd` instead of falling back to a potentially missing or incomplete value.

### Change 2: SNOMED-derived CONDITION_CD
Was using the disease name (`sc.DISEASE_NM` = "Salmonellosis"), now uses the disease code (`sc.CONDITION_CD` = "50265").

`LAB100` will now correctly store numeric condition codes instead of text disease names for SNOMED-mapped results.

## Related Issue
[APP-600: LAB100.CONDITION_CD should receive numeric value](https://cdc-nbs.atlassian.net/browse/APP-600)

## Additional Notes
- This should automatically close PR #814 
- New Test Database Image has been published based on this branch
- Documentation must be updated after this PR is merged

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
