### PR TITLE
Remove base directory scan from dependabot to prevent duplicate PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
   - package-ecosystem: "gradle"
     directories:
       - "/"
-      - "/liquibase-service"
-      - "/reporting-pipeline-service"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Description
The Dependabot configuration was scanning both `/` and the sub-directories `/liquibase-service`, `/reporting-pipeline-service` leading to duplicate dependabot PRs being opened for gradle dependency upgrades.

See: https://github.com/CDCgov/NEDSS-DataReporting/pull/824 and https://github.com/CDCgov/NEDSS-DataReporting/pull/819

This PR removes the sub-directory scans from the gradle checks. 