### PR TITLE
Fix build_step_test_artifacts.py: Add .000 to all times, not just 00:00:00

### DIFF
--- a/testing-tools/local-db-tracing/build_step_test_artifacts.py
+++ b/testing-tools/local-db-tracing/build_step_test_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -65,7 +66,7 @@ def transform_query_sql(content: str) -> str:
 
 
 def transform_expected_json(content: str) -> str:
-    transformed = content.replace('T00:00:00"', 'T00:00:00.000"')
+    transformed = re.sub(r'(T\d{2}:\d{2}:\d{2})(")', r'\1.000\2', content)
     if not transformed.endswith("\n"):
         transformed += "\n"
     return transformed


### PR DESCRIPTION
## Description
While working on [APP-570](https://cdc-nbs.atlassian.net/browse/APP-570) my test was failing:

```
Expected: 2026-05-13T07:30:00
got: 2026-05-13T07:30:00.000
```

This edit will add .000 to all times, not just 00:00:00

## Related Issue
N/A

## Additional Notes
N/A

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
