### PR TITLE
[APP-564] bump Spring Boot to 3.5.14

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -6,6 +6,9 @@ plugins {
     id 'org.sonarqube' version '7.3.0.8198'
 }
 
+// Override the Spring Boot managed Tomcat version to address security vulnerabilities
+ext['tomcat.version'] = '10.1.55'
+
 group = 'gov.cdc.etldatapipeline'
 version = '0.0.1-SNAPSHOT'
 

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.14'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
     id 'org.sonarqube' version '7.3.0.8198'
@@ -127,15 +127,6 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-}
-
-dependencyManagement {
-    dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
-        dependency 'com.fasterxml.jackson.core:jackson-core:2.21.1'
-    }
 }
 
 sonarqube {


### PR DESCRIPTION
## Description
Upgrades the Spring Boot plugin and resolves multiple high/critical security vulnerabilities.

- Spring Boot Upgrade: Bumped plugin version from 3.5.6 to 3.5.14.
- Dependency Cleanup: Removed the explicit dependencyManagement block overrides for Tomcat and Jackson, allowing the Spring Boot BOM to natively manage version harmony.
- Security Hotfix: Explicitly forced Gradle to use Tomcat version 10.1.55 via property override to remediate multiple Trivy-flagged CVEs (including authentication bypass and input validation vulnerabilities).

## Related Issue
[APP-564](https://cdc-nbs.atlassian.net/browse/APP-564)

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
