### PR TITLE
Disable PHC datamart feature flag by default

### DIFF
--- a/reporting-pipeline-service/src/main/resources/application.yaml
+++ b/reporting-pipeline-service/src/main/resources/application.yaml
@@ -84,7 +84,7 @@ spring:
 
 featureFlag:
   elastic-search-enable: ${FF_ES_ENABLE:false}
-  phc-datamart-enable: ${FF_PHC_DM_ENABLE:true}
+  phc-datamart-enable: ${FF_PHC_DM_ENABLE:false}
   thread-pool-size: ${FF_THREAD_POOL_SIZE:1}
   post-processing-enable: ${FF_POST_PROCESSING_ENABLE:true}
 


### PR DESCRIPTION
## Description
Changes the default value of the `phc-datamart-enable` feature flag from `true` to `false` in the reporting pipeline service configuration to match what STLT will have in production. Aligning local and default config with production ensures we're validating prod behavior rather than a configuration that isn't live.

## Related Issue
[Slack convo](https://skylight-hq.slack.com/archives/C09KAHXEZT5/p1780339350420519)

## Additional Notes
The flag can still be enabled by setting `FF_PHC_DM_ENABLE=true`.

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
