### PR TITLE
[APP-615] Datamart failures shouldn't prevent other datamarts from running

### DIFF
--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingService.java
@@ -1328,7 +1328,7 @@ public class PostProcessingService {
       return null;
     }
 
-    batchId = dmProcessor.getBatchId(batchId, e);
+    batchId = dmProcessor.nextBatchId(batchId, e);
 
     Map<String, Queue<Long>> retryMap =
         retryCache.computeIfAbsent(batchId, k -> new ConcurrentHashMap<>());

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/ProcessDatamartData.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/ProcessDatamartData.java
@@ -518,44 +518,41 @@ public class ProcessDatamartData {
 
   private void processDynDatamart(BatchProcessingState state, List<DatamartData> dmDataList) {
     if (!dmDataList.isEmpty()) {
-      Map<String, String> datamartPhcIdMap =
+      Map<String, List<Long>> datamartPhcIdMap =
           dmDataList.stream()
               .collect(
                   Collectors.groupingBy(
                       DatamartData::getDatamart,
                       Collectors.mapping(
-                          dmData -> String.valueOf(dmData.getPublicHealthCaseUid()),
-                          Collectors.joining(","))));
+                          DatamartData::getPublicHealthCaseUid, Collectors.toList())));
 
       List<CompletableFuture<Void>> futures = new ArrayList<>();
       datamartPhcIdMap.forEach(
-          (datamart, phcIds) ->
-              futures.add(
-                  CompletableFuture.runAsync(
-                      () -> {
-                        logger.info(
-                            "Executing stored proc: sp_dyn_datamart_postprocessing '{}', '{}'",
+          (datamart, phcIds) -> {
+            String phcIdsString =
+                phcIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+            futures.add(
+                CompletableFuture.runAsync(
+                    () -> {
+                      logger.info(
+                          "Executing stored proc: sp_dyn_datamart_postprocessing '{}', '{}'",
+                          datamart,
+                          phcIdsString);
+                      try {
+                        procRepository.executeStoredProcForDynDatamart(datamart, phcIdsString);
+                        logExecutionCompleted("sp_dyn_datamart_postprocessing");
+                        incrementIf(ppDmSuccess, !state.isRetry);
+                      } catch (Exception e) {
+                        incrementIf(ppDmFailure, !state.isRetry);
+                        logger.error("Error processing dynamic datamart: {}", datamart, e);
+                        state.registerFailure(
                             datamart,
-                            phcIds);
-                        try {
-                          procRepository.executeStoredProcForDynDatamart(datamart, phcIds);
-                          logExecutionCompleted("sp_dyn_datamart_postprocessing");
-                          incrementIf(ppDmSuccess, !state.isRetry);
-                        } catch (Exception e) {
-                          incrementIf(ppDmFailure, !state.isRetry);
-                          logger.error("Error processing dynamic datamart: {}", datamart, e);
-                          state.registerFailure(
-                              datamart,
-                              Collections.singletonMap(
-                                  INVESTIGATION.getEntityName(),
-                                  Arrays.stream(phcIds.split(","))
-                                      .map(String::trim)
-                                      .map(Long::parseLong)
-                                      .collect(Collectors.toList())),
-                              e);
-                        }
-                      },
-                      dynDmExecutor)));
+                            Collections.singletonMap(INVESTIGATION.getEntityName(), phcIds),
+                            e);
+                      }
+                    },
+                    dynDmExecutor));
+          });
 
       // Wait for all async tasks to complete before returning
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/ProcessDatamartData.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/ProcessDatamartData.java
@@ -159,7 +159,7 @@ public class ProcessDatamartData {
 
   protected boolean processDmCache(Map<String, Map<String, List<Long>>> dmCache, Long batchId) {
     List<Long> ldfUids = new ArrayList<>();
-    boolean failed = false;
+    BatchProcessingState state = new BatchProcessingState(batchId);
 
     Timer.Sample sample = metrics.startSample();
 
@@ -174,40 +174,35 @@ public class ProcessDatamartData {
 
       List<Long> uids = getUids(dmValues, INVESTIGATION);
 
-      if (failed) {
-        updateRetryCache(batchId, dmKey, dmValues);
-      } else {
-        if (batchId != null) {
-          logger.info(
-              "Retrying {} id(s) from datamart topic: {}, attempt #{} for batch id: {}",
-              uids.size(),
-              dmKey,
-              retryAttempts.getOrDefault(batchId, 0) + 1,
-              batchId);
-        }
+      if (state.isRetry) {
+        logger.info(
+            "Retrying {} id(s) from datamart topic: {}, attempt #{} for batch id: {}",
+            uids.size(),
+            dmKey,
+            retryAttempts.getOrDefault(state.getBatchId(), 0) + 1,
+            state.getBatchId());
+      }
 
-        try {
-          processDatamart(dmKey, dmValues, ldfUids);
-          incrementIf(ppDmSuccess, batchId == null);
-        } catch (Exception e) {
-          incrementIf(ppDmFailure, batchId == null);
-          logger.error(
-              errorMessage(
-                  dmKey, listToParameterString(uids), new Exception(e.getClass().getSimpleName())));
-          failed = true;
-          batchId = buildRetryCache(batchId, dmKey, dmValues, e);
-        }
+      try {
+        processDatamart(dmKey, dmValues, ldfUids);
+        incrementIf(ppDmSuccess, !state.isRetry);
+      } catch (Exception e) {
+        incrementIf(ppDmFailure, !state.isRetry);
+        logger.error(
+            errorMessage(
+                dmKey, listToParameterString(uids), new Exception(e.getClass().getSimpleName())));
+        state.registerFailure(dmKey, dmValues, e);
       }
     }
 
-    failed = processLdfVaccinePreventDm(batchId, ldfUids, failed);
+    processLdfVaccinePreventDm(state, ldfUids);
 
     if (dmCache.containsKey(MULTI_ID_DATAMART)) {
-      failed = processMultiIdDatamart(batchId, dmCache.get(MULTI_ID_DATAMART), failed);
+      processMultiIdDatamart(state, dmCache.get(MULTI_ID_DATAMART));
     }
 
     metrics.stopSample(sample, processTimer);
-    return !failed;
+    return !state.hasFailed();
   }
 
   private void incrementIf(Counter cnt, boolean notRetry) {
@@ -384,8 +379,8 @@ public class ProcessDatamartData {
     }
   }
 
-  private boolean processLdfVaccinePreventDm(Long batchId, List<Long> ldfUids, boolean failed) {
-    if (!failed && !ldfUids.isEmpty()) {
+  private void processLdfVaccinePreventDm(BatchProcessingState state, List<Long> ldfUids) {
+    if (!ldfUids.isEmpty()) {
 
       String cases = listToParameterString(ldfUids);
       try {
@@ -394,19 +389,17 @@ public class ProcessDatamartData {
             invRepository::executeStoredProcForLdfVacPreventDiseasesDatamart,
             cases,
             this::checkResult);
-        incrementIf(ppDmSuccess, batchId == null);
+        incrementIf(ppDmSuccess, !state.isRetry);
       } catch (Exception e) {
-        incrementIf(ppDmFailure, batchId == null);
+        incrementIf(ppDmFailure, !state.isRetry);
         String ldfType = LDF_VACCINE_PREVENT_DISEASES.getEntityName();
         String dmKey = "LDF," + ldfType;
 
         logger.error(errorMessage(ldfType, cases, new Exception(e.getClass().getSimpleName())));
-        buildRetryCache(
-            batchId, dmKey, Collections.singletonMap(INVESTIGATION.getEntityName(), ldfUids), e);
-        failed = true;
+        state.registerFailure(
+            dmKey, Collections.singletonMap(INVESTIGATION.getEntityName(), ldfUids), e);
       }
     }
-    return failed;
   }
 
   private void processLdfLegacy(String ldfType, String cases) {
@@ -465,72 +458,65 @@ public class ProcessDatamartData {
    *
    * @param dmMulti
    */
-  private boolean processMultiIdDatamart(
-      Long batchId, Map<String, List<Long>> dmMulti, boolean failed) {
-    if (failed) {
-      updateRetryCache(batchId, MULTI_ID_DATAMART, dmMulti);
-    } else {
-      String invString = listToParameterString(dmMulti.get(INVESTIGATION.getEntityName()));
-      String obsString = listToParameterString(dmMulti.get(OBSERVATION.getEntityName()));
-      String notifString = listToParameterString(dmMulti.get(NOTIFICATION.getEntityName()));
-      String patString = listToParameterString(dmMulti.get(PATIENT.getEntityName()));
-      String provString = listToParameterString(dmMulti.get(PROVIDER.getEntityName()));
-      String orgString = listToParameterString(dmMulti.get(ORGANIZATION.getEntityName()));
+  private void processMultiIdDatamart(BatchProcessingState state, Map<String, List<Long>> dmMulti) {
+    String invString = listToParameterString(dmMulti.get(INVESTIGATION.getEntityName()));
+    String obsString = listToParameterString(dmMulti.get(OBSERVATION.getEntityName()));
+    String notifString = listToParameterString(dmMulti.get(NOTIFICATION.getEntityName()));
+    String patString = listToParameterString(dmMulti.get(PATIENT.getEntityName()));
+    String provString = listToParameterString(dmMulti.get(PROVIDER.getEntityName()));
+    String orgString = listToParameterString(dmMulti.get(ORGANIZATION.getEntityName()));
 
-      int totalLengthInvSummary = invString.length() + notifString.length() + obsString.length();
-      int totalLengthMorbReportDM =
-          obsString.length()
-              + patString.length()
-              + provString.length()
-              + orgString.length()
-              + invString.length();
+    int totalLengthInvSummary = invString.length() + notifString.length() + obsString.length();
+    int totalLengthMorbReportDM =
+        obsString.length()
+            + patString.length()
+            + provString.length()
+            + orgString.length()
+            + invString.length();
 
-      try {
-        if (totalLengthInvSummary > 0) {
-          // reusing the same DTO class for Dynamic Marts
-          logger.info(
-              "Executing stored proc: sp_inv_summary_datamart_postprocessing '{}', '{}', '{}'",
-              invString,
-              notifString,
-              obsString);
-          List<DatamartData> dmDataList =
-              procRepository.executeStoredProcForInvSummaryDatamart(
-                  invString, notifString, obsString);
-          logExecutionCompleted("sp_inv_summary_datamart_postprocessing");
-          processDynDatamart(dmDataList, batchId);
-          incrementIf(ppDmSuccess, batchId == null);
-        } else {
-          logger.info("No updates to INV_SUMMARY Datamart");
-        }
-
-        if (totalLengthMorbReportDM > 0) {
-          logger.info(
-              "Executing stored proc: sp_morbidity_report_datamart_postprocessing '{}', '{}', '{}', '{}', '{}'",
-              obsString,
-              patString,
-              provString,
-              orgString,
-              invString);
-          procRepository.executeStoredProcForMorbidityReportDatamart(
-              obsString, patString, provString, orgString, invString);
-          logExecutionCompleted("sp_morbidity_report_datamart_postprocessing");
-          incrementIf(ppDmSuccess, batchId == null);
-        } else {
-          logger.info("No updates to MORBIDITY_REPORT_DATAMART");
-        }
-      } catch (Exception e) {
-        incrementIf(ppDmFailure, batchId == null);
-        logger.error(
-            errorMessage(
-                MULTI_ID_DATAMART, invString, new Exception(e.getClass().getSimpleName())));
-        buildRetryCache(batchId, MULTI_ID_DATAMART, dmMulti, e);
-        failed = true;
+    try {
+      if (totalLengthInvSummary > 0) {
+        // reusing the same DTO class for Dynamic Marts
+        logger.info(
+            "Executing stored proc: sp_inv_summary_datamart_postprocessing '{}', '{}', '{}'",
+            invString,
+            notifString,
+            obsString);
+        List<DatamartData> dmDataList =
+            procRepository.executeStoredProcForInvSummaryDatamart(
+                invString, notifString, obsString);
+        logExecutionCompleted("sp_inv_summary_datamart_postprocessing");
+        processDynDatamart(state, dmDataList);
+        incrementIf(ppDmSuccess, !state.isRetry);
+      } else {
+        logger.info("No updates to INV_SUMMARY Datamart");
       }
+
+      if (totalLengthMorbReportDM > 0) {
+        logger.info(
+            "Executing stored proc: sp_morbidity_report_datamart_postprocessing '{}', '{}', '{}',"
+                + " '{}', '{}'",
+            obsString,
+            patString,
+            provString,
+            orgString,
+            invString);
+        procRepository.executeStoredProcForMorbidityReportDatamart(
+            obsString, patString, provString, orgString, invString);
+        logExecutionCompleted("sp_morbidity_report_datamart_postprocessing");
+        incrementIf(ppDmSuccess, !state.isRetry);
+      } else {
+        logger.info("No updates to MORBIDITY_REPORT_DATAMART");
+      }
+    } catch (Exception e) {
+      incrementIf(ppDmFailure, !state.isRetry);
+      logger.error(
+          errorMessage(MULTI_ID_DATAMART, invString, new Exception(e.getClass().getSimpleName())));
+      state.registerFailure(MULTI_ID_DATAMART, dmMulti, e);
     }
-    return failed;
   }
 
-  private void processDynDatamart(List<DatamartData> dmDataList, Long batchId) {
+  private void processDynDatamart(BatchProcessingState state, List<DatamartData> dmDataList) {
     if (!dmDataList.isEmpty()) {
       Map<String, String> datamartPhcIdMap =
           dmDataList.stream()
@@ -541,19 +527,38 @@ public class ProcessDatamartData {
                           dmData -> String.valueOf(dmData.getPublicHealthCaseUid()),
                           Collectors.joining(","))));
 
+      List<CompletableFuture<Void>> futures = new ArrayList<>();
       datamartPhcIdMap.forEach(
           (datamart, phcIds) ->
-              CompletableFuture.runAsync(
-                  () -> {
-                    logger.info(
-                        "Executing stored proc: sp_dyn_datamart_postprocessing '{}', '{}'",
-                        datamart,
-                        phcIds);
-                    procRepository.executeStoredProcForDynDatamart(datamart, phcIds);
-                    logExecutionCompleted("sp_dyn_datamart_postprocessing");
-                    incrementIf(ppDmSuccess, batchId == null);
-                  },
-                  dynDmExecutor));
+              futures.add(
+                  CompletableFuture.runAsync(
+                      () -> {
+                        logger.info(
+                            "Executing stored proc: sp_dyn_datamart_postprocessing '{}', '{}'",
+                            datamart,
+                            phcIds);
+                        try {
+                          procRepository.executeStoredProcForDynDatamart(datamart, phcIds);
+                          logExecutionCompleted("sp_dyn_datamart_postprocessing");
+                          incrementIf(ppDmSuccess, !state.isRetry);
+                        } catch (Exception e) {
+                          incrementIf(ppDmFailure, !state.isRetry);
+                          logger.error("Error processing dynamic datamart: {}", datamart, e);
+                          state.registerFailure(
+                              datamart,
+                              Collections.singletonMap(
+                                  INVESTIGATION.getEntityName(),
+                                  Arrays.stream(phcIds.split(","))
+                                      .map(String::trim)
+                                      .map(Long::parseLong)
+                                      .collect(Collectors.toList())),
+                              e);
+                        }
+                      },
+                      dynDmExecutor)));
+
+      // Wait for all async tasks to complete before returning
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
   }
 
@@ -574,7 +579,8 @@ public class ProcessDatamartData {
     if (totalLengthEventMetric > 0) {
       Timer.Sample sample = metrics.startSample();
       logger.info(
-          "Executing stored proc: sp_event_metric_datamart_postprocessing '{}', '{}', '{}', '{}', '{}'",
+          "Executing stored proc: sp_event_metric_datamart_postprocessing '{}', '{}', '{}', '{}',"
+              + " '{}'",
           invString,
           obsString,
           notifString,
@@ -658,6 +664,24 @@ public class ProcessDatamartData {
     }
   }
 
+  protected long nextBatchId(Long batchId, Exception e) {
+    if (batchId == null) {
+      batchId = (System.currentTimeMillis() << 10) | INSTANCE_ID;
+      retryAttempts.put(batchId, 0);
+    } else {
+      retryAttempts.merge(batchId, 1, Integer::sum);
+    }
+
+    Throwable cause = e;
+    while (cause.getCause() != null) {
+      cause = cause.getCause(); // unwrap nested exceptions
+    }
+    String errorMsg = cause.getMessage();
+    errorMap.put(batchId, errorMsg);
+
+    return batchId;
+  }
+
   /**
    * Persists failed entities for backfill processing into the database.
    *
@@ -731,68 +755,21 @@ public class ProcessDatamartData {
     return false;
   }
 
-  private Long buildRetryCache(
-      Long batchId, String dmKey, Map<String, List<Long>> idMap, Exception e) {
-
-    // skip retrying for non-positive value
-    if (maxRetries <= 0) {
-      return null;
-    }
-
-    batchId = getBatchId(batchId, e);
-    updateRetryCache(batchId, dmKey, idMap);
-
-    return batchId;
-  }
-
-  protected Long getBatchId(Long batchId, Exception e) {
-    if (batchId == null) {
-      batchId = (System.currentTimeMillis() << 10) | INSTANCE_ID;
-      retryAttempts.put(batchId, 0);
-    } else {
-      retryAttempts.merge(batchId, 1, Integer::sum);
-    }
-
-    Throwable cause = e;
-    while (cause.getCause() != null) {
-      cause = cause.getCause(); // unwrap nested exceptions
-    }
-    String errorMsg = cause.getMessage();
-    errorMap.put(batchId, errorMsg);
-
-    return batchId;
-  }
-
   void updateRetryCache(Long batchId, BackfillData bfd) {
+    backfillAttempts.put(batchId, bfd.getRetryCount());
+    retryAttempts.put(batchId, bfd.getRetryCount());
+    errorMap.put(batchId, bfd.getErrDescription());
 
     String dmKey = bfd.getEntity().substring("DM^".length());
-
-    // Parse recordUidList into a map
-    String recordUidList = bfd.getRecordUidList();
     Map<String, List<Long>> idMap =
-        Arrays.stream(recordUidList.split("\\s+"))
+        Arrays.stream(bfd.getRecordUidList().split("\\s+"))
             .map(token -> token.split(":", 2))
             .collect(
                 Collectors.toMap(
                     parts -> parts[0],
                     parts -> Arrays.stream(parts[1].split(",")).map(Long::valueOf).toList()));
-    backfillAttempts.put(batchId, bfd.getRetryCount());
-    retryAttempts.put(batchId, bfd.getRetryCount());
-    errorMap.put(batchId, bfd.getErrDescription());
-
-    updateRetryCache(batchId, dmKey, idMap);
-  }
-
-  private void updateRetryCache(Long batchId, String dmKey, Map<String, List<Long>> idMap) {
-    if (batchId != null) {
-      Map<String, Queue<Long>> dmMap =
-          retryCache
-              .computeIfAbsent(batchId, k -> new ConcurrentHashMap<>())
-              .computeIfAbsent(dmKey, k -> new ConcurrentHashMap<>());
-      idMap.forEach(
-          (key, value) ->
-              dmMap.computeIfAbsent(key, k -> new ConcurrentLinkedQueue<>()).addAll(value));
-    }
+    BatchProcessingState state = new BatchProcessingState(batchId);
+    state.updateRetryCache(dmKey, idMap);
   }
 
   private <T> void executeDmProc(
@@ -853,6 +830,76 @@ public class ProcessDatamartData {
       if ("Error".equals(dme.getDatamart())) {
         throw new DataProcessingException(dme.getStoredProcedure());
       }
+    }
+  }
+
+  private class BatchProcessingState {
+    // final because this never changes after initialization
+    final boolean isRetry;
+
+    // volatile ensures threads reading these outside the sync block see the latest values
+    // immediately
+    private volatile Long batchId;
+    private volatile boolean failed = false;
+
+    // No volatile needed; only accessed inside the synchronized block
+    private boolean retryCountIncremented = false;
+
+    BatchProcessingState(Long batchId) {
+      this.batchId = batchId;
+      this.isRetry = (batchId != null);
+    }
+
+    // synchronized ensures only one thread can evaluate and update the state at a time
+    synchronized void registerFailure(String dmKey, Map<String, List<Long>> idMap, Exception e) {
+      this.failed = true;
+
+      if (this.batchId == null) {
+        // The first thread to fail gets here, generates the ID, and locks it in for the rest
+        this.buildRetryCache(dmKey, idMap, e);
+        this.retryCountIncremented = true;
+      } else {
+        if (this.isRetry && !this.retryCountIncremented) {
+          this.buildRetryCache(dmKey, idMap, e);
+          this.retryCountIncremented = true;
+        } else {
+          // Subsequent threads see the initialized batchId and safely append to it
+          this.updateRetryCache(dmKey, idMap);
+
+          Throwable cause = e;
+          while (cause.getCause() != null) {
+            cause = cause.getCause();
+          }
+          // errorMap is a ConcurrentHashMap, so this is safe
+          errorMap.put(this.batchId, cause.getMessage());
+        }
+      }
+    }
+
+    private void buildRetryCache(String dmKey, Map<String, List<Long>> idMap, Exception e) {
+      // skip retrying for non-positive value
+      if (maxRetries > 0) {
+        this.batchId = nextBatchId(this.batchId, e);
+        this.updateRetryCache(dmKey, idMap);
+      }
+    }
+
+    private void updateRetryCache(String dmKey, Map<String, List<Long>> idMap) {
+      Map<String, Queue<Long>> dmMap =
+          retryCache
+              .computeIfAbsent(batchId, k -> new ConcurrentHashMap<>())
+              .computeIfAbsent(dmKey, k -> new ConcurrentHashMap<>());
+      idMap.forEach(
+          (key, value) ->
+              dmMap.computeIfAbsent(key, k -> new ConcurrentLinkedQueue<>()).addAll(value));
+    }
+
+    public boolean hasFailed() {
+      return failed;
+    }
+
+    public Long getBatchId() {
+      return batchId;
     }
   }
 }

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
@@ -85,13 +85,26 @@ class PostProcessingServiceRetryTest {
     String invTopic = "dummy_investigation";
     String invKey = "{\"payload\":{\"public_health_case_uid\":234}}";
     String invMsg =
-        "{\"payload\":{\"public_health_case_uid\":234,"
-            + " \"rdb_table_name_list\":\"D_INV_CLINICAL,D_INV_ADMINISTRATIVE\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 234,
+            "rdb_table_name_list": "D_INV_CLINICAL,D_INV_ADMINISTRATIVE"
+          }
+        }
+        """;
     String obsTopic = "dummy_observation";
     String obsKey = "{\"payload\":{\"observation_uid\":567}}";
     String obsMsg =
-        "{\"payload\":{\"observation_uid\":567, \"obs_domain_cd_st_1\":"
-            + " \"Order\",\"ctrl_cd_display_form\": \"LabReport\"}}";
+        """
+        {
+          "payload": {
+            "observation_uid": 567,
+            "obs_domain_cd_st_1": "Order",
+            "ctrl_cd_display_form": "LabReport"
+          }
+        }
+        """;
 
     String patientUid = "123";
 
@@ -183,8 +196,17 @@ class PostProcessingServiceRetryTest {
     verify(postProcRepositoryMock, never()).executeBackfillEvent(anyString());
 
     String genDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\","
-            + "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "12020",
+            "datamart": "Generic_Case",
+            "stored_procedure": "sp_generic_case_datamart_postprocessing"
+          }
+        }
+        """;
 
     datamartProcessor.setMaxRetries(-1);
     when(investigationRepositoryMock.executeStoredProcForGenericCaseDatamart(anyString()))
@@ -215,11 +237,29 @@ class PostProcessingServiceRetryTest {
 
     String topic = "dummy_datamart";
     String hepDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\","
-            + "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "10110",
+            "datamart": "Hepatitis_Datamart",
+            "stored_procedure": "sp_hepatitis_datamart_postprocessing"
+          }
+        }
+        """;
     String genDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\","
-            + "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "12020",
+            "datamart": "Generic_Case",
+            "stored_procedure": "sp_generic_case_datamart_postprocessing"
+          }
+        }
+        """;
 
     String phcUid = "123";
 
@@ -285,11 +325,29 @@ class PostProcessingServiceRetryTest {
   void testProcessIndependentProcessingOnFailure() {
     String topic = "dummy_datamart";
     String hepDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\","
-            + "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "10110",
+            "datamart": "Hepatitis_Datamart",
+            "stored_procedure": "sp_hepatitis_datamart_postprocessing"
+          }
+        }
+        """;
     String genDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\","
-            + "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "12020",
+            "datamart": "Generic_Case",
+            "stored_procedure": "sp_generic_case_datamart_postprocessing"
+          }
+        }
+        """;
 
     when(investigationRepositoryMock.executeStoredProcForHepDatamart(anyString()))
         .thenThrow(new RuntimeException(errorMsg));
@@ -360,11 +418,29 @@ class PostProcessingServiceRetryTest {
   void testProcessRetryDatamartSuccess() {
     String topic = "dummy_datamart";
     String hepDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\","
-            + "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "10110",
+            "datamart": "Hepatitis_Datamart",
+            "stored_procedure": "sp_hepatitis_datamart_postprocessing"
+          }
+        }
+        """;
     String genDmMsg =
-        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\","
-            + "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+        """
+        {
+          "payload": {
+            "public_health_case_uid": 123,
+            "patient_uid": 456,
+            "condition_cd": "12020",
+            "datamart": "Generic_Case",
+            "stored_procedure": "sp_generic_case_datamart_postprocessing"
+          }
+        }
+        """;
 
     String phcUid = "123";
     when(investigationRepositoryMock.executeStoredProcForHepDatamart(phcUid))

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
@@ -85,11 +85,13 @@ class PostProcessingServiceRetryTest {
     String invTopic = "dummy_investigation";
     String invKey = "{\"payload\":{\"public_health_case_uid\":234}}";
     String invMsg =
-        "{\"payload\":{\"public_health_case_uid\":234, \"rdb_table_name_list\":\"D_INV_CLINICAL,D_INV_ADMINISTRATIVE\"}}";
+        "{\"payload\":{\"public_health_case_uid\":234,"
+            + " \"rdb_table_name_list\":\"D_INV_CLINICAL,D_INV_ADMINISTRATIVE\"}}";
     String obsTopic = "dummy_observation";
     String obsKey = "{\"payload\":{\"observation_uid\":567}}";
     String obsMsg =
-        "{\"payload\":{\"observation_uid\":567, \"obs_domain_cd_st_1\": \"Order\",\"ctrl_cd_display_form\": \"LabReport\"}}";
+        "{\"payload\":{\"observation_uid\":567, \"obs_domain_cd_st_1\":"
+            + " \"Order\",\"ctrl_cd_display_form\": \"LabReport\"}}";
 
     String patientUid = "123";
 
@@ -233,8 +235,13 @@ class PostProcessingServiceRetryTest {
 
     Long batchId = datamartProcessor.retryCache.entrySet().iterator().next().getKey();
     assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
-    assertEquals(3, datamartProcessor.retryCache.get(batchId).size());
-    assertTrue(datamartProcessor.retryCache.get(batchId).containsKey(MULTI_ID_DATAMART));
+    assertEquals(1, datamartProcessor.retryCache.get(batchId).size());
+    assertFalse(datamartProcessor.retryCache.get(batchId).containsKey(MULTI_ID_DATAMART));
+    assertTrue(
+        datamartProcessor
+            .retryCache
+            .get(batchId)
+            .containsKey(Entity.HEPATITIS_DATAMART.getEntityName()));
 
     String dmEntity = "DM^" + Entity.HEPATITIS_DATAMART.getEntityName();
     datamartProcessor.processRetryCache();

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
@@ -282,6 +282,28 @@ class PostProcessingServiceRetryTest {
   }
 
   @Test
+  void testProcessIndependentProcessingOnFailure() {
+    String topic = "dummy_datamart";
+    String hepDmMsg =
+        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"10110\","
+            + "\"datamart\":\"Hepatitis_Datamart\",\"stored_procedure\":\"sp_hepatitis_datamart_postprocessing\"}}";
+    String genDmMsg =
+        "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456,\"condition_cd\":\"12020\","
+            + "\"datamart\":\"Generic_Case\",\"stored_procedure\":\"sp_generic_case_datamart_postprocessing\"}}";
+
+    when(investigationRepositoryMock.executeStoredProcForHepDatamart(anyString()))
+        .thenThrow(new RuntimeException(errorMsg));
+
+    postProcessingServiceMock.processDmMessage(topic, hepDmMsg);
+    postProcessingServiceMock.processDmMessage(topic, genDmMsg);
+    postProcessingServiceMock.processDatamartIds();
+
+    // Verify Hepatitis failed but Generic_Case was processed anyway
+    verify(investigationRepositoryMock).executeStoredProcForHepDatamart(anyString());
+    verify(investigationRepositoryMock).executeStoredProcForGenericCaseDatamart(anyString());
+  }
+
+  @Test
   void testProcessRetryMultiId() {
     String investigationKey = "{\"payload\":{\"public_health_case_uid\":123}}";
     String notificationKey = "{\"payload\":{\"notification_uid\":124}}";
@@ -304,6 +326,34 @@ class PostProcessingServiceRetryTest {
     Long batchId = datamartProcessor.retryCache.entrySet().iterator().next().getKey();
     assertEquals(errorMsg, datamartProcessor.errorMap.get(batchId));
     assertTrue(datamartProcessor.retryCache.get(batchId).containsKey(MULTI_ID_DATAMART));
+  }
+
+  @Test
+  void testProcessRetryDynamicDatamart() {
+    String investigationKey = "{\"payload\":{\"public_health_case_uid\":123}}";
+    String invTopic = "dummy_investigation";
+    postProcessingServiceMock.processNrtMessage(invTopic, investigationKey, investigationKey);
+    postProcessingServiceMock.processCachedIds();
+
+    // Setup: Simulate dynamic datamart failure
+    List<DatamartData> dmDataList = new ArrayList<>();
+    DatamartData dd = new DatamartData();
+    dd.setDatamart("DYN_DM");
+    dd.setPublicHealthCaseUid(123L);
+    dmDataList.add(dd);
+
+    when(postProcRepositoryMock.executeStoredProcForInvSummaryDatamart(any(), any(), any()))
+        .thenReturn(dmDataList);
+    doThrow(new RuntimeException(errorMsg))
+        .when(postProcRepositoryMock)
+        .executeStoredProcForDynDatamart("DYN_DM", "123");
+
+    postProcessingServiceMock.processDatamartIds();
+
+    // The failure should be caught and enqueued for retry
+    assertFalse(datamartProcessor.retryCache.isEmpty());
+    assertTrue(
+        datamartProcessor.retryCache.values().stream().anyMatch(dm -> dm.containsKey("DYN_DM")));
   }
 
   @Test


### PR DESCRIPTION
## Description
 - This pull request refactors the Datamart post-processing orchestrator in ProcessDatamartData.java to enable independent processing for Dynamic Data Marts (DDMs). This change prevents a single DDM failure from short-circuiting and incorrectly enqueuing the remaining successful DDMs in the same batch for unnecessary retries.
 - Previously, the orchestrator aborted processing for an entire batch upon encountering the first DDM failure, forcing surviving DDMs into a retry cache and delaying data freshness by an entire cycle. By removing the global short-circuit flag and introducing a BatchProcessingState helper, each DDM is now processed independently, even if previous ones fail. The processLdfVaccinePreventDm and processMultiIdDatamart methods were also updated to run independently with proper error registration. Additionally, processDynDatamart was made synchronous to resolve race conditions identified during functional test verification. These changes significantly improve pipeline resilience and data freshness without sacrificing reliability.

## Related Issues
- [APP-615](https://cdc-nbs.atlassian.net/browse/APP-615)

## Additional Notes
 - The goal of this change is to improve overall data freshness by ensuring that a single failing datamart does not block the processing of other healthy datamarts in the same batch.
 - Key technical details:
     - Removed the global failure short-circuit logic in processDmCache.
     - Introduced BatchProcessingState as a helper to track batchId, failure state, and retry count increments within a processing loop.
     - Updated asynchronous processing in processDynDatamart to block until completion, ensuring data availability for tests.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.