### PR TITLE
address unused redundant deps

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -91,16 +91,12 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka:3.3.1'
     implementation 'org.apache.kafka:kafka-clients:3.9.2'
-    implementation 'org.apache.kafka:connect-api:3.9.1'
 
     // Persistence & Database
-    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     implementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
 
     // Logging
     compileOnly 'org.slf4j:slf4j-api'
-    implementation 'ch.qos.logback:logback-classic:1.5.32'
-    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
     // Metrics & Monitoring
     implementation 'io.micrometer:micrometer-core'

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // Kafka
-    implementation 'org.springframework.kafka:spring-kafka:3.3.1'
+    implementation 'org.springframework.kafka:spring-kafka:3.3.15'
     implementation 'org.apache.kafka:kafka-clients:3.9.2'
 
     // Persistence & Database


### PR DESCRIPTION
## Description
 - This pull request performs dependency cleanup and updates for the reporting-pipeline-service.
 - Specifically, it upgrades the `spring-kafka` dependency to version 3.3.15 and removes several unused dependencies to streamline the build and reduce potential conflicts.
 - These changes ensure the service is utilizing current, necessary dependencies, improving overall maintainability and build efficiency.

## Additional Notes
 - Removed unused `connect-api` and `logstash-logback-encoder` dependencies.
 - Removed redundant `jakarta.persistence-api` and `logback-classic`.
 - Updated `spring-kafka` from 3.3.1 to 3.3.15.

## Checklist
 - [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
 - [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
 - [x] I have updated the documentation, if applicable.
 - [x] I have added or updated test cases to cover my changes, if applicable.
