### PR TITLE
Cross platform solution to setting sas PATH

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - sas_user_pass=n3dss4dm1n
       - sas_encoding=latin1
       - ADDITIONAL_SAS_FLAGS=-DEBUG
-      - PATH=$PATH:/opt/mssql-tools18/bin
+      - PATH=/home/SAS/.local/bin:/home/SAS/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/mssql-tools18/bin
     depends_on:
       nbs-mssql:
         condition: service_healthy


### PR DESCRIPTION
## Description
As a Windows user, when I spun up the sas container it died with the logs saying:
```
sas-1 | Updating User SAS password
sas-1 | ./1_runtime.sh: line 7: passwd: command not found
sas-1 | Switching to User SAS
sas-1 | ./1_runtime.sh: line 12: su: command not found
sas-1 exited with code 127
```

My short-term solution was to comment-out the `PATH=` line in `docker-compose.yaml` and then once the container was up, login and set the path. This is a more automatic solution.

## Related Issue
N/A

## Additional Notes
Verified the existing PATH, then added to it
```bash
[SAS@391f056bc22c ~]$ echo $PATH
/home/SAS/.local/bin:/home/SAS/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~I have updated the documentation, if applicable.~
- [ ] ~I have added or updated test cases to cover my changes, if applicable.~
 
