### PR TITLE
Remove datatype-jsr310 dependency

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -106,7 +106,6 @@ dependencies {
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     // Serialization & Mapping
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0'
     implementation 'org.modelmapper:modelmapper:3.2.0'
 
     // Utilities


### PR DESCRIPTION
## Description
Removes the redundant `datatype-jsr310` dependency. This is already bundled in the `spring-boot-starter-web` dependency. 

`./gradlew clean reporting-pipeline-service:dependencies` before removal:

```
+--- org.springframework.boot:spring-boot-starter-web -> 3.5.14
|    +--- org.springframework.boot:spring-boot-starter:3.5.14 (*)
|    +--- org.springframework.boot:spring-boot-starter-json:3.5.14
|    |    +--- org.springframework.boot:spring-boot-starter:3.5.14 (*)
|    |    +--- org.springframework:spring-web:6.2.18
|    |    |    +--- org.springframework:spring-beans:6.2.18 (*)
|    |    |    +--- org.springframework:spring-core:6.2.18 (*)
|    |    |    \--- io.micrometer:micrometer-observation:1.15.11 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.21.2
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.2
|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.21.2
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.2 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.21.2 (c)
|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.2 (c)
|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2 -> 2.17.0 (c)
... other stuff...
+--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0 (*)
```

After removal

```
+--- org.springframework.boot:spring-boot-starter-web -> 3.5.14
|    +--- org.springframework.boot:spring-boot-starter:3.5.14 (*)
|    +--- org.springframework.boot:spring-boot-starter-json:3.5.14
|    |    +--- org.springframework.boot:spring-boot-starter:3.5.14 (*)
|    |    +--- org.springframework:spring-web:6.2.18
|    |    |    +--- org.springframework:spring-beans:6.2.18 (*)
|    |    |    +--- org.springframework:spring-core:6.2.18 (*)
|    |    |    \--- io.micrometer:micrometer-observation:1.15.11 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.21.2 (*)
|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.2
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.2 (*)
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.21.2 (*)
|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.21.2 (*)
|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2 (*)
```

Note that the dependency is still present but no longer locked to the `2.17.0` version.

## Additional Notes
It appears that this was added to the `reporting-pipeline-service` as part of the investigation service consolidation: https://github.com/CDCgov/NEDSS-DataReporting/commit/908d38678bf254a402a1a1436bfe4e9f9f0622c6#diff-d73f96626b9d06663cc7e2e6ecd9781accdc86a297c71108af10488bf2b76bf6R64

I did not dig into why this was specified in the Investigation service.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
