### PR TITLE
GitGuardian initial set-up

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,8 @@
+# See https://docs.gitguardian.com/ggshield-docs/configuration
+
+# Required, otherwise ggshield considers the file to use the deprecated v1 format
+version: 2
+
+secret:
+  ignored_paths:
+    - 'env.sample'

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -6,3 +6,6 @@ version: 2
 secret:
   ignored_paths:
     - 'env.sample'
+  ignored_matches:
+    - name: 'local dev password in samples'
+      match: 'PizzaIsGood33!'


### PR DESCRIPTION
## Description
GitGuardian alerted about a "Generic Password exposed within your GitHub account" but it was the local dev password in the `env.sample` file. We're going to ignore this file, and ignore instances of this password.

## Related Issue
N/A

## Additional Notes
See https://docs.gitguardian.com/ggshield-docs/configuration

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
