### PR TITLE
[CVE-2026-41731] bump spring-kafka to 3.3.16

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // Kafka
-    implementation 'org.springframework.kafka:spring-kafka:3.3.15'
+    implementation 'org.springframework.kafka:spring-kafka:3.3.16'
     implementation 'org.apache.kafka:kafka-clients:3.9.2'
 
     // Persistence & Database


### PR DESCRIPTION
## Description
Update spring-kafka dependency from version 3.3.15 to 3.3.16 to address CVE-2026-41731.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
