### PR TITLE
add default row for some dimension tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,4 @@ published through the [CDC web site](http://www.cdc.gov).
 ## Additional Standard Notices
 
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template) for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/main/CONTRIBUTING.md), [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/main/DISCLAIMER.md), and [code of conduct](https://github.com/CDCgov/template/blob/main/code-of-conduct.md).
+

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/onboarding/003-unknown_member_seeds-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/onboarding/003-unknown_member_seeds-001.sql
@@ -1,0 +1,75 @@
+-- ---------------------------------------------------------------------------
+-- Add default rows for certain dimension tables.
+-- ---------------------------------------------------------------------------
+--
+-- Several RTR stored procedures fall back to a key=1 surrogate when a fact
+-- row cannot be matched to a real dimension row -- e.g.
+--   COALESCE(D_PATIENT.PATIENT_KEY, 1) AS PATIENT_KEY
+--   COALESCE(CONDITION.CONDITION_KEY, 1) AS CONDITION_KEY
+--
+-- The legacy MasterETL pipeline adds a key=1 row in each of
+-- these dimensions via its SAS %assign_key macro, so the fallback resolves
+-- to an existing row. RTR's create scripts (006-, 008-, 013-create_nrt_*)
+-- *reserve* the IDENTITY slot at 1 by reseeding to MAX(*_KEY)+1, but they
+-- do not INSERT a row at key=1. In a production migration to RTR the
+-- MasterETL-populated RDB should already have these default rows.
+-- However, in development or greenfield install no seed exists, and any
+-- COALESCE(*, 1) fallback writes an FK pointing to a row that does not
+-- exist -- a latent dangling-reference bug.
+--
+-- This script defensively INSERTs (KEY = 1, other columns NULL) for selected tables,
+-- to avoid future problems due to the default row being missing.
+-- The tables selected are those which seem most likely to cause problems
+-- due frequent use of COALESCE(...,1).
+-- Further tables can be added to this list if needed.
+-- The script is idempotent and therefore safe to re-run.
+-- ---------------------------------------------------------------------------
+
+
+-- D_PROVIDER
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_PROVIDER' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.D_PROVIDER WHERE PROVIDER_KEY = 1)
+BEGIN
+    INSERT INTO dbo.D_PROVIDER (PROVIDER_KEY) VALUES (1);
+END
+GO
+
+-- D_ORGANIZATION
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_ORGANIZATION' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.D_ORGANIZATION WHERE ORGANIZATION_KEY = 1)
+BEGIN
+    INSERT INTO dbo.D_ORGANIZATION (ORGANIZATION_KEY) VALUES (1);
+END
+GO
+
+-- D_PATIENT
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'D_PATIENT' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.D_PATIENT WHERE PATIENT_KEY = 1)
+BEGIN
+    INSERT INTO dbo.D_PATIENT (PATIENT_KEY) VALUES (1);
+END
+GO
+
+-- CONDITION
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'CONDITION' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.CONDITION WHERE CONDITION_KEY = 1)
+BEGIN
+    INSERT INTO dbo.CONDITION (CONDITION_KEY) VALUES (1);
+END
+GO
+
+-- NOTIFICATION
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'NOTIFICATION' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.NOTIFICATION WHERE NOTIFICATION_KEY = 1)
+BEGIN
+    INSERT INTO dbo.NOTIFICATION (NOTIFICATION_KEY) VALUES (1);
+END
+GO
+
+-- GEOCODING_LOCATION
+IF EXISTS (SELECT 1 FROM sysobjects WHERE name = 'GEOCODING_LOCATION' AND xtype = 'U')
+   AND NOT EXISTS (SELECT 1 FROM dbo.GEOCODING_LOCATION WHERE GEOCODING_LOCATION_KEY = 1)
+BEGIN
+    INSERT INTO dbo.GEOCODING_LOCATION (GEOCODING_LOCATION_KEY) VALUES (1);
+END
+GO

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/rdb.changelog-17.3.yaml
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/rdb.changelog-17.3.yaml
@@ -3232,6 +3232,16 @@ databaseChangeLog:
             splitStatements: true
             endDelimiter: GO
   - changeSet:
+      id: onboarding-unknown-member-seeds
+      author: liquibase
+      runOnChange: true
+      runInTransaction: false
+      changes:
+        - sqlFile:
+            path: db/changelog/migrations/v17.3/rdb/onboarding/003-unknown_member_seeds-001.sql
+            splitStatements: true
+            endDelimiter: GO
+  - changeSet:
       id: onboarding-indexes
       author: liquibase
       runOnChange: true


### PR DESCRIPTION
## Description
As a defensive measure, adds the default row (key=1, otherwise NULL) to some dimension tables. 
This was motivated when noticing that NOTIFICATION was missing the default row in RDB_MODERN,
although MasterEtl generates it in RDB. This pr adds the default row (if not present) for
some other tables too based on the prevalance of COALESCE(.., 1) to those tables.

## Related Issue
[APP-712](https://cdc-nbs.atlassian.net/browse/APP-712)

## Additional Notes
Additional notes and context if necessary

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
