### PR TITLE
Resolve RTR NULL values for LAB100 table

### DIFF
--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -476,8 +476,8 @@ BEGIN
 
         select
             * , coalesce(
-                TRY_CAST(substring(left(RTRIM(CAST(oid AS varchar(30))) + space(11), 11), 7, 5) as int),
-                TRY_CAST(substring(right(space(11) + RTRIM(CAST(oid AS varchar(30))), 11), 7, 5) as int)
+                TRY_CAST(NULLIF(LTRIM(RTRIM(substring(left(RTRIM(CAST(oid AS varchar(30))) + space(11), 11), 7, 5))), '') as int),
+                TRY_CAST(NULLIF(LTRIM(RTRIM(substring(right(space(11) + RTRIM(CAST(oid AS varchar(30))), 11), 7, 5))), '') as int)
             ) as PROGRAM_AREA_ID  -- Prefer current left-aligned behavior; fallback preserves SAS-style SUBSTR(PUT(OID,11.),7,5)
         into #TMP_LAB_RESULTS_ORDER_CONTACT1
         from #TMP_LABTEST_UPDATED

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -475,7 +475,10 @@ BEGIN
             drop table #TMP_LAB_RESULTS_ORDER_CONTACT1;
 
         select
-            * , substring(left(RTRIM(CAST(oid AS varchar)) + space(11), 11), 7, 5) as PROGRAM_AREA_ID  --VS =SUBSTR(PUT(OID,11.),7,5)
+            * , coalesce(
+                TRY_CAST(substring(left(RTRIM(CAST(oid AS varchar(30))) + space(11), 11), 7, 5) as int),
+                TRY_CAST(substring(right(space(11) + RTRIM(CAST(oid AS varchar(30))), 11), 7, 5) as int)
+            ) as PROGRAM_AREA_ID  -- Prefer current left-aligned behavior; fallback preserves SAS-style SUBSTR(PUT(OID,11.),7,5)
         into #TMP_LAB_RESULTS_ORDER_CONTACT1
         from #TMP_LABTEST_UPDATED
         ;
@@ -502,8 +505,8 @@ BEGIN
             tlroc1.*, pac.*
         into #TMP_LAB_RESULTS_ORDER_CONTACT2
         from #TMP_LAB_RESULTS_ORDER_CONTACT1 tlroc1
-                 left outer join dbo.nrt_srte_Program_area_code pac with(NOLOCK)
-                                 on left( pac.NBS_UID+ space(5), 5)  = cast(tlroc1.PROGRAM_AREA_ID as int)
+             left outer join dbo.nrt_srte_Program_area_code pac with(NOLOCK)
+                     on TRY_CAST(left(cast(pac.NBS_UID as varchar(30)) + space(5), 5) as int) = tlroc1.PROGRAM_AREA_ID
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
         INSERT INTO dbo.[JOB_FLOW_LOG]

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/019-sp_lab100_datamart_postprocessing-001.sql
@@ -475,7 +475,7 @@ BEGIN
             drop table #TMP_LAB_RESULTS_ORDER_CONTACT1;
 
         select
-            * , SUBSTRING(RIGHT(SPACE(11) + RTRIM(oid), 11), 7, 5) as PROGRAM_AREA_ID  --VS =SUBSTR(PUT(OID,11.),7,5)
+            * , substring(left(RTRIM(CAST(oid AS varchar)) + space(11), 11), 7, 5) as PROGRAM_AREA_ID  --VS =SUBSTR(PUT(OID,11.),7,5)
         into #TMP_LAB_RESULTS_ORDER_CONTACT1
         from #TMP_LABTEST_UPDATED
         ;


### PR DESCRIPTION
## Description
This change fixes LAB100 program area population in the modern pipeline so rows no longer get null or mismatched `PROGRAM_AREA_CD` / `PROGRAM_AREA_DESC`.

### What Changed

Updated `sp_lab100_datamart_postprocessing` to derive program area values more reliably. The process is as follows:

1. Converts `oid` to varchar(30) and trims right-side spaces.
2. Tries one parsing strategy where `oid` is left-aligned into an 11-character string.
3. Extracts characters 7 through 11 from that 11-character string.
4. Trims spaces.
5. Converts empty string to `NULL`.
6. Tries to cast the result to `int`.
7. If that fails or returns `NULL`, it tries a second parsing strategy where `oid` is right-aligned into an 11-character string.
8. Returns whichever parsed integer works first.

The purpose is probably to handle inconsistent `oid` formatting - sometimes padded/aligned differently - and safely pull out a numeric identifier from positions 7–11. `TRY_CAST` prevents the query from failing if that chunk is not numeric.

### Result

- LAB100 rows now populate program area fields consistently.
- Unit-test fixture flows are stable and aligned between RDB and RDB_MODERN behavior.

## Related Issue
[APP-739](https://cdc-nbs.atlassian.net/browse/APP-739)

## Additional Notes
Much of the work on this Jira ticket was done by updating the synthetic fixtures. I also verified the modern stored procedure against the legacy RDB logic so the resulting LAB100 data matches the expected source behavior:

```sql
-- RDB
SELECT [LAB_RPT_LOCAL_ID], [PROGRAM_AREA_CD], [PROGRAM_AREA_DESC], [RDB_LAST_REFRESH_TIME], [REPORTING_FACILITY_UID]
FROM [RDB].[dbo].[LAB100]
ORDER BY [LAB_RPT_LOCAL_ID]
;

-- RDB_MODERN
SELECT [LAB_RPT_LOCAL_ID], [PROGRAM_AREA_CD], [PROGRAM_AREA_DESC], [RDB_LAST_REFRESH_TIME], [REPORTING_FACILITY_UID]
FROM [RDB_MODERN].[dbo].[LAB100]
ORDER BY [LAB_RPT_LOCAL_ID]
;
```
<img width="772" height="377" alt="image" src="https://github.com/user-attachments/assets/57f12704-c785-414e-a13c-ad96a91e5a47" />

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.