### PR TITLE
update debezium/connect image to 2.7

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,7 +118,7 @@ services:
       start_period: 10s
 
   debezium:
-    image: debezium/connect:2.4
+    image: quay.io/debezium/connect:2.7
     depends_on:
       kafka:
         condition: service_healthy


### PR DESCRIPTION
## Description
Update the debezium/connect image from 2.4 to 2.7 and switch to the quay.io repository.  Our helm chart is currently using the 2.7 version, so it seemed reasonable to upgrade our dev/CI environments to match.

https://github.com/CDCgov/NEDSS-Helm/blob/main/charts/debezium/values.yaml#L8-L11

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
