### PR TITLE
APP-564 vulnerabilities

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -12,6 +12,11 @@ ext['tomcat.version'] = '10.1.55'
 // Override the Spring Boot managed Logback version to address GHSA-25qh-j22f-pwp8 and GHSA-qqpg-mvqg-649v
 ext['logback.version'] = '1.5.25'
 
+// Override the Spring Boot managed Commons Lang version to address CVE-2025-48924.
+// Liquibase 5.0.3 + its transitives (opencsv, commons-text) all request >= 3.18.0;
+// the Spring Boot 3.5.x BOM was downgrading them to 3.17.0.
+ext['commons-lang3.version'] = '3.20.0'
+
 group = 'gov.cdc.etldatapipeline'
 version = '0.0.1-SNAPSHOT'
 

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -9,6 +9,9 @@ plugins {
 // Override the Spring Boot managed Tomcat version to address security vulnerabilities
 ext['tomcat.version'] = '10.1.55'
 
+// Override the Spring Boot managed Logback version to address GHSA-25qh-j22f-pwp8 and GHSA-qqpg-mvqg-649v
+ext['logback.version'] = '1.5.25'
+
 group = 'gov.cdc.etldatapipeline'
 version = '0.0.1-SNAPSHOT'
 


### PR DESCRIPTION
## Description
This addresses CVE-2025-48924 found by Trivy (and Clair) by updating Apache Commons Lang to 3.20.0.
https://avd.aquasec.com/nvd/2025/cve-2025-48924/
https://harbor.skylightnbs.com/harbor/projects/2/repositories/nbs7-reporting-pipeline/artifacts-tab/artifacts/sha256:e8d531237adc5e13819b67a6012ec93b9079804d6336d29dbcb8c6a3ff19e954?sbomDigest=sha256:4b739bd4500d8b9316dcf4ec871e293925c7bdb2d4fc981e3a046ad155ad2fbd

This addresses https://github.com/advisories/GHSA-25qh-j22f-pwp8 and GHSA-qqpg-mvqg-649v
by updating logback to 1.5.25.
https://github.com/advisories/GHSA-25qh-j22f-pwp8
https://github.com/advisories/GHSA-qqpg-mvqg-649v



## Related Issue
[Jira Ticket](https://cdc-nbs.atlassian.net/browse/APP-564)

## Additional Notes
Additional notes and context if necessary

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
