### PR TITLE
Functional/Unit Test - command line test list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ To run only the `functional` tests in the reporting-pipeline-service
 ./gradlew clean reporting-pipeline-service:test-functional
 ```
 
+Specific `functional` tests can be executed using the `tests` argument
+```sh
+./gradlew clean reporting-pipeline-service:test-functional -D tests=elrEColi,interview
+```
+
 To run only _some_ of the `functional` tests in the reporting-pipeline-service, set `SELECTED_TEST_NAMES` in `reporting-pipeline-service\src\test\java\gov\cdc\nbs\report\pipeline\integration\functional\DataDrivenFunctionalTests.java`. Examples are in the code as a comment. If this list is empty, all functional tests will run.
 
 ### Adding MasterEtl-level Validation for Functional Tests

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ Specific `functional` tests can be executed using the `tests` argument
 ./gradlew clean reporting-pipeline-service:test-functional -D tests=elrEColi,interview
 ```
 
-To run only _some_ of the `functional` tests in the reporting-pipeline-service, set `SELECTED_TEST_NAMES` in `reporting-pipeline-service\src\test\java\gov\cdc\nbs\report\pipeline\integration\functional\DataDrivenFunctionalTests.java`. Examples are in the code as a comment. If this list is empty, all functional tests will run.
-
 ### Adding MasterEtl-level Validation for Functional Tests
 Review [FuncationTestValidation.md](./documentation/FunctionalTestValidation.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ To run only the `functional` tests in the reporting-pipeline-service
 ./gradlew clean reporting-pipeline-service:test-functional
 ```
 
-Specific `functional` tests can be executed using the `tests` argument
+Specific `functional` and `unit` tests can be executed using the `tests` argument
 ```sh
 ./gradlew clean reporting-pipeline-service:test-functional -D tests=elrEColi,interview
+./gradlew clean reporting-pipeline-service:test-unit -D tests=covidCaseDatamart
 ```
 
 ### Adding MasterEtl-level Validation for Functional Tests

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -47,7 +47,9 @@ tasks.register("test-functional", Test) {
 tasks.register("test-unit", Test) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
-
+    if (System.getProperty("tests") != null) {
+        systemProperty "tests", System.getProperty("tests")
+    }
     useJUnitPlatform {
         includeTags "Unit"
     }

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -34,6 +34,9 @@ test {
 tasks.register("test-functional", Test) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
+    if (System.getProperty("tests") != null) {
+        systemProperty "tests", System.getProperty("tests")
+    }
 
     useJUnitPlatform {
         includeTags "Functional"

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -33,18 +34,26 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 class DataDrivenFunctionalTests extends FunctionalTest {
 
   /**
-   * If empty, all functional test directories are executed.
+   * <p>
+   * Specific tests can be executed by manually adding the test name to the list below or by
+   * specifying the "tests" parameter. </p>
+   * 
+   * <p>If empty, all functional test directories are executed.</p>
    *
-   * <p>Examples:
+   * <p>Command line example:
+   *
+   * <pre>
+   * ./gradlew clean reporting-pipeline-service:test-functional -Dtests=elrEColi,interview
+   * </pre>
+   *
+   * <p>Direct java class example:
    *
    * <ul>
    *   <li>List.of("hivNotificationActualReferral")
    *   <li>List.of("interview", "elrEColi")
    * </ul>
    */
-  // private static final List<String> SELECTED_TEST_NAMES =
-  // List.of("hivNotificationActualReferral");
-  private static final List<String> SELECTED_TEST_NAMES = List.of();
+  private static List<String> selectedTestNames = List.of();
 
   private final JdbcClient client;
 
@@ -65,13 +74,18 @@ class DataDrivenFunctionalTests extends FunctionalTest {
   static Stream<Path> functionalTestDirectoryProvider() throws IOException {
     Path root = Paths.get("src/test/resources/testData/functional");
     Stream<Path> directories = Files.list(root).filter(Files::isDirectory);
+    String testsArg = System.getProperty("tests");
+    if (testsArg != null) {
+      selectedTestNames = new ArrayList<>(selectedTestNames);
+      Collections.addAll(selectedTestNames, testsArg.split(","));
+    }
 
-    if (SELECTED_TEST_NAMES.isEmpty()) {
+    if (selectedTestNames.isEmpty()) {
       return directories;
     }
 
     Set<String> selectedNames =
-        SELECTED_TEST_NAMES.stream()
+        selectedTestNames.stream()
             .map(name -> name.toLowerCase(Locale.ROOT))
             .collect(java.util.stream.Collectors.toSet());
 

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
@@ -6,20 +6,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import gov.cdc.nbs.report.pipeline.integration.support.Await;
+import gov.cdc.nbs.report.pipeline.integration.support.DirectoryProvider;
 import gov.cdc.nbs.report.pipeline.integration.support.QueryRunner;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.json.JSONException;
 import org.junit.jupiter.api.parallel.Execution;
@@ -71,26 +69,14 @@ class DataDrivenFunctionalTests extends FunctionalTest {
    * testRunner one at a time.
    */
   static Stream<Path> functionalTestDirectoryProvider() throws IOException {
-    Path root = Paths.get("src/test/resources/testData/functional");
-    Stream<Path> directories = Files.list(root).filter(Files::isDirectory);
     String testsArg = System.getProperty("tests");
+
     if (testsArg != null) {
       selectedTestNames = new ArrayList<>(selectedTestNames);
       Collections.addAll(selectedTestNames, testsArg.split(","));
     }
 
-    if (selectedTestNames.isEmpty()) {
-      return directories;
-    }
-
-    Set<String> selectedNames =
-        selectedTestNames.stream()
-            .map(name -> name.toLowerCase(Locale.ROOT))
-            .collect(java.util.stream.Collectors.toSet());
-
-    return directories.filter(
-        directory ->
-            selectedNames.contains(directory.getFileName().toString().toLowerCase(Locale.ROOT)));
+    return DirectoryProvider.stream("src/test/resources/testData/functional", selectedTestNames);
   }
 
   /**

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/functional/DataDrivenFunctionalTests.java
@@ -34,11 +34,10 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 class DataDrivenFunctionalTests extends FunctionalTest {
 
   /**
-   * <p>
    * Specific tests can be executed by manually adding the test name to the list below or by
-   * specifying the "tests" parameter. </p>
-   * 
-   * <p>If empty, all functional test directories are executed.</p>
+   * specifying the "tests" parameter.
+   *
+   * <p>If empty, all functional test directories are executed.
    *
    * <p>Command line example:
    *

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/support/DirectoryProvider.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/support/DirectoryProvider.java
@@ -1,0 +1,38 @@
+package gov.cdc.nbs.report.pipeline.integration.support;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class DirectoryProvider {
+
+  private DirectoryProvider() {}
+
+  /**
+   * Returns a stream of {@link Path} for each directory contained within the specified root and
+   * optionally filtered. If no entries are present in the filter, all entries will be returned.
+   *
+   * @param root the path to scan for sub-directories
+   * @param filter optional list of directory names to filter by
+   * @return stream of {@link Path} that are contained in the root and match the filter list if
+   *     provided
+   * @throws IOException
+   */
+  public static Stream<Path> stream(String root, List<String> filter) throws IOException {
+    Stream<Path> directories = Files.list(Paths.get(root)).filter(Files::isDirectory);
+
+    if (filter == null || filter.isEmpty()) {
+      return directories;
+    }
+
+    Set<String> selectedNames =
+        filter.stream().map(String::toLowerCase).collect(java.util.stream.Collectors.toSet());
+
+    return directories.filter(
+        directory -> selectedNames.contains(directory.getFileName().toString().toLowerCase()));
+  }
+}

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/integration/unit/DataDrivenUnitTests.java
@@ -3,12 +3,14 @@ package gov.cdc.nbs.report.pipeline.integration.unit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import gov.cdc.nbs.report.pipeline.integration.support.Await;
+import gov.cdc.nbs.report.pipeline.integration.support.DirectoryProvider;
 import gov.cdc.nbs.report.pipeline.integration.support.QueryRunner;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -42,17 +44,39 @@ class DataDrivenUnitTests extends UnitTest {
           .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
           .setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
 
-  public DataDrivenUnitTests() {
-    super();
-  }
+  /**
+   * Specific tests can be executed by manually adding the test name to the list below or by
+   * specifying the "tests" parameter.
+   *
+   * <p>If empty, all unit tests are executed.
+   *
+   * <p>Command line example:
+   *
+   * <pre>
+   * ./gradlew clean reporting-pipeline-service:test-unit -Dtests=covidCaseDatamart
+   * </pre>
+   *
+   * <p>Direct java class example:
+   *
+   * <ul>
+   *   <li>List.of("covidCaseDatamart")
+   * </ul>
+   */
+  private static List<String> selectedTestNames = List.of();
 
   /**
    * Provides each of the folders present in the /resources/testData/unit/ directory to the
    * testRunner one at a time.
    */
   static Stream<Path> unitTestDirectoryProvider() throws IOException {
-    Path root = Paths.get("src/test/resources/testData/unit");
-    return Files.list(root).filter(Files::isDirectory); // Filter out files
+    String testsArg = System.getProperty("tests");
+
+    if (testsArg != null) {
+      selectedTestNames = new ArrayList<>(selectedTestNames);
+      Collections.addAll(selectedTestNames, testsArg.split(","));
+    }
+
+    return DirectoryProvider.stream("src/test/resources/testData/unit", selectedTestNames);
   }
 
   /**


### PR DESCRIPTION
## Description
Allows us to specify a list of functional or unit tests to run from the command line. Creates a `DirectoryProvider` class that handles the streaming and filtering of folders.
## Usage

### Run specific tests
Run only the `elrEColi` and `interview` functional tests.
Run only the `covidCaseDatamart` unit test.
```sh
./gradlew clean reporting-pipeline-service:test-functional -D tests=elrEColi,interview

./gradlew clean reporting-pipeline-service:test-unit -Dtests=covidCaseDatamart
```

### Run All tests (no filtering)
```sh
./gradlew clean reporting-pipeline-service:test-functional

./gradlew clean reporting-pipeline-service:test-unit
```

### Using both command line and direct list update
If the `selectedTestNames` list is directly updated and command line tests argument is used, the test lists will be combined.

```java
private static List<String> selectedTestNames = List.of("covidMarkReviewed");
```
 and
```sh
./gradlew clean reporting-pipeline-service:test-functional -D tests=elrEColi,interview
```

Will run the `covidMarkReviewed`, `elrEColi`, and `interview` functional tests.

## Additional Info
The addition to the `build.gradle` passes the `tests` argument through to the Java service if it is provided.

```groovy
  if (System.getProperty("tests") != null) {
      systemProperty "tests", System.getProperty("tests")
  }
```



