### PR TITLE
APP-781: rank-align BMIRD strep pneumo additional-site datasets

### DIFF
--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/140-sp_bmird_strep_pneumo_datamart_postprocessing-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/140-sp_bmird_strep_pneumo_datamart_postprocessing-001.sql
@@ -631,113 +631,64 @@ BEGIN
 
         /*
         Site Data Processing -
-        Retrieve BMD125, BMD142 and BMD144 from BMIRD_MULTI_VALUE_FIELD and pivot into 3 columns
+        Retrieve BMD125, BMD142 and BMD144 from BMIRD_MULTI_VALUE_FIELD and pivot the top 3 entries into distinct columns.
 
-        Step 1: Create a dataset of all non-sterile sites
-        Step 2: Create 2 datasets of all additional culture sites
-        Step 3: Merge the datasets to create a new table with the columns transposed
-        Step 4: Merge the new table with the BMIRD_ANTIMICRO table
+        Step 1: Unpivot the non-sterile and additional culture sites from a single read into a unified row dataset using CROSS APPLY.
+        Step 2: Number the entries (1..N) per investigation and site type to establish their sequential order.
+        Step 3: Filter to the first 3 entries and pivot them directly into their final transposed columns (_1, _2, _3) using conditional aggregation.
+        Step 4: Merge the new table with the BMIRD_ANTIMICRO table.
+
+        Numbering each site type independently and pivoting by (site type, position) keeps the
+        Nth value of each question in its own slot. The previous version built three lists and
+        joined them on INVESTIGATION_KEY alone, a Cartesian product that, for any multi-answer
+        question, copied a single value into all three slots instead of the distinct sites.
         */
 
         BEGIN TRANSACTION;
 
         SET @Proc_Step_no = @Proc_Step_no + 1;
-        SET @Proc_Step_name = ' Generating #DM_BMD125, #DM_BMD142 and #DM_BMD144';
+        SET @Proc_Step_name = ' Generating #DM_BR7_T';
 
-        -- Build the three site lists for the case (non-sterile sites, and the two
-        -- additional-culture site lists). Number the entries 1..N per investigation
-        -- (rn) so that further down the lists can be lined up by position rather than
-        -- matching every value against every other value.
-        -- Step 1: non-sterile sites
-        SELECT INVESTIGATION_KEY, NON_STERILE_SITE_,
-               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY NON_STERILE_SITE_) AS rn
-        into #DM_BMD125
-        FROM (
-            SELECT distinct bc.INVESTIGATION_KEY,
-                     a.NON_STERILE_SITE AS NON_STERILE_SITE_
+        WITH cte_combined AS (
+            SELECT DISTINCT
+                bc.INVESTIGATION_KEY,
+                v.Site_Type,
+                v.Site_Value
             FROM #BMIRD_PATIENT1 bc
-                 INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
-                            on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-            WHERE A.NON_STERILE_SITE IS NOT NULL
-        ) z;
-
-        -- Step 2: Create 2 datasets of all additional culture sites
-        SELECT INVESTIGATION_KEY, ADD_CULTURE_1_SITE_,
-               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY ADD_CULTURE_1_SITE_) AS rn
-        into #DM_BMD142
-        FROM (
-            SELECT distinct bc.INVESTIGATION_KEY,
-                     a.STREP_PNEUMO_1_CULTURE_SITES AS ADD_CULTURE_1_SITE_
-            FROM #BMIRD_PATIENT1 bc
-                 INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
-                            on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-            WHERE A.STREP_PNEUMO_1_CULTURE_SITES IS NOT NULL
-        ) z;
-
-        SELECT INVESTIGATION_KEY, ADD_CULTURE_2_SITE_,
-               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY ADD_CULTURE_2_SITE_) AS rn
-        into #DM_BMD144
-        FROM (
-            SELECT distinct bc.INVESTIGATION_KEY,
-                     a.STREP_PNEUMO_2_CULTURE_SITES  AS ADD_CULTURE_2_SITE_
-            FROM #BMIRD_PATIENT1 bc
-                 INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
-                            on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-            WHERE A.STREP_PNEUMO_2_CULTURE_SITES IS NOT NULL
-        ) z;
-
-
-        SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-        INSERT INTO [DBO].[JOB_FLOW_LOG]
-        (BATCH_ID, [DATAFLOW_NAME], [PACKAGE_NAME], [STATUS_TYPE], [STEP_NUMBER], [STEP_NAME], [ROW_COUNT])
-        VALUES (@BATCH_ID, @Dataflow_Name, @Package_Name, 'START', @PROC_STEP_NO, @PROC_STEP_NAME, @ROWCOUNT_NO);
-
-        COMMIT TRANSACTION;
-
-        BEGIN TRANSACTION;
-
-        SET @Proc_Step_no = @Proc_Step_no + 1;
-        SET @Proc_Step_name = ' Generating #DM_BR7';
-
-
-        -- Step 3: line the three lists up by position. We join them on the number
-        -- assigned above (rn), so the 1st non-sterile site, 1st culture-1 site and
-        -- 1st culture-2 site share a row (COUNTER = 1), the 2nd of each share the
-        -- next row, and so on. The columns are then spread into _1/_2/_3 below.
-        --
-        -- The previous version joined the three lists on INVESTIGATION_KEY alone,
-        -- which paired every site with every other site (a Cartesian product). When
-        -- a question had more than one answer, the pivot that follows ended up
-        -- copying a single value into all three slots instead of the distinct sites.
-        select k.INVESTIGATION_KEY, k.rn AS COUNTER,
-               a.NON_STERILE_SITE_, b.ADD_CULTURE_1_SITE_, c.ADD_CULTURE_2_SITE_
-        into #DM_BR7
-        from (
-                 SELECT INVESTIGATION_KEY, rn FROM #DM_BMD125
-                 UNION SELECT INVESTIGATION_KEY, rn FROM #DM_BMD142
-                 UNION SELECT INVESTIGATION_KEY, rn FROM #DM_BMD144
-             ) k
-                 left outer join #DM_BMD125 a on a.INVESTIGATION_KEY = k.INVESTIGATION_KEY and a.rn = k.rn
-                 left outer join #DM_BMD142 b on b.INVESTIGATION_KEY = k.INVESTIGATION_KEY and b.rn = k.rn
-                 left outer join #DM_BMD144 c on c.INVESTIGATION_KEY = k.INVESTIGATION_KEY and c.rn = k.rn;
-
-        with cte2 as (
-            SELECT *
-            FROM #DM_BR7 WHERE COUNTER <= 3
+            INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a WITH (NOLOCK)
+                ON bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
+            CROSS APPLY (VALUES
+                ('NON_STERILE_SITE', a.NON_STERILE_SITE),
+                ('ADD_CULTURE_1_SITE', a.STREP_PNEUMO_1_CULTURE_SITES),
+                ('ADD_CULTURE_2_SITE', a.STREP_PNEUMO_2_CULTURE_SITES)
+            ) v (Site_Type, Site_Value)
+            WHERE v.Site_Value IS NOT NULL
+        ),
+        cte_numbered AS (
+            SELECT
+                INVESTIGATION_KEY,
+                Site_Type,
+                Site_Value,
+                ROW_NUMBER() OVER (
+                    PARTITION BY INVESTIGATION_KEY, Site_Type
+                    ORDER BY Site_Value
+                ) AS COUNTER
+            FROM cte_combined
         )
         SELECT INVESTIGATION_KEY,
-               MAX(CASE WHEN COUNTER = 1 THEN NON_STERILE_SITE_ END) AS NON_STERILE_SITE_1,
-               MAX(CASE WHEN COUNTER = 1 THEN ADD_CULTURE_1_SITE_ END) AS ADD_CULTURE_1_SITE_1,
-               MAX(CASE WHEN COUNTER = 1 THEN ADD_CULTURE_2_SITE_ END) AS ADD_CULTURE_2_SITE_1,
-               MAX(CASE WHEN COUNTER = 2 THEN NON_STERILE_SITE_ END) AS NON_STERILE_SITE_2,
-               MAX(CASE WHEN COUNTER = 2 THEN ADD_CULTURE_1_SITE_ END) AS ADD_CULTURE_1_SITE_2,
-               MAX(CASE WHEN COUNTER = 2 THEN ADD_CULTURE_2_SITE_ END) AS ADD_CULTURE_2_SITE_2,
-               MAX(CASE WHEN COUNTER = 3 THEN NON_STERILE_SITE_ END) AS NON_STERILE_SITE_3,
-               MAX(CASE WHEN COUNTER = 3 THEN ADD_CULTURE_1_SITE_ END) AS ADD_CULTURE_1_SITE_3,
-               MAX(CASE WHEN COUNTER = 3 THEN ADD_CULTURE_2_SITE_ END) AS ADD_CULTURE_2_SITE_3
-        into #DM_BR7_T
-        from cte2
-        group by INVESTIGATION_KEY;
+               MAX(CASE WHEN Site_Type = 'NON_STERILE_SITE'   AND COUNTER = 1 THEN Site_Value END) AS NON_STERILE_SITE_1,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_1_SITE' AND COUNTER = 1 THEN Site_Value END) AS ADD_CULTURE_1_SITE_1,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_2_SITE' AND COUNTER = 1 THEN Site_Value END) AS ADD_CULTURE_2_SITE_1,
+               MAX(CASE WHEN Site_Type = 'NON_STERILE_SITE'   AND COUNTER = 2 THEN Site_Value END) AS NON_STERILE_SITE_2,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_1_SITE' AND COUNTER = 2 THEN Site_Value END) AS ADD_CULTURE_1_SITE_2,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_2_SITE' AND COUNTER = 2 THEN Site_Value END) AS ADD_CULTURE_2_SITE_2,
+               MAX(CASE WHEN Site_Type = 'NON_STERILE_SITE'   AND COUNTER = 3 THEN Site_Value END) AS NON_STERILE_SITE_3,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_1_SITE' AND COUNTER = 3 THEN Site_Value END) AS ADD_CULTURE_1_SITE_3,
+               MAX(CASE WHEN Site_Type = 'ADD_CULTURE_2_SITE' AND COUNTER = 3 THEN Site_Value END) AS ADD_CULTURE_2_SITE_3
+        INTO #DM_BR7_T
+        FROM cte_numbered
+        WHERE COUNTER <= 3
+        GROUP BY INVESTIGATION_KEY;
 
         if @debug = 'true' select @Proc_Step_Name as step, * from #DM_BR7_T;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/140-sp_bmird_strep_pneumo_datamart_postprocessing-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v17.3/rdb/routines/140-sp_bmird_strep_pneumo_datamart_postprocessing-001.sql
@@ -644,37 +644,47 @@ BEGIN
         SET @Proc_Step_no = @Proc_Step_no + 1;
         SET @Proc_Step_name = ' Generating #DM_BMD125, #DM_BMD142 and #DM_BMD144';
 
-        -- Step 1: Create a dataset of all non-sterile sites
-        SELECT
-            distinct bc.INVESTIGATION_KEY,
-                     a.NON_STERILE_SITE AS NON_STERILE_SITE_
+        -- Build the three site lists for the case (non-sterile sites, and the two
+        -- additional-culture site lists). Number the entries 1..N per investigation
+        -- (rn) so that further down the lists can be lined up by position rather than
+        -- matching every value against every other value.
+        -- Step 1: non-sterile sites
+        SELECT INVESTIGATION_KEY, NON_STERILE_SITE_,
+               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY NON_STERILE_SITE_) AS rn
         into #DM_BMD125
-        FROM #BMIRD_PATIENT1 bc
+        FROM (
+            SELECT distinct bc.INVESTIGATION_KEY,
+                     a.NON_STERILE_SITE AS NON_STERILE_SITE_
+            FROM #BMIRD_PATIENT1 bc
                  INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
                             on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-        WHERE A.NON_STERILE_SITE IS NOT NULL
-        ORDER BY bc.INVESTIGATION_KEY, a.NON_STERILE_SITE;
+            WHERE A.NON_STERILE_SITE IS NOT NULL
+        ) z;
 
         -- Step 2: Create 2 datasets of all additional culture sites
-        SELECT
-            distinct bc.INVESTIGATION_KEY,
-                     a.STREP_PNEUMO_1_CULTURE_SITES AS ADD_CULTURE_1_SITE_
+        SELECT INVESTIGATION_KEY, ADD_CULTURE_1_SITE_,
+               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY ADD_CULTURE_1_SITE_) AS rn
         into #DM_BMD142
-        FROM #BMIRD_PATIENT1 bc
+        FROM (
+            SELECT distinct bc.INVESTIGATION_KEY,
+                     a.STREP_PNEUMO_1_CULTURE_SITES AS ADD_CULTURE_1_SITE_
+            FROM #BMIRD_PATIENT1 bc
                  INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
                             on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-        WHERE A.STREP_PNEUMO_1_CULTURE_SITES IS NOT NULL
-        ORDER BY bc.INVESTIGATION_KEY, 	a.STREP_PNEUMO_1_CULTURE_SITES;
+            WHERE A.STREP_PNEUMO_1_CULTURE_SITES IS NOT NULL
+        ) z;
 
-        SELECT
-            distinct bc.INVESTIGATION_KEY,
-                     a.STREP_PNEUMO_2_CULTURE_SITES  AS ADD_CULTURE_2_SITE_
+        SELECT INVESTIGATION_KEY, ADD_CULTURE_2_SITE_,
+               ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY ORDER BY ADD_CULTURE_2_SITE_) AS rn
         into #DM_BMD144
-        FROM #BMIRD_PATIENT1 bc
+        FROM (
+            SELECT distinct bc.INVESTIGATION_KEY,
+                     a.STREP_PNEUMO_2_CULTURE_SITES  AS ADD_CULTURE_2_SITE_
+            FROM #BMIRD_PATIENT1 bc
                  INNER JOIN dbo.BMIRD_MULTI_VALUE_FIELD a with (nolock)
                             on bc.BMIRD_MULTI_VAL_GRP_KEY = a.BMIRD_MULTI_VAL_GRP_KEY
-        WHERE A.STREP_PNEUMO_2_CULTURE_SITES IS NOT NULL
-        ORDER BY bc.INVESTIGATION_KEY, 	a.STREP_PNEUMO_2_CULTURE_SITES;
+            WHERE A.STREP_PNEUMO_2_CULTURE_SITES IS NOT NULL
+        ) z;
 
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
@@ -690,24 +700,30 @@ BEGIN
         SET @Proc_Step_name = ' Generating #DM_BR7';
 
 
-        -- Step 3: Merge the datasets to create a new table with the columns transposed
-        select d.INVESTIGATION_KEY, a.NON_STERILE_SITE_, b.ADD_CULTURE_1_SITE_, c.ADD_CULTURE_2_SITE_
+        -- Step 3: line the three lists up by position. We join them on the number
+        -- assigned above (rn), so the 1st non-sterile site, 1st culture-1 site and
+        -- 1st culture-2 site share a row (COUNTER = 1), the 2nd of each share the
+        -- next row, and so on. The columns are then spread into _1/_2/_3 below.
+        --
+        -- The previous version joined the three lists on INVESTIGATION_KEY alone,
+        -- which paired every site with every other site (a Cartesian product). When
+        -- a question had more than one answer, the pivot that follows ended up
+        -- copying a single value into all three slots instead of the distinct sites.
+        select k.INVESTIGATION_KEY, k.rn AS COUNTER,
+               a.NON_STERILE_SITE_, b.ADD_CULTURE_1_SITE_, c.ADD_CULTURE_2_SITE_
         into #DM_BR7
-        from #BMIRD_PATIENT1 d
-                 left outer join #DM_BMD125 a on a.INVESTIGATION_KEY = d.INVESTIGATION_KEY
-                 left outer join #DM_BMD142 b on b.INVESTIGATION_KEY = d.INVESTIGATION_KEY
-                 left outer join #DM_BMD144 c on c.INVESTIGATION_KEY = d.INVESTIGATION_KEY
-        where coalesce(a.NON_STERILE_SITE_, b.ADD_CULTURE_1_SITE_, c.ADD_CULTURE_2_SITE_) is not null ;
+        from (
+                 SELECT INVESTIGATION_KEY, rn FROM #DM_BMD125
+                 UNION SELECT INVESTIGATION_KEY, rn FROM #DM_BMD142
+                 UNION SELECT INVESTIGATION_KEY, rn FROM #DM_BMD144
+             ) k
+                 left outer join #DM_BMD125 a on a.INVESTIGATION_KEY = k.INVESTIGATION_KEY and a.rn = k.rn
+                 left outer join #DM_BMD142 b on b.INVESTIGATION_KEY = k.INVESTIGATION_KEY and b.rn = k.rn
+                 left outer join #DM_BMD144 c on c.INVESTIGATION_KEY = k.INVESTIGATION_KEY and c.rn = k.rn;
 
-        with cte1 as  (
-            SELECT *,
-                   ROW_NUMBER() OVER (PARTITION BY INVESTIGATION_KEY
-                       ORDER BY coalesce(NON_STERILE_SITE_, ADD_CULTURE_1_SITE_, ADD_CULTURE_2_SITE_)) AS COUNTER
-            FROM #DM_BR7
-        )
-           , cte2 as (
+        with cte2 as (
             SELECT *
-            FROM cte1 WHERE COUNTER <= 3
+            FROM #DM_BR7 WHERE COUNTER <= 3
         )
         SELECT INVESTIGATION_KEY,
                MAX(CASE WHEN COUNTER = 1 THEN NON_STERILE_SITE_ END) AS NON_STERILE_SITE_1,

--- a/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/expected.json
@@ -1,0 +1,15 @@
+{
+  "0": [
+    {
+      "NON_STERILE_SITE_1": "Amniotic fluid",
+      "NON_STERILE_SITE_2": "Middle ear",
+      "NON_STERILE_SITE_3": "Other",
+      "ADD_CULTURE_1_SITE_1": "Blood",
+      "ADD_CULTURE_1_SITE_2": "Bone",
+      "ADD_CULTURE_1_SITE_3": "Cerebral Spinal Fluid",
+      "ADD_CULTURE_2_SITE_1": "Joint Fluid",
+      "ADD_CULTURE_2_SITE_2": "Lung",
+      "ADD_CULTURE_2_SITE_3": "Sinus"
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/query.sql
@@ -1,0 +1,13 @@
+-- The three non-sterile-site slots should hold the three distinct values that were
+-- entered (slot 1 'Amniotic fluid', slot 2 'Middle ear', slot 3 'Other'). The old
+-- routine repeated the first value in every slot, so requiring slot 2 = 'Middle ear'
+-- and slot 3 = 'Other' returns no row; the Await poll then times out and the test
+-- fails (RED). With the fix the row is found and the test passes (GREEN).
+SELECT
+    NON_STERILE_SITE_1, NON_STERILE_SITE_2, NON_STERILE_SITE_3,
+    ADD_CULTURE_1_SITE_1, ADD_CULTURE_1_SITE_2, ADD_CULTURE_1_SITE_3,
+    ADD_CULTURE_2_SITE_1, ADD_CULTURE_2_SITE_2, ADD_CULTURE_2_SITE_3
+FROM RDB_MODERN.dbo.BMIRD_STREP_PNEUMO_DATAMART
+WHERE INVESTIGATION_KEY = 22781000
+  AND NON_STERILE_SITE_2 = N'Middle ear'
+  AND NON_STERILE_SITE_3 = N'Other';

--- a/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/query.sql
@@ -1,7 +1,7 @@
 -- The three non-sterile-site slots should hold the three distinct values that were
 -- entered (slot 1 'Amniotic fluid', slot 2 'Middle ear', slot 3 'Other'). The old
 -- routine repeated the first value in every slot, so requiring slot 2 = 'Middle ear'
--- and slot 3 = 'Other' returns no row; the Await poll then times out and the test
+-- and slot 3 = 'Other' returns no row, the Await poll then times out and the test
 -- fails (RED). With the fix the row is found and the test passes (GREEN).
 SELECT
     NON_STERILE_SITE_1, NON_STERILE_SITE_2, NON_STERILE_SITE_3,

--- a/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/app781_bmird_strep_pneumo_site/setup.sql
@@ -1,0 +1,68 @@
+-- Regression test for APP-781.
+--
+-- The bug: when a Strep pneumo case had more than one value for one of the
+-- additional-site questions, the datamart showed a single value repeated in every
+-- slot (NON_STERILE_SITE_1/2/3 and the two ADD_CULTURE_*_SITE_1/2/3 sets) instead
+-- of the distinct sites that were entered. It lived in routine 140,
+-- sp_bmird_strep_pneumo_datamart_postprocessing, which combined the three site
+-- lists by matching every value against every other (a Cartesian product).
+--
+-- This seeds one Strep pneumo investigation (PHC 22781000, condition 11723) with
+-- three distinct values for each additional-site question and then runs the
+-- datamart procedure. The rows go straight into the RDB_MODERN dimension tables
+-- (rather than through the full ODSE -> pipeline path) so the test exercises only
+-- this one procedure.
+--
+-- query.sql then checks that the three NON_STERILE_SITE slots hold the three
+-- distinct values. Against the old routine they all come out 'Amniotic fluid', so
+-- the query finds no row, the Await poll times out, and the test fails (RED);
+-- with the fix the slots are distinct and the test passes (GREEN).
+USE RDB_MODERN;
+
+-- Parent rows the BMIRD_CASE row needs. RDB_DATE, LDF_GROUP and
+-- BMIRD_MULTI_VALUE_FIELD_GROUP have no usable row to point at in the restored
+-- RDB_MODERN, so create the specific keys this case references. Each needs only
+-- its key column. D_PATIENT needs a real local id because the datamart's
+-- PATIENT_LOCAL_ID is NOT NULL and the shared key=1 patient leaves it null.
+INSERT INTO [dbo].[RDB_DATE] ([DATE_KEY]) VALUES (22781004);
+INSERT INTO [dbo].[LDF_GROUP] ([LDF_GROUP_KEY]) VALUES (22781003);
+INSERT INTO [dbo].[BMIRD_MULTI_VALUE_FIELD_GROUP] ([BMIRD_MULTI_VAL_GRP_KEY]) VALUES (22781002);
+INSERT INTO [dbo].[D_PATIENT] ([PATIENT_KEY], [PATIENT_LOCAL_ID]) VALUES (22781005, N'PSN22781000GA01');
+
+INSERT INTO [dbo].[CONDITION] ([CONDITION_KEY], [CONDITION_CD], [CONDITION_SHORT_NM])
+VALUES (22781001, N'11723', N'Streptococcus pneumoniae');
+
+-- The case must be active and a non-summary case_type, and its CASE_UID has to
+-- match the @phc_uids passed to the procedure below.
+INSERT INTO [dbo].[INVESTIGATION]
+    ([INVESTIGATION_KEY], [CASE_UID], [CASE_OID], [INV_LOCAL_ID], [CASE_TYPE], [RECORD_STATUS_CD])
+VALUES
+    (22781000, 22781000, 22781000, N'CAS22781000GA01', N'I', N'ACTIVE');
+
+-- The remaining BMIRD_CASE keys (investigator/physician/reporter, organizations)
+-- point at the existing shared key=1 rows.
+INSERT INTO [dbo].[BMIRD_CASE]
+    ([INVESTIGATION_KEY], [CONDITION_KEY], [BMIRD_MULTI_VAL_GRP_KEY], [ANTIMICROBIAL_GRP_KEY],
+     [PATIENT_KEY], [INVESTIGATOR_KEY], [PHYSICIAN_KEY], [REPORTER_KEY], [NURSING_HOME_KEY],
+     [DAYCARE_FACILITY_KEY], [INV_ASSIGNED_DT_KEY], [ADT_HSPTL_KEY], [RPT_SRC_ORG_KEY], [LDF_GROUP_KEY])
+VALUES
+    (22781000, 22781001, 22781002, 1, 22781005, 1, 1, 1, 1, 1, 22781004, 1, 1, 22781003);
+
+-- Three distinct answers for each of the three additional-site questions, one
+-- answer per row. This is the multi-value shape that triggers the bug; with a
+-- single answer per question it never showed up.
+INSERT INTO [dbo].[BMIRD_MULTI_VALUE_FIELD]
+    ([BMIRD_MULTI_VAL_FIELD_KEY], [BMIRD_MULTI_VAL_GRP_KEY],
+     [NON_STERILE_SITE], [STREP_PNEUMO_1_CULTURE_SITES], [STREP_PNEUMO_2_CULTURE_SITES])
+VALUES
+    (22781010, 22781002, N'Amniotic fluid', NULL, NULL),
+    (22781011, 22781002, N'Middle ear',     NULL, NULL),
+    (22781012, 22781002, N'Other',          NULL, NULL),
+    (22781013, 22781002, NULL, N'Blood',                 NULL),
+    (22781014, 22781002, NULL, N'Bone',                  NULL),
+    (22781015, 22781002, NULL, N'Cerebral Spinal Fluid', NULL),
+    (22781016, 22781002, NULL, NULL, N'Joint Fluid'),
+    (22781017, 22781002, NULL, NULL, N'Lung'),
+    (22781018, 22781002, NULL, NULL, N'Sinus');
+
+EXEC dbo.sp_bmird_strep_pneumo_datamart_postprocessing @phc_uids = N'22781000', @debug = 0;


### PR DESCRIPTION
## Description
When a Strep pneumo case has more than one value for one of the additional-site questions, the datamart was showing a single value repeated in every slot instead of the distinct sites that were entered. For example, non-sterile sites of "Amniotic fluid, Middle ear, Other" came out as "Amniotic fluid, Amniotic fluid, Amniotic fluid" (and likewise for the two additional-culture site columns).

The cause is in `sp_bmird_strep_pneumo_datamart_postprocessing`. It builds three separate site lists (non-sterile, and the two additional-culture lists) and then combined them by matching only on the investigation, which pairs every site against every other site (a Cartesian product). The pivot that follows then copied one value into all three slots.

The fix numbers each list per investigation (1st, 2nd, 3rd site) and lines the three lists up by that number, so the Nth site from each list ends up on the same row before being spread into the `_1/_2/_3` columns. A case with a single site is unaffected. Adds a data-driven regression test.

## Related Issue
[APP-781](https://cdc-nbs.atlassian.net/browse/APP-781)

## Additional Notes
This surfaced during the APP-471 synthetic-fixtures work, which is the first time the pipeline processed a case with multiple values for a site question, so the bug had gone unnoticed until now. Verified red-fix-green: the new test fails against the old routine and passes with the fix (`reporting-pipeline-service:test-unit -Dtests=app781_bmird_strep_pneumo_site`).

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
