### PR TITLE
Add rdb-compare: local RDB vs RDB_MODERN comparison tool

### DIFF
--- a/testing-tools/rdb-compare/README.md
+++ b/testing-tools/rdb-compare/README.md
@@ -1,0 +1,54 @@
+# rdb-compare
+
+A local tool that compares the legacy **RDB** (produced by MasterETL/SAS) against
+**RDB_MODERN** (produced by the RTR reporting pipeline), documenting which tables
+and which columns differ. It classifies every difference as **NEW**
+(unexplained, needs attention), **EXPECTED** (documented by-design),
+**KNOWN_BUG** (documented probable bug), or **IGNORED** (skip table, surrogate-key
+offset, ETL timestamp, audit column).
+
+It is the local-development counterpart to
+[CDCgov/NEDSS-DataCompare](https://github.com/CDCgov/NEDSS-DataCompare): it reuses
+that project's per-table key columns and comparison SQL approach, but drops the
+S3/Kafka/Spring machinery for a single tool that reads two databases in
+the same SQL Server instance and emits JSON + Markdown.
+
+## How it works
+
+The comparison is **UID-keyed and column-by-column** (matching the SQL templates
+in the RTR reporting-differences Confluence page): rows are matched on a table's
+business/UID key(s), never the surrogate `*_KEY` columns, which carry documented
+offsets. Every non-key column is compared NULL-aware via a cross-database
+join (`RDB.dbo.X JOIN RDB_MODERN.dbo.X ON key`).
+
+The known/expected differences live in a **declarative rule registry**
+(`rdb_compare/rules/`) rather than if/else sprawl: each known difference is a
+typed `Rule` instance (`SkipTableRule`, `IgnoreColumnRule`, `ExpectedDiffRule`,
+`KnownBugRule`) in `rdb_compare/rules/catalog.py`, sourced from the
+reporting-differences page and the DataCompare config. Classification is a
+separate, pure pass over the raw comparison results.
+
+## Usage
+
+```bash
+uv sync
+uv run rdb-compare --host localhost --port 3433 --user sa \
+    --rdb RDB --modern RDB_MODERN --out ./out
+```
+
+Outputs `out/comparison.json` (full machine-readable results) and
+`out/comparison.md` (human report: per-table summary, per-column mismatch counts,
+sample mismatched rows, each diff classified).
+
+Run `uv run rdb-compare --help` for all options (table include/exclude globs,
+sample cap, verdict filtering, etc.).
+
+## Tests
+
+```bash
+uv run pytest
+```
+
+The comparison engine, rule registry, classifier, and report renderers are all
+unit-tested without a live database (fixture data); the DB layer is integration
+-tested separately against the dev SQL Server.

--- a/testing-tools/rdb-compare/pyproject.toml
+++ b/testing-tools/rdb-compare/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "rdb-compare"
+version = "0.1.0"
+description = "Local RDB (MasterETL) vs RDB_MODERN (RTR) database comparison tool with a declarative known-differences rule registry."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "pymssql>=2.3.0",
+]
+
+[project.scripts]
+rdb-compare = "rdb_compare.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["rdb_compare"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/testing-tools/rdb-compare/rdb_compare/__init__.py
+++ b/testing-tools/rdb-compare/rdb_compare/__init__.py
@@ -1,0 +1,3 @@
+"""rdb-compare: local RDB (MasterETL) vs RDB_MODERN (RTR) comparison."""
+
+__version__ = "0.1.0"

--- a/testing-tools/rdb-compare/rdb_compare/classifier.py
+++ b/testing-tools/rdb-compare/rdb_compare/classifier.py
@@ -1,0 +1,64 @@
+"""Apply the rule registry to raw comparison results.
+
+The engine produces :class:`~rdb_compare.models.TableResult` objects with raw,
+unclassified :class:`~rdb_compare.models.ColumnDiff` entries. :func:`classify_run`
+walks the results and attaches a :class:`~rdb_compare.models.Classification` to
+each column difference (and a table-level note for skipped tables), without
+mutating the comparison logic itself -- classification is a separate, pure pass
+so the known-differences knowledge stays in the rule catalog.
+"""
+
+from __future__ import annotations
+
+from rdb_compare.models import Classification, RunReport, TableResult, Verdict
+from rdb_compare.rules import RuleRegistry
+
+
+def classify_table_result(result: TableResult, registry: RuleRegistry) -> TableResult:
+    """Attach classifications to a single table result (in place) and return it."""
+    table_cls = registry.classify_table(result.table)
+    if table_cls is not None:
+        result.skipped = True
+        result.skip_reason = table_cls.reason
+        result.classification = table_cls
+        return result
+
+    for col in result.columns:
+        col.classification = registry.classify_column(
+            result.table, col.column, col.samples
+        )
+    return result
+
+
+def classify_run(report: RunReport, registry: RuleRegistry) -> RunReport:
+    """Classify every table result in a run (in place) and return the report."""
+    for result in report.tables:
+        classify_table_result(result, registry)
+    return report
+
+
+def summarize(report: RunReport) -> dict:
+    """Roll up verdict counts across all classified column differences."""
+    counts = {v.value: 0 for v in Verdict}
+    actionable_tables = 0
+    for t in report.tables:
+        if t.skipped:
+            # Skipped tables carry only a table-level IGNORED classification;
+            # their (typically absent) columns must not roll up as NEW.
+            counts[Verdict.IGNORED.value] += 1
+            continue
+        has_new = False
+        for c in t.columns:
+            cls = c.classification or Classification(Verdict.NEW)
+            counts[cls.verdict.value] += 1
+            if cls.verdict == Verdict.NEW:
+                has_new = True
+        if has_new:
+            actionable_tables += 1
+    return {
+        "verdict_counts": counts,
+        "actionable_tables": actionable_tables,
+        "tables_compared": report.compared,
+        "tables_skipped": report.skipped,
+        "tables_discovered": report.discovered,
+    }

--- a/testing-tools/rdb-compare/rdb_compare/cli.py
+++ b/testing-tools/rdb-compare/rdb_compare/cli.py
@@ -1,0 +1,177 @@
+"""Command-line entrypoint for rdb-compare.
+
+Connects to the SQL Server instance holding both RDB and RDB_MODERN, discovers
+the tables to compare, resolves each table's business/UID key, runs the
+column-by-column comparison, classifies every difference against the
+known-differences rule catalog, and writes JSON + Markdown reports.
+
+    uv run rdb-compare --host localhost --port 3433 --user sa \\
+        --rdb RDB --modern RDB_MODERN --out ./out
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+from rdb_compare import db, discovery, engine, keys, report
+from rdb_compare.classifier import classify_run, summarize
+from rdb_compare.models import Presence, RunReport, TableResult
+from rdb_compare.rules.catalog import build_default_registry
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(
+        prog="rdb-compare",
+        description="Compare legacy RDB (MasterETL) against RDB_MODERN (RTR), "
+        "classifying every difference as NEW / EXPECTED / KNOWN_BUG / IGNORED.",
+    )
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int, default=3433)
+    p.add_argument("--user", default="sa")
+    p.add_argument(
+        "--password",
+        default=os.environ.get("SQLCMDPASSWORD", "PizzaIsGood33!"),
+        help="DB password (default: $SQLCMDPASSWORD or the dev default).",
+    )
+    p.add_argument("--rdb", default="RDB", help="Legacy database name.")
+    p.add_argument("--modern", default="RDB_MODERN", help="Modern database name.")
+    p.add_argument("--out", default="./out", help="Output directory.")
+    p.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        help="Glob of table names to include (repeatable).",
+    )
+    p.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        help="Glob of table names to exclude (repeatable).",
+    )
+    p.add_argument("--sample-cap", type=int, default=20, help="Max sample rows per column.")
+    p.add_argument(
+        "--query-timeout",
+        type=int,
+        default=120,
+        help="Per-query timeout in seconds (0 = no limit). A table whose "
+        "cross-DB join exceeds this is recorded as an error and the run "
+        "continues.",
+    )
+    p.add_argument(
+        "--progress",
+        action="store_true",
+        help="Print per-table progress to stderr (table index, presence, timing).",
+    )
+    p.add_argument(
+        "--fail-on-new",
+        action="store_true",
+        help="Exit non-zero if any NEW (unexplained) difference is found.",
+    )
+    return p.parse_args(argv)
+
+
+def _common_columns(conn, rdb_db, modern_db, table):
+    """Columns present in BOTH copies of the table, preserving RDB order."""
+    rdb_cols = db.list_columns(conn, rdb_db, table)
+    modern_cols = {c.upper() for c in db.list_columns(conn, modern_db, table)}
+    return [c for c in rdb_cols if c.upper() in modern_cols]
+
+
+def _progress(args, msg):
+    """Emit a per-table progress line to stderr when --progress is set."""
+    if args.progress:
+        print(msg, file=sys.stderr, flush=True)
+
+
+def run(args) -> RunReport:
+    registry = build_default_registry()
+    timeout = getattr(args, "query_timeout", 0)
+    conn = db.connect(args.host, args.port, args.user, args.password, timeout=timeout)
+
+    tables = discovery.discover(
+        conn, args.rdb, args.modern, registry,
+        include=args.include, exclude=args.exclude,
+    )
+
+    report_obj = RunReport(
+        rdb_db=args.rdb,
+        modern_db=args.modern,
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        discovered=len(tables),
+    )
+
+    total = len(tables)
+    for i, table in enumerate(tables, 1):
+        _progress(args, f"[{i}/{total}] {table} ...")
+        started = time.monotonic()
+        try:
+            common = _common_columns(conn, args.rdb, args.modern, table)
+            key_cols = keys.resolve_keys(table, common)
+            value_cols = [
+                c for c in common
+                if not key_cols or c.upper() not in {k.upper() for k in key_cols}
+            ]
+            result = engine.compare_table(
+                conn, table, key_cols or (), value_cols,
+                args.rdb, args.modern, sample_cap=args.sample_cap,
+            )
+            if not key_cols:
+                note = "no usable UID/LOCAL_ID key; compared row counts only"
+                result.error = (result.error + "; " + note) if result.error else note
+        except Exception as exc:  # noqa: BLE001 -- isolate per-table failures
+            result = TableResult(table=table, presence=Presence.BOTH, error=str(exc))
+            # A query timeout (or any driver-level error) can leave the shared
+            # connection unusable for subsequent tables; reconnect so one bad
+            # table cannot cascade into a wall of errors.
+            try:
+                conn = db.connect(
+                    args.host, args.port, args.user, args.password, timeout=timeout
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        elapsed = time.monotonic() - started
+        _progress(
+            args,
+            f"[{i}/{total}] {table} {result.presence.value} "
+            f"rdb={result.rdb_count} modern={result.modern_count} "
+            f"{elapsed:.1f}s{' ERR' if result.error else ''}",
+        )
+        report_obj.tables.append(result)
+
+    report_obj.compared = sum(1 for t in report_obj.tables if not t.skipped)
+    classify_run(report_obj, registry)
+    report_obj.skipped = sum(1 for t in report_obj.tables if t.skipped)
+    report_obj.compared = len(report_obj.tables) - report_obj.skipped
+    return report_obj
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    report_obj = run(args)
+
+    os.makedirs(args.out, exist_ok=True)
+    json_path = os.path.join(args.out, "comparison.json")
+    md_path = os.path.join(args.out, "comparison.md")
+    report.write_json(report_obj, json_path)
+    report.write_markdown(report_obj, md_path)
+
+    s = summarize(report_obj)
+    counts = s["verdict_counts"]
+    print(f"Compared {report_obj.compared} tables ({report_obj.skipped} skipped) "
+          f"of {report_obj.discovered} discovered.")
+    print(f"  NEW={counts['NEW']}  KNOWN_BUG={counts['KNOWN_BUG']}  "
+          f"EXPECTED={counts['EXPECTED']}  IGNORED={counts['IGNORED']}")
+    print(f"  {s['actionable_tables']} table(s) with unexplained (NEW) differences.")
+    print(f"Wrote {json_path} and {md_path}")
+
+    if args.fail_on_new and counts["NEW"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/testing-tools/rdb-compare/rdb_compare/db.py
+++ b/testing-tools/rdb-compare/rdb_compare/db.py
@@ -1,0 +1,68 @@
+"""Thin pymssql access layer for the RDB vs RDB_MODERN comparison.
+
+Both databases live in the *same* SQL Server instance, so a single connection
+(opened against ``master``) can reach either via three-part names
+(``[db].dbo.[table]``, ``[db].sys.columns``). Every helper here is a small,
+side-effect-free wrapper around a cursor; the comparison logic lives in
+:mod:`rdb_compare.engine`.
+"""
+
+from __future__ import annotations
+
+import pymssql
+
+
+def connect(host, port, user, password, database="master", timeout=0):
+    """Open an autocommit pymssql connection to the SQL Server instance.
+
+    ``database`` defaults to ``master`` because the comparison reaches both RDB
+    and RDB_MODERN through fully qualified three-part names rather than the
+    connection's current database.
+
+    ``timeout`` is the per-query timeout in seconds (0 = wait forever). A
+    non-zero value lets a pathologically slow per-table comparison (an unindexed
+    cross-DB join over a large reference table) abort and be recorded as a
+    per-table error instead of hanging the whole run.
+    """
+    return pymssql.connect(
+        server=host,
+        port=str(port),
+        user=user,
+        password=password,
+        database=database,
+        autocommit=True,
+        timeout=timeout,
+    )
+
+
+def list_tables(conn, db):
+    """Return the set of UPPERCASE base-table names in database ``db``."""
+    sql = (
+        f"SELECT TABLE_NAME FROM [{db}].INFORMATION_SCHEMA.TABLES "
+        "WHERE TABLE_TYPE = 'BASE TABLE'"
+    )
+    return {row["TABLE_NAME"].upper() for row in run_query(conn, sql)}
+
+
+def list_columns(conn, db, table):
+    """Return ``table``'s column names in ordinal order, excluding computed ones.
+
+    Uses ``[db].sys.columns`` joined to ``[db].sys.tables`` so the lookup is
+    scoped to the right database even though the connection points at
+    ``master``.
+    """
+    sql = (
+        "SELECT c.name AS name "
+        f"FROM [{db}].sys.columns AS c "
+        f"INNER JOIN [{db}].sys.tables AS t ON c.object_id = t.object_id "
+        f"WHERE t.name = '{table}' AND c.is_computed = 0 "
+        "ORDER BY c.column_id"
+    )
+    return [row["name"] for row in run_query(conn, sql)]
+
+
+def run_query(conn, sql):
+    """Execute ``sql`` and return all rows as a list of ``{column: value}`` dicts."""
+    with conn.cursor(as_dict=True) as cur:
+        cur.execute(sql)
+        return cur.fetchall()

--- a/testing-tools/rdb-compare/rdb_compare/discovery.py
+++ b/testing-tools/rdb-compare/rdb_compare/discovery.py
@@ -1,0 +1,61 @@
+"""Table discovery for the RDB vs RDB_MODERN comparison.
+
+The comparison only runs on tables that exist in *both* databases. This module
+computes that common set, drops the structurally uninteresting tables the rule
+registry skips (ETL/event/lookup/staging/SAS/temp, RDB_MODERN-only tables, etc.),
+and applies optional caller-supplied include/exclude globs.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+
+from rdb_compare import db
+
+
+def discover(conn, rdb_db, modern_db, registry, include=None, exclude=None):
+    """Return the sorted list of tables to compare.
+
+    Starts from the intersection of the tables present in ``rdb_db`` and
+    ``modern_db``, then:
+
+    * drops any table the ``registry`` marks skipped
+      (:meth:`~rdb_compare.rules.RuleRegistry.is_skipped`);
+    * if ``include`` globs are given, keeps only tables matching at least one;
+    * if ``exclude`` globs are given, drops tables matching at least one.
+
+    Glob matching is case-insensitive via :func:`fnmatch.fnmatchcase` on
+    upper-cased table names (SQL Server's default collation behaviour).
+
+    :param conn: an open DB connection (passed through to :mod:`rdb_compare.db`).
+    :param rdb_db: legacy RDB database name.
+    :param modern_db: modern RDB_MODERN database name.
+    :param registry: a :class:`~rdb_compare.rules.RuleRegistry`.
+    :param include: optional iterable of glob patterns to keep.
+    :param exclude: optional iterable of glob patterns to drop.
+    :returns: sorted list of table names common to both databases and surviving
+        the skip rules and include/exclude filters.
+    """
+    rdb_tables = db.list_tables(conn, rdb_db)
+    modern_tables = db.list_tables(conn, modern_db)
+    common = set(rdb_tables) & set(modern_tables)
+
+    include = list(include) if include else None
+    exclude = list(exclude) if exclude else None
+
+    kept: list[str] = []
+    for table in common:
+        if registry.is_skipped(table):
+            continue
+        upper = table.upper()
+        if include is not None and not any(
+            fnmatchcase(upper, p.upper()) for p in include
+        ):
+            continue
+        if exclude is not None and any(
+            fnmatchcase(upper, p.upper()) for p in exclude
+        ):
+            continue
+        kept.append(table)
+
+    return sorted(kept)

--- a/testing-tools/rdb-compare/rdb_compare/engine.py
+++ b/testing-tools/rdb-compare/rdb_compare/engine.py
@@ -1,0 +1,214 @@
+"""The cross-database comparison engine.
+
+Given a table and its business/UID key column(s), the engine builds the T-SQL
+that joins ``RDB.dbo.<table>`` against ``RDB_MODERN.dbo.<table>`` on those keys
+and reports, per value column, the rows whose values differ (NULL-aware). It
+then runs that SQL through :mod:`rdb_compare.db` and folds the raw rows into the
+shared :class:`~rdb_compare.models.TableResult` / :class:`ColumnDiff` /
+:class:`CellDiff` contract.
+
+The SQL mirrors the canonical comparison templates: identifiers are
+bracket-quoted, values are cast to ``NVARCHAR(4000)``, and the difference test is
+the NULL-safe ``EXISTS (SELECT L.[col] EXCEPT SELECT M.[col])`` -- true exactly
+when the two values differ, with ``NULL`` treated as equal to ``NULL``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from rdb_compare import db
+from rdb_compare.models import CellDiff, ColumnDiff, Presence, TableResult
+
+
+def _qualified(database: str, table: str) -> str:
+    """Three-part, bracket-quoted ``[db].dbo.[table]`` name."""
+    return f"[{database}].[dbo].[{table}]"
+
+
+def build_value_diff_sql(table, key_cols, value_cols, rdb_db, modern_db):
+    """Build the per-column value-difference SQL for one table.
+
+    Returns a single ``UNION ALL`` statement with one branch per value column.
+    Each branch INNER JOINs ``rdb_db`` (``L``) to ``modern_db`` (``M``) on the
+    key column(s), emits ``(key columns..., column_name, rdb_value,
+    modern_value)`` cast to ``NVARCHAR(4000)``, and is filtered to only the rows
+    where ``L.[col]`` and ``M.[col]`` differ via the NULL-safe
+    ``EXISTS (SELECT L.[col] EXCEPT SELECT M.[col])`` test.
+    """
+    left = _qualified(rdb_db, table)
+    right = _qualified(modern_db, table)
+
+    join_on = " AND ".join(f"L.[{k}] = M.[{k}]" for k in key_cols)
+    key_select = ", ".join(
+        f"CAST(L.[{k}] AS NVARCHAR(4000)) AS [{k}]" for k in key_cols
+    )
+
+    branches = []
+    for col in value_cols:
+        branches.append(
+            f"SELECT {key_select}, "
+            f"N'{col}' AS [column_name], "
+            f"CAST(L.[{col}] AS NVARCHAR(4000)) AS [rdb_value], "
+            f"CAST(M.[{col}] AS NVARCHAR(4000)) AS [modern_value]\n"
+            f"FROM {left} AS L\n"
+            f"INNER JOIN {right} AS M ON {join_on}\n"
+            f"WHERE EXISTS (SELECT L.[{col}] EXCEPT SELECT M.[{col}])"
+        )
+
+    return "\nUNION ALL\n".join(branches)
+
+
+def build_count_sql(table, db):
+    """Build a ``SELECT COUNT(*)`` over ``[db].dbo.[table]``."""
+    return f"SELECT COUNT(*) AS [n] FROM {_qualified(db, table)}"
+
+
+def build_key_duplicate_probe_sql(table, key_cols, db):
+    """Build SQL that returns one row iff the key is *non-unique* in ``db``.
+
+    A resolved ``*_UID`` / ``*_LOCAL_ID`` key is only a valid join key if it
+    uniquely identifies a row. On reference / lookup tables a ``*_UID`` column
+    can repeat across many rows; joining ``RDB`` to ``RDB_MODERN`` on such a key
+    fans out into a many-to-many (near-cartesian) product that can balloon to
+    billions of row pairs and hang the run. This probe -- a cheap single-scan
+    ``GROUP BY ... HAVING COUNT(*) > 1`` capped at one row -- lets the engine
+    detect that case up front and degrade to counts-only instead.
+    """
+    keys = ", ".join(f"[{k}]" for k in key_cols)
+    not_null = " AND ".join(f"[{k}] IS NOT NULL" for k in key_cols)
+    return (
+        f"SELECT TOP 1 1 AS [dup] FROM {_qualified(db, table)} "
+        f"WHERE {not_null} "
+        f"GROUP BY {keys} HAVING COUNT(*) > 1"
+    )
+
+
+def build_key_overlap_sql(table, key_cols, rdb_db, modern_db):
+    """Build SQL returning ``matched_keys``, ``rdb_only_keys``, ``modern_only_keys``.
+
+    Rows with a NULL key are excluded on both sides (they cannot be matched), so
+    the three counts are computed safely against non-NULL keys only.
+    """
+    left = _qualified(rdb_db, table)
+    right = _qualified(modern_db, table)
+
+    join_on = " AND ".join(f"L.[{k}] = M.[{k}]" for k in key_cols)
+    l_not_null = " AND ".join(f"L.[{k}] IS NOT NULL" for k in key_cols)
+    m_not_null = " AND ".join(f"M.[{k}] IS NOT NULL" for k in key_cols)
+    # Correlated NOT EXISTS predicates for the "only" counts.
+    no_match_in_modern = " AND ".join(f"M.[{k}] = L.[{k}]" for k in key_cols)
+    no_match_in_rdb = " AND ".join(f"L.[{k}] = M.[{k}]" for k in key_cols)
+
+    return (
+        "SELECT\n"
+        f"  (SELECT COUNT(*) FROM {left} AS L "
+        f"INNER JOIN {right} AS M ON {join_on} "
+        f"WHERE {l_not_null} AND {m_not_null}) AS [matched_keys],\n"
+        f"  (SELECT COUNT(*) FROM {left} AS L "
+        f"WHERE {l_not_null} AND NOT EXISTS "
+        f"(SELECT 1 FROM {right} AS M WHERE {no_match_in_modern})) AS [rdb_only_keys],\n"
+        f"  (SELECT COUNT(*) FROM {right} AS M "
+        f"WHERE {m_not_null} AND NOT EXISTS "
+        f"(SELECT 1 FROM {left} AS L WHERE {no_match_in_rdb})) AS [modern_only_keys]"
+    )
+
+
+def compare_table(
+    conn,
+    table,
+    key_cols,
+    value_cols,
+    rdb_db,
+    modern_db,
+    sample_cap=20,
+) -> TableResult:
+    """Compare one table across the two databases and return a :class:`TableResult`.
+
+    Populates row counts, key overlap, presence and -- when ``key_cols`` is
+    usable -- one :class:`ColumnDiff` per value column that has any mismatch
+    (``compared`` = matched keys, ``mismatches`` = differing rows, ``samples``
+    capped at ``sample_cap`` :class:`CellDiff`). With no usable key the result
+    carries only counts + presence and ``error`` is set. Any per-table SQL error
+    is caught and recorded on ``result.error``.
+    """
+    result = TableResult(table=table, key_columns=tuple(key_cols or ()))
+
+    try:
+        rdb_rows = db.run_query(conn, build_count_sql(table, rdb_db))
+        modern_rows = db.run_query(conn, build_count_sql(table, modern_db))
+        result.rdb_count = rdb_rows[0]["n"] if rdb_rows else 0
+        result.modern_count = modern_rows[0]["n"] if modern_rows else 0
+
+        if result.rdb_count and not result.modern_count:
+            result.presence = Presence.RDB_ONLY
+        elif result.modern_count and not result.rdb_count:
+            result.presence = Presence.MODERN_ONLY
+        else:
+            result.presence = Presence.BOTH
+
+        if not key_cols:
+            result.error = "no usable key; counts only"
+            return result
+
+        # Guard against a non-unique resolved key: joining on a key that repeats
+        # (common on reference / lookup tables whose *_UID column is a FK, not a
+        # row id) fans the comparison out into a near-cartesian product. Detect
+        # it cheaply on either side and degrade to counts-only rather than hang.
+        for side_db in (rdb_db, modern_db):
+            dup = db.run_query(
+                conn, build_key_duplicate_probe_sql(table, key_cols, side_db)
+            )
+            if dup:
+                result.error = (
+                    f"key {'+'.join(key_cols)} not unique in {side_db}; "
+                    "counts only (would fan out)"
+                )
+                return result
+
+        overlap = db.run_query(
+            conn, build_key_overlap_sql(table, key_cols, rdb_db, modern_db)
+        )
+        if overlap:
+            result.matched_keys = overlap[0].get("matched_keys", 0) or 0
+            result.rdb_only_keys = overlap[0].get("rdb_only_keys", 0) or 0
+            result.modern_only_keys = overlap[0].get("modern_only_keys", 0) or 0
+
+        if not value_cols:
+            return result
+
+        diff_rows = db.run_query(
+            conn,
+            build_value_diff_sql(table, key_cols, value_cols, rdb_db, modern_db),
+        )
+
+        by_column: dict[str, ColumnDiff] = {}
+        for row in diff_rows:
+            col_name = row["column_name"]
+            col = by_column.get(col_name)
+            if col is None:
+                col = ColumnDiff(
+                    table=table, column=col_name, compared=result.matched_keys
+                )
+                by_column[col_name] = col
+            col.mismatches += 1
+            if len(col.samples) < sample_cap:
+                key = tuple(row[k] for k in key_cols)
+                col.samples.append(
+                    CellDiff(
+                        table=table,
+                        key=key,
+                        column=col_name,
+                        rdb_value=row["rdb_value"],
+                        modern_value=row["modern_value"],
+                    )
+                )
+
+        # Preserve value_cols ordering for stable, readable output.
+        result.columns = [
+            by_column[c] for c in value_cols if c in by_column
+        ]
+    except Exception as exc:  # per-table isolation: one bad table != run failure
+        result.error = str(exc)
+
+    return result

--- a/testing-tools/rdb-compare/rdb_compare/keys.py
+++ b/testing-tools/rdb-compare/rdb_compare/keys.py
@@ -1,0 +1,147 @@
+"""Per-table business/UID key resolution for the RDB vs RDB_MODERN comparison.
+
+Rows are matched across the two databases on a table's *business* key -- the
+stable identifier that originates in the source system (ODSE) and is therefore
+identical in both RDB and RDB_MODERN. They are **never** matched on the
+surrogate ``*_KEY`` columns, which carry documented per-table offsets (see the
+reporting-differences page: PATIENT_KEY's offset cascades through every other
+``*_KEY``).
+
+The project convention (from the reporting work and the comparison SQL
+templates) is that the stable cross-DB business key is usually a ``*_LOCAL_ID``
+column (the ODSE local id), occasionally a ``*_UID``. A few tables hold several
+rows per id and need a 2-column key (e.g. ``LAB100`` keys on both
+``LAB_RPT_LOCAL_ID`` and ``LAB_RPT_UID``).
+
+:data:`KEY_CONFIG` pins the keys for tables the page/templates name explicitly;
+everything else falls through to :func:`resolve_keys`'s heuristic
+(``*_LOCAL_ID`` -> ``*_UID`` -> none).
+"""
+
+from __future__ import annotations
+
+# Explicit per-table keys, keyed by UPPERCASE table name. Each value is the
+# tuple of key column(s). Basis cited per entry from /tmp/rtr-diffs.txt (the
+# RTR reporting-differences page) and the in-repo datamart DDL.
+KEY_CONFIG: dict[str, tuple[str, ...]] = {
+    # --- Single-UID tables (PDF "Comparable Records Using a Single UID") -----
+    # The single-UID SQL template ships with @TableName='LAB_TEST',
+    # @UniqueIdColumn='LAB_TEST_UID'.
+    "LAB_TEST": ("LAB_TEST_UID",),
+    # --- Two-id tables (PDF "Comparable Results Using 2 IDs") ----------------
+    # The 2-id SQL template ships with @TableName='LAB100',
+    # @UniqueIdColumn='LAB_RPT_LOCAL_ID', @SecondaryUniqueIdColumn='LAB_RPT_UID'.
+    # The page also notes "LAB_RPT_LOCAL_ID and LAB_RPT_UID were used" for LAB100.
+    "LAB100": ("LAB_RPT_LOCAL_ID", "LAB_RPT_UID"),
+    # --- Patient ------------------------------------------------------------
+    # Probable-bugs section: records were matched on PATIENT_UID; the 2-id
+    # discussion pairs PATIENT_LOCAL_ID with INVESTIGATION_LOCAL_ID. The local
+    # id is the stable cross-DB key for the patient dimension.
+    "D_PATIENT": ("PATIENT_LOCAL_ID",),
+    # --- Investigation ------------------------------------------------------
+    # Page repeatedly matches investigations on INVESTIGATION_LOCAL_ID
+    # (e.g. "The local ID for the investigation is CAS10063001GA01");
+    # INVESTIGATION_KEY (surrogate) is explicitly an offset column and must not
+    # be used.
+    "INVESTIGATION": ("INVESTIGATION_LOCAL_ID",),
+    # --- Morbidity report ---------------------------------------------------
+    # The morbidity_report_datamart DDL exposes MORBIDITY_REPORT_LOCAL_ID; the
+    # page discusses MORBIDITY_REPORT differences keyed on the local id.
+    "MORBIDITY_REPORT": ("MORBIDITY_REPORT_LOCAL_ID",),
+    "MORBIDITY_REPORT_DATAMART": ("MORBIDITY_REPORT_LOCAL_ID",),
+    # --- Notification -------------------------------------------------------
+    # Page lists NOTIFICATION_LOCAL_ID among the compared identifiers; the
+    # datamarts carry NOTIFICATION_LOCAL_ID.
+    "NOTIFICATION": ("NOTIFICATION_LOCAL_ID",),
+    # --- D_INV_* dimensional tables -----------------------------------------
+    # Offset section: "the D_INV_* tables have a column called
+    # NBS_CASE_ANSWER_UID which originates from the ODSE table NBS_CASE_ANSWER.
+    # This value was used to find the NBS_CASE_ANSWER record to ensure the
+    # compared D_INV_* records from both databases were valid." So the stable
+    # cross-DB key for these is NBS_CASE_ANSWER_UID, not the D_INV_*_KEY
+    # surrogate.
+    "D_INV_ADMINISTRATIVE": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_CLINICAL": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_COMPLICATION": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_CONTACT": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_DEATH": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_EPIDEMIOLOGY": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_HIV": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_ISOLATE_TRACKING": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_LAB_FINDING": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_MEDICAL_HISTORY": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_MOTHER": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_OTHER": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_PATIENT_OBS": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_PREGNANCY_BIRTH": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_RESIDENCY": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_RISK_FACTOR": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_SOCIAL_HISTORY": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_SYMPTOM": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_TRAVEL": ("NBS_CASE_ANSWER_UID",),
+    "D_INV_VACCINATION": ("NBS_CASE_ANSWER_UID",),
+}
+
+
+def _suffix_matches(column: str, suffix: str) -> bool:
+    """True if ``column`` ends with ``suffix`` (case-insensitive)."""
+    return column.upper().endswith(suffix.upper())
+
+
+def resolve_keys(
+    table: str, available_columns: tuple[str, ...] | list[str]
+) -> tuple[str, ...] | None:
+    """Resolve the business/UID key column(s) for ``table``.
+
+    Precedence:
+
+    1. If ``UPPER(table)`` is in :data:`KEY_CONFIG` *and* every configured
+       column is present in ``available_columns`` (case-insensitive), return the
+       configured columns, spelled as they actually appear in
+       ``available_columns``.
+    2. Else, if at least one ``*_LOCAL_ID`` column is present, return the single
+       best one: prefer one whose prefix matches the table's entity name, else
+       the first such column in ``available_columns`` order.
+    3. Else, if a ``*_UID`` column exists (and is not a surrogate ``*_KEY``),
+       return it (the first in column order).
+    4. Else ``None`` -- no usable key; the caller compares counts/existence only.
+
+    A surrogate ``*_KEY`` column is **never** returned as a key.
+
+    :param table: table name (any case).
+    :param available_columns: columns actually present on the table.
+    :returns: a tuple of key column name(s) as they appear in
+        ``available_columns``, or ``None``.
+    """
+    cols = list(available_columns)
+    # Case-insensitive lookup: UPPER(col) -> actual spelling (first wins).
+    by_upper: dict[str, str] = {}
+    for c in cols:
+        by_upper.setdefault(c.upper(), c)
+
+    # (1) Configured keys -- require every configured column to be available.
+    configured = KEY_CONFIG.get(table.upper())
+    if configured and all(c.upper() in by_upper for c in configured):
+        return tuple(by_upper[c.upper()] for c in configured)
+
+    # (2) *_LOCAL_ID columns, preferring an entity-matching prefix.
+    local_ids = [c for c in cols if _suffix_matches(c, "_LOCAL_ID")]
+    if local_ids:
+        entity = table.upper().lstrip("D_").lstrip("F_")  # strip dim/fact prefix
+        for c in local_ids:
+            prefix = c.upper()[: -len("_LOCAL_ID")]
+            if prefix and (entity.startswith(prefix) or prefix.startswith(entity)):
+                return (c,)
+        return (local_ids[0],)
+
+    # (3) *_UID fallback, never a surrogate *_KEY.
+    uids = [
+        c
+        for c in cols
+        if _suffix_matches(c, "_UID") and not _suffix_matches(c, "_KEY")
+    ]
+    if uids:
+        return (uids[0],)
+
+    # (4) Nothing usable.
+    return None

--- a/testing-tools/rdb-compare/rdb_compare/models.py
+++ b/testing-tools/rdb-compare/rdb_compare/models.py
@@ -1,0 +1,153 @@
+"""Shared data contracts for the RDB vs RDB_MODERN comparison.
+
+Every module in :mod:`rdb_compare` agrees on these dataclasses. The comparison
+*engine* produces :class:`TableResult` objects (raw, unclassified); the
+*classifier* annotates each finding with a :class:`Classification` by consulting
+the rule registry; the *report* layer renders the annotated results to JSON/MD.
+
+The comparison is UID-keyed and column-by-column (see the PDF templates): rows
+are matched on a table's business/UID key(s) -- never the surrogate ``*_KEY``
+columns, which carry documented offsets -- and every non-key column is compared
+NULL-aware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+# Sentinel meaning "no value supplied" (distinct from SQL NULL, which is None).
+class _Unset:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        return "UNSET"
+
+    def __bool__(self):
+        return False
+
+
+UNSET = _Unset()
+
+
+class Verdict(str, Enum):
+    """How a raw difference should be interpreted."""
+
+    NEW = "NEW"             # Unexpected -- not covered by any rule; needs attention.
+    EXPECTED = "EXPECTED"   # Documented, by-design difference.
+    KNOWN_BUG = "KNOWN_BUG"  # Documented probable bug (has a ticket/PDF reference).
+    IGNORED = "IGNORED"     # Structurally uninteresting (skip table, env/timestamp,
+                            # surrogate-key offset, audit column).
+
+    def __str__(self) -> str:  # nice rendering in reports
+        return self.value
+
+
+@dataclass(frozen=True)
+class Classification:
+    """The verdict the rule registry assigns to a finding."""
+
+    verdict: Verdict
+    rule_id: Optional[str] = None  # e.g. "SKIP-ETL", "BUG-D_PLACE", "EXP-EVENT_DATE_TYPE"
+    reason: str = ""
+
+    @property
+    def is_actionable(self) -> bool:
+        """NEW findings are the ones a human needs to look at."""
+        return self.verdict == Verdict.NEW
+
+
+@dataclass(frozen=True)
+class CellDiff:
+    """A single (row-key, column) value mismatch."""
+
+    table: str
+    key: tuple              # the UID value(s) identifying the row
+    column: str
+    rdb_value: Any
+    modern_value: Any
+
+
+@dataclass
+class ColumnDiff:
+    """Aggregated mismatch information for one column of one table."""
+
+    table: str
+    column: str
+    compared: int = 0                 # rows present in BOTH and thus comparable
+    mismatches: int = 0               # of those, how many differ
+    samples: list = field(default_factory=list)  # list[CellDiff], capped
+    classification: Optional[Classification] = None
+
+    @property
+    def mismatch_rate(self) -> float:
+        return (self.mismatches / self.compared) if self.compared else 0.0
+
+
+class Presence(str, Enum):
+    BOTH = "both"
+    RDB_ONLY = "rdb_only"
+    MODERN_ONLY = "modern_only"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class TableResult:
+    """Comparison outcome for a single table."""
+
+    table: str
+    presence: Presence = Presence.BOTH
+    key_columns: tuple = ()
+    rdb_count: int = 0
+    modern_count: int = 0
+    matched_keys: int = 0             # keys present in both
+    rdb_only_keys: int = 0            # keys only in RDB
+    modern_only_keys: int = 0         # keys only in RDB_MODERN
+    columns: list = field(default_factory=list)  # list[ColumnDiff] (mismatching columns)
+    skipped: bool = False
+    skip_reason: Optional[str] = None
+    # Classification attached to a *table-level* observation (skip, or a
+    # row-count/existence difference). Column-level verdicts live on each ColumnDiff.
+    classification: Optional[Classification] = None
+    error: Optional[str] = None       # populated if the table could not be compared
+
+    @property
+    def row_count_matches(self) -> bool:
+        return self.rdb_count == self.modern_count
+
+    @property
+    def has_column_mismatches(self) -> bool:
+        return any(c.mismatches for c in self.columns)
+
+
+@dataclass
+class RunReport:
+    """The full comparison run."""
+
+    rdb_db: str
+    modern_db: str
+    generated_at: str = ""            # ISO timestamp, stamped by the caller
+    tables: list = field(default_factory=list)  # list[TableResult]
+    discovered: int = 0               # tables found in common
+    skipped: int = 0                  # tables skipped by rule
+    compared: int = 0                 # tables actually compared
+
+    def actionable_tables(self) -> list:
+        """Tables with at least one NEW (unexplained) column difference."""
+        out = []
+        for t in self.tables:
+            if any(
+                c.classification and c.classification.verdict == Verdict.NEW
+                for c in t.columns
+            ):
+                out.append(t)
+        return out

--- a/testing-tools/rdb-compare/rdb_compare/report.py
+++ b/testing-tools/rdb-compare/rdb_compare/report.py
@@ -1,0 +1,332 @@
+"""Render a classified :class:`~rdb_compare.models.RunReport` to JSON and Markdown.
+
+This is the *report* layer (see :mod:`rdb_compare.models` for the contract): the
+engine produces raw :class:`~rdb_compare.models.TableResult` objects, the
+classifier annotates each finding with a :class:`~rdb_compare.models.Classification`,
+and this module turns the annotated run into deliverables -- a fully
+JSON-serializable dict (for machines/diffing) and a human-readable Markdown
+report that leads with the differences a person actually needs to look at (NEW),
+then known bugs, then expected, then the structurally-uninteresting tail.
+
+Nothing here mutates the report; rendering is a pure read-only pass.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from rdb_compare.classifier import summarize
+from rdb_compare.models import (
+    Classification,
+    ColumnDiff,
+    RunReport,
+    TableResult,
+    Verdict,
+)
+
+# Verdict ordering used to surface the actionable findings first.
+_VERDICT_ORDER = {
+    Verdict.NEW: 0,
+    Verdict.KNOWN_BUG: 1,
+    Verdict.EXPECTED: 2,
+    Verdict.IGNORED: 3,
+}
+
+# How many cell samples to inline per column in the Markdown report.
+_MAX_INLINE_SAMPLES = 3
+# Truncate long sample values so the Markdown table stays readable.
+_MAX_VALUE_LEN = 40
+
+
+# --- helpers ------------------------------------------------------------
+
+
+def _verdict_of(col: ColumnDiff) -> Verdict:
+    """The verdict for a column, treating an unclassified column as NEW."""
+    return col.classification.verdict if col.classification else Verdict.NEW
+
+
+def _ordered_columns(table: TableResult) -> list:
+    """Columns ordered NEW-first, then known-bug/expected/ignored, then by name."""
+    return sorted(
+        table.columns,
+        key=lambda c: (_VERDICT_ORDER.get(_verdict_of(c), 99), c.column),
+    )
+
+
+def _trunc(value: Any) -> str:
+    """Render a cell value as a short, single-line string for inline samples."""
+    if value is None:
+        return "NULL"
+    text = str(value).replace("\n", " ").replace("\r", " ")
+    if len(text) > _MAX_VALUE_LEN:
+        return text[: _MAX_VALUE_LEN - 1] + "…"
+    return text
+
+
+def _classification_dict(cls: Optional[Classification]) -> dict:
+    """JSON-friendly form of a classification (defaulting to NEW when absent)."""
+    if cls is None:
+        return {"verdict": Verdict.NEW.value, "rule_id": None, "reason": ""}
+    return {
+        "verdict": cls.verdict.value,
+        "rule_id": cls.rule_id,
+        "reason": cls.reason,
+    }
+
+
+# --- JSON ---------------------------------------------------------------
+
+
+def to_dict(report: RunReport) -> dict:
+    """Convert a classified run to a fully JSON-serializable dict.
+
+    Enums become their ``.value``, tuples become lists, and every dataclass is
+    expanded into a plain dict. The result embeds the :func:`summarize` rollup
+    and per-table/per-column detail (presence, counts, matched/only key counts,
+    key columns, and each column's compared/mismatches/rate/classification plus
+    capped value samples).
+    """
+    return {
+        "rdb_db": report.rdb_db,
+        "modern_db": report.modern_db,
+        "generated_at": report.generated_at,
+        "discovered": report.discovered,
+        "skipped": report.skipped,
+        "compared": report.compared,
+        "summary": summarize(report),
+        "tables": [_table_to_dict(t) for t in report.tables],
+    }
+
+
+def _table_to_dict(table: TableResult) -> dict:
+    return {
+        "table": table.table,
+        "presence": table.presence.value,
+        "key_columns": list(table.key_columns),
+        "rdb_count": table.rdb_count,
+        "modern_count": table.modern_count,
+        "row_count_matches": table.row_count_matches,
+        "matched_keys": table.matched_keys,
+        "rdb_only_keys": table.rdb_only_keys,
+        "modern_only_keys": table.modern_only_keys,
+        "skipped": table.skipped,
+        "skip_reason": table.skip_reason,
+        "error": table.error,
+        "classification": (
+            _classification_dict(table.classification)
+            if table.classification
+            else None
+        ),
+        "columns": [_column_to_dict(c) for c in table.columns],
+    }
+
+
+def _column_to_dict(col: ColumnDiff) -> dict:
+    return {
+        "column": col.column,
+        "compared": col.compared,
+        "mismatches": col.mismatches,
+        "mismatch_rate": col.mismatch_rate,
+        "classification": _classification_dict(col.classification),
+        "samples": [_sample_to_dict(s) for s in col.samples],
+    }
+
+
+def _sample_to_dict(cell) -> dict:
+    return {
+        "key": list(cell.key),
+        "rdb_value": cell.rdb_value,
+        "modern_value": cell.modern_value,
+    }
+
+
+def render_json(report: RunReport) -> str:
+    """Return the JSON text for a run (indent=2, non-JSON values via ``str``)."""
+    return json.dumps(to_dict(report), indent=2, default=str)
+
+
+def write_json(report: RunReport, path) -> None:
+    """Write the run's JSON form to ``path``."""
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(render_json(report))
+
+
+# --- Markdown -----------------------------------------------------------
+
+
+def _samples_cell(col: ColumnDiff) -> str:
+    """Inline ``rdb -> modern`` samples for a column, capped and truncated."""
+    if not col.samples:
+        return ""
+    parts = []
+    for s in col.samples[:_MAX_INLINE_SAMPLES]:
+        parts.append(f"`{_trunc(s.rdb_value)}` → `{_trunc(s.modern_value)}`")
+    extra = len(col.samples) - _MAX_INLINE_SAMPLES
+    if extra > 0:
+        parts.append(f"(+{extra} more)")
+    return "; ".join(parts)
+
+
+def _column_rows(table: TableResult) -> list:
+    """Markdown table rows (NEW-first) for a table's differing columns."""
+    rows = []
+    for col in _ordered_columns(table):
+        cls = col.classification or Classification(Verdict.NEW)
+        rate = f"{col.mismatch_rate * 100:.1f}%"
+        rule = cls.rule_id or "-"
+        rows.append(
+            "| {col} | {compared} | {mm} | {rate} | {verdict} | {rule} | {samples} |".format(
+                col=col.column,
+                compared=col.compared,
+                mm=col.mismatches,
+                rate=rate,
+                verdict=cls.verdict.value,
+                rule=rule,
+                samples=_samples_cell(col),
+            )
+        )
+    return rows
+
+
+def _table_section(table: TableResult) -> list:
+    """Markdown lines for one non-skipped table that has differences."""
+    lines = [f"### `{table.table}`", ""]
+    key_cols = ", ".join(table.key_columns) if table.key_columns else "(none)"
+    lines.append(f"- Presence: `{table.presence.value}`")
+    lines.append(f"- Key columns: {key_cols}")
+    count_note = "" if table.row_count_matches else " (differs)"
+    lines.append(
+        f"- Row counts: RDB={table.rdb_count}, RDB_MODERN={table.modern_count}{count_note}"
+    )
+    lines.append(
+        "- Keys: matched={m}, rdb-only={r}, modern-only={n}".format(
+            m=table.matched_keys, r=table.rdb_only_keys, n=table.modern_only_keys
+        )
+    )
+    if table.classification is not None:
+        lines.append(
+            "- Table note: {v} ({rid}) -- {reason}".format(
+                v=table.classification.verdict.value,
+                rid=table.classification.rule_id or "-",
+                reason=table.classification.reason,
+            )
+        )
+    lines.append("")
+    if table.columns:
+        lines.append(
+            "| Column | Compared | Mismatches | Rate | Verdict | Rule | Sample (rdb → modern) |"
+        )
+        lines.append("| --- | ---: | ---: | ---: | --- | --- | --- |")
+        lines.extend(_column_rows(table))
+        lines.append("")
+    return lines
+
+
+def _has_verdict(table: TableResult, verdict: Verdict) -> bool:
+    return any(_verdict_of(c) == verdict for c in table.columns)
+
+
+def render_markdown(report: RunReport) -> str:
+    """Return a human-readable Markdown report for a classified run.
+
+    The report leads with the summary, then the tables needing attention (NEW
+    differences), then known-bug tables, then expected-difference tables, and
+    finally a compact list of skipped/ignored tables.
+    """
+    s = summarize(report)
+    lines: list = []
+
+    lines.append("# RDB vs RDB_MODERN Comparison Report")
+    lines.append("")
+    lines.append(f"- RDB (legacy): `{report.rdb_db}`")
+    lines.append(f"- RDB_MODERN: `{report.modern_db}`")
+    lines.append(f"- Generated at: {report.generated_at or '(unset)'}")
+    lines.append("")
+
+    # Summary table.
+    counts = s["verdict_counts"]
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Count |")
+    lines.append("| --- | ---: |")
+    lines.append(f"| Tables discovered | {s['tables_discovered']} |")
+    lines.append(f"| Tables compared | {s['tables_compared']} |")
+    lines.append(f"| Tables skipped | {s['tables_skipped']} |")
+    lines.append(f"| Tables needing attention | {s['actionable_tables']} |")
+    lines.append(f"| Column diffs: NEW | {counts[Verdict.NEW.value]} |")
+    lines.append(f"| Column diffs: KNOWN_BUG | {counts[Verdict.KNOWN_BUG.value]} |")
+    lines.append(f"| Column diffs: EXPECTED | {counts[Verdict.EXPECTED.value]} |")
+    lines.append(f"| Column diffs: IGNORED | {counts[Verdict.IGNORED.value]} |")
+    lines.append("")
+
+    # Partition the non-skipped tables by their highest-priority verdict.
+    non_skipped = [t for t in report.tables if not t.skipped]
+    skipped = [t for t in report.tables if t.skipped]
+
+    new_tables = [t for t in non_skipped if _has_verdict(t, Verdict.NEW)]
+    bug_tables = [
+        t
+        for t in non_skipped
+        if t not in new_tables and _has_verdict(t, Verdict.KNOWN_BUG)
+    ]
+    expected_tables = [
+        t
+        for t in non_skipped
+        if t not in new_tables
+        and t not in bug_tables
+        and _has_verdict(t, Verdict.EXPECTED)
+    ]
+
+    lines.append("## Tables needing attention (NEW differences)")
+    lines.append("")
+    if new_tables:
+        for t in new_tables:
+            lines.extend(_table_section(t))
+    else:
+        lines.append("_None -- no unexplained differences._")
+        lines.append("")
+
+    lines.append("## Known-bug differences")
+    lines.append("")
+    if bug_tables:
+        for t in bug_tables:
+            lines.extend(_table_section(t))
+    else:
+        lines.append("_None._")
+        lines.append("")
+
+    lines.append("## Expected differences")
+    lines.append("")
+    if expected_tables:
+        for t in expected_tables:
+            lines.extend(_table_section(t))
+    else:
+        lines.append("_None._")
+        lines.append("")
+
+    lines.append("## Skipped / ignored tables")
+    lines.append("")
+    if skipped:
+        for t in skipped:
+            reason = t.skip_reason or (
+                t.classification.reason if t.classification else ""
+            )
+            rid = (
+                t.classification.rule_id
+                if t.classification and t.classification.rule_id
+                else "-"
+            )
+            lines.append(f"- `{t.table}` ({rid}): {reason}")
+    else:
+        lines.append("_None._")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_markdown(report: RunReport, path) -> None:
+    """Write the run's Markdown report to ``path``."""
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(render_markdown(report))

--- a/testing-tools/rdb-compare/rdb_compare/rules/__init__.py
+++ b/testing-tools/rdb-compare/rdb_compare/rules/__init__.py
@@ -1,0 +1,87 @@
+"""The known-differences rule registry.
+
+A :class:`RuleRegistry` holds an ordered list of :class:`~rdb_compare.rules.types.Rule`
+objects and answers two questions for the classifier:
+
+* :meth:`classify_table` -- is this whole table skipped?
+* :meth:`classify_column` -- given a column's mismatches, what verdict applies?
+
+Rules are consulted in ``sort_key`` order (skip < known-bug < expected < ignore,
+exact before glob); the first matching rule wins. A column with no matching rule
+is classified ``NEW`` -- an unexplained difference that needs human attention.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from rdb_compare.models import Classification, Verdict
+from rdb_compare.rules.types import (
+    ExpectedDiffRule,
+    IgnoreColumnRule,
+    KnownBugRule,
+    Rule,
+    SkipTableRule,
+)
+
+__all__ = [
+    "RuleRegistry",
+    "Rule",
+    "SkipTableRule",
+    "IgnoreColumnRule",
+    "ExpectedDiffRule",
+    "KnownBugRule",
+]
+
+# The verdict for a difference no rule explains.
+UNEXPLAINED = Classification(
+    verdict=Verdict.NEW,
+    rule_id=None,
+    reason="No rule matched -- unexplained difference",
+)
+
+
+class RuleRegistry:
+    def __init__(self, rules: Optional[Iterable[Rule]] = None):
+        self._rules = sorted(rules or [], key=lambda r: r.sort_key())
+
+    def add(self, rule: Rule) -> None:
+        self._rules.append(rule)
+        self._rules.sort(key=lambda r: r.sort_key())
+
+    def extend(self, rules: Iterable[Rule]) -> None:
+        for r in rules:
+            self._rules.append(r)
+        self._rules.sort(key=lambda r: r.sort_key())
+
+    @property
+    def rules(self) -> list:
+        return list(self._rules)
+
+    def __len__(self) -> int:
+        return len(self._rules)
+
+    # --- classification -------------------------------------------------
+    def classify_table(self, table: str) -> Optional[Classification]:
+        """Return an IGNORED classification if the table is skipped, else None."""
+        for r in self._rules:
+            if r.scope == "table" and r.matches_table(table):
+                return Classification(r.verdict, r.id, r.reason)
+        return None
+
+    def is_skipped(self, table: str) -> bool:
+        c = self.classify_table(table)
+        return c is not None and c.verdict == Verdict.IGNORED
+
+    def classify_column(self, table: str, column: str, cells=()) -> Classification:
+        """Classify a column's mismatches.
+
+        ``cells`` is the list of :class:`~rdb_compare.models.CellDiff` for this
+        column; value-predicate rules only apply when they explain *all* of them.
+        """
+        for r in self._rules:
+            if r.scope != "column":
+                continue
+            if r.matches_column(table, column) and r.applies_to_cells(cells):
+                return Classification(r.verdict, r.id, r.reason)
+        return UNEXPLAINED

--- a/testing-tools/rdb-compare/rdb_compare/rules/catalog.py
+++ b/testing-tools/rdb-compare/rdb_compare/rules/catalog.py
@@ -1,0 +1,903 @@
+"""The default known-differences catalog, transcribed from the RTR page.
+
+This module is the single, human-curated source of truth that turns the
+"RTR reporting differences" page into executable :class:`~rdb_compare.rules.types.Rule`
+objects. :func:`build_default_registry` assembles every rule into a populated
+:class:`~rdb_compare.rules.RuleRegistry` for the classifier.
+
+The rules are grouped to mirror the page's own sections:
+
+* **SKIP_TABLES** -- "RDB Tables Not Considered for Comparison": whole tables /
+  table families excluded from the comparison.
+* **IGNORE_COLUMNS** -- "Identified Offset for ``_KEY`` Columns" (surrogate-key
+  offsets, ``category="key_offset"``) and the environment/timestamp columns the
+  page repeatedly calls out as non-issues (``category="env_timestamp"``).
+* **EXPECTED** -- "Expected Differences": documented, by-design divergences.
+* **KNOWN_BUGS** -- "Unexpected Differences (Probable Bugs)": documented probable
+  defects, each with a short ``RTR-diffs:bug-<n>`` reference.
+
+Where the page names exact ``table.column`` pairs, the rule is column-specific;
+where it only names a table (e.g. "D_PLACE is not populated") the rule uses a
+``"*"`` column pattern and the reason explains the scope. Predicates are attached
+where the page describes the *shape* of the difference (NULL-in-RDB vs populated,
+NULL vs empty-string, etc.) so a column only gets the documented verdict when its
+mismatches actually fit that shape.
+"""
+
+from __future__ import annotations
+
+from rdb_compare.rules import (
+    ExpectedDiffRule,
+    IgnoreColumnRule,
+    KnownBugRule,
+    RuleRegistry,
+    SkipTableRule,
+)
+from rdb_compare.rules.predicates import (
+    modern_null_rdb_set,
+    null_vs_empty,
+    rdb_null_modern_set,
+)
+
+
+# =====================================================================
+# RDB Tables Not Considered for Comparison  -> SkipTableRule
+# =====================================================================
+# The page lists explicit ETL/event-metric tables plus several table
+# *families* identified by prefix, and RDB_MODERN-only staging tables.
+SKIP_TABLES = [
+    # --- explicitly named skip-list tables ---
+    SkipTableRule("ETL_DQ_LOG", "Skip-list: ETL data-quality log, not compared.", id="SKIP-ETL_DQ_LOG"),
+    SkipTableRule(
+        "ETL_HEALTH_CHECK_PAT_DATA",
+        "Skip-list: ETL health-check table, not compared.",
+        id="SKIP-ETL_HEALTH_CHECK_PAT_DATA",
+    ),
+    SkipTableRule("ETL_MISSING_PATIENT", "Skip-list: ETL bookkeeping table, not compared.", id="SKIP-ETL_MISSING_PATIENT"),
+    SkipTableRule("ETL_MISSING_RECORD", "Skip-list: ETL bookkeeping table, not compared.", id="SKIP-ETL_MISSING_RECORD"),
+    SkipTableRule("ETL_PROCESS", "Skip-list: ETL process bookkeeping, not compared.", id="SKIP-ETL_PROCESS"),
+    SkipTableRule(
+        "EVENT_METRIC",
+        "Skip-list: time-bound metric table (RDB holds only ~last 30 days; RTR "
+        "does not age records out), so it is excluded from comparison.",
+        id="SKIP-EVENT_METRIC",
+    ),
+    SkipTableRule(
+        "EVENT_METRIC_INC",
+        "Skip-list: time-bound incremental metric table, excluded from comparison.",
+        id="SKIP-EVENT_METRIC_INC",
+    ),
+    # --- table families named by prefix ---
+    SkipTableRule("ETL_*", "Skip-list: all ETL_* bookkeeping/process tables.", id="SKIP-ETL_PREFIX"),
+    SkipTableRule("L_*", "Skip-list: lookup tables (prefixed L_).", id="SKIP-LOOKUP_L_PREFIX"),
+    SkipTableRule("LOOKUP_*", "Skip-list: lookup tables (prefixed LOOKUP_).", id="SKIP-LOOKUP_PREFIX"),
+    SkipTableRule("S_*", "Skip-list: staging tables (prefixed S_).", id="SKIP-STAGING_S_PREFIX"),
+    SkipTableRule("SAS_*", "Skip-list: SAS tables (prefixed SAS_).", id="SKIP-SAS_PREFIX"),
+    SkipTableRule(
+        "TEMP_*",
+        "Skip-list: temporary tables (prefixed TEMP_, case-insensitive).",
+        id="SKIP-TEMP_PREFIX",
+    ),
+    SkipTableRule(
+        "nrt_*",
+        "Skip-list: RDB_MODERN-only staging tables (e.g. nrt_investigation, "
+        "nrt_patient); no RDB counterpart to compare.",
+        id="SKIP-NRT_PREFIX",
+    ),
+    # --- APP-720: transient SELECT INTO scratch / working tables ---
+    # These are intermediate tables the SAS MasterETL and RTR pipelines build
+    # with SELECT INTO mid-run (UID worklists, staging/keystores, *_REPT report
+    # intermediates, temp/incremental scratch). They are not reporting output:
+    # in the captured runs they were `presence=both` with no column verdict, and
+    # whether they exist at scan time depends on run timing/cleanup -- so counting
+    # them in discovered/compared makes the totals non-comparable run-to-run
+    # (the spurious "7.12=202 vs 7.13=180" table-count delta). The existing
+    # ETL_*/L_*/S_*/SAS_*/TEMP_* families miss them only because those globs are
+    # prefix-anchored. Patterns below are scoped to match ONLY these scratch
+    # tables in the APP-720 7.12/7.13 universe (verified -- no real comparand hit).
+    SkipTableRule("PHC_*", "Skip-list: transient PHC UID worklists/keys built via SELECT INTO; not reporting output.", id="SKIP-PHC_PREFIX"),
+    SkipTableRule("*_REPT", "Skip-list: SAS report-build intermediate tables (suffix _REPT); not compared.", id="SKIP-REPT_SUFFIX"),
+    SkipTableRule("*_REPT_*", "Skip-list: SAS report-build intermediate/temp tables (e.g. *_REPT_TEMP, *_REPT_FINAL).", id="SKIP-REPT_INFIX"),
+    SkipTableRule("STAGING_*", "Skip-list: staging tables (prefixed STAGING_).", id="SKIP-STAGING_PREFIX"),
+    SkipTableRule("*_KEYS", "Skip-list: key-mapping scratch tables (suffix _KEYS, e.g. DIMENSIONAL_KEYS, PHC_KEYS).", id="SKIP-KEYS_SUFFIX"),
+    SkipTableRule("*KEYSTORE*", "Skip-list: entity keystore scratch tables (e.g. ENTITY_KEYSTORE_STD/INC).", id="SKIP-KEYSTORE"),
+    SkipTableRule("TMP_*", "Skip-list: temporary tables (prefixed TMP_; complements TEMP_*).", id="SKIP-TMP_PREFIX"),
+    SkipTableRule("*TEMP_INC", "Skip-list: incremental temp scratch (e.g. F_PAGE_CASE_TEMP_INC); TEMP_* glob is prefix-only.", id="SKIP-TEMP_INC_SUFFIX"),
+    SkipTableRule("UPDATED_*_LIST", "Skip-list: ETL delta worklists (e.g. UPDATED_OBSERVATION_LIST); not reporting output.", id="SKIP-UPDATED_LIST"),
+    SkipTableRule("DIMENSION_KEYS_PAGECASEID", "Skip-list: page-case-id key-mapping scratch table.", id="SKIP-DIMENSION_KEYS_PAGECASEID"),
+    SkipTableRule("ACTIVITY_LOG_MASTER_LAST_SAS", "Skip-list: SAS MasterETL run-bookkeeping table; not compared.", id="SKIP-ACTIVITY_LOG_MASTER_LAST_SAS"),
+    SkipTableRule("INIT", "Skip-list: ETL init/bootstrap scratch table; not reporting output.", id="SKIP-INIT"),
+    # F_S_* are staging fact intermediates (the _S_ infix mirrors the existing
+    # S_* staging family). Only these two were verified transient (they dropped
+    # out of the 7.13 scan); F_S_TB_PAM / F_S_VAR_PAM persist in both runs and
+    # are left in scope pending confirmation -- revisit whether F_S_* should be a
+    # family skip once those two are characterized.
+    SkipTableRule("F_S_INV_CASE", "Skip-list: staging fact intermediate (SELECT INTO); not reporting output.", id="SKIP-F_S_INV_CASE"),
+    SkipTableRule("F_S_STD_HIV_CASE", "Skip-list: staging fact intermediate (SELECT INTO); not reporting output.", id="SKIP-F_S_STD_HIV_CASE"),
+]
+
+
+# =====================================================================
+# Identified Offset for _KEY Columns + environment/timestamp columns
+#   -> IgnoreColumnRule
+# =====================================================================
+IGNORE_COLUMNS = [
+    # --- surrogate-key offsets (category="key_offset") ---
+    # The PATIENT_KEY offset in D_PATIENT cascades into every *_KEY column.
+    # MasterETL not capturing the very first patient record shifts the
+    # surrogate keys, so all *_KEY columns carry a documented offset.
+    IgnoreColumnRule(
+        "*_KEY",
+        "Identified Offset for _KEY Columns: surrogate *_KEY values carry a "
+        "documented offset (the D_PATIENT PATIENT_KEY offset cascades through "
+        "all *_KEY columns). Rows are matched on business/UID keys, not *_KEY. "
+        "A value of 1 typically flags missing/unfetched data and is worth a "
+        "double-check.",
+        category="key_offset",
+        id="IGN-key_offset-ALL",
+    ),
+    IgnoreColumnRule(
+        "RESULTED_LAB_TEST_KEY",
+        "Identified Offset for _KEY Columns: RESULTED_LAB_TEST_KEY shares the "
+        "LAB_TEST_KEY offset behaviour.",
+        category="key_offset",
+        id="IGN-key_offset-RESULTED_LAB_TEST_KEY",
+    ),
+    IgnoreColumnRule(
+        "INVESTIGATION_KEYS",
+        "Identified Offset for _KEY Columns: plural INVESTIGATION_KEYS column "
+        "(e.g. in LAB100) carries the same surrogate-key offset.",
+        category="key_offset",
+        id="IGN-key_offset-INVESTIGATION_KEYS",
+    ),
+    # --- environment / refresh timestamp columns (category="env_timestamp") ---
+    # RTR and the SAS/MasterETL environments stamp refresh/update times at
+    # different moments, so these never match and are non-issues.
+    IgnoreColumnRule(
+        "RDB_LAST_REFRESH_TIME",
+        "Environment timestamp: RDB_LAST_REFRESH_TIME reflects when each "
+        "pipeline refreshed the table (SAS/MasterETL vs RTR services); values "
+        "differ by environment date/time configuration and are a non-issue.",
+        category="env_timestamp",
+        id="IGN-env_timestamp-RDB_LAST_REFRESH_TIME",
+    ),
+    IgnoreColumnRule(
+        "*_LAST_REFRESH_TIME",
+        "Environment timestamp: any *_LAST_REFRESH_TIME column reflects the "
+        "differing refresh process between MasterETL and RTR; non-issue.",
+        category="env_timestamp",
+        id="IGN-env_timestamp-LAST_REFRESH_TIME",
+    ),
+    IgnoreColumnRule(
+        "*_LAST_UPDATE_DT",
+        "Environment timestamp: *_LAST_UPDATE_DT values diverge because of "
+        "date/time configuration differences between the SAS and RTR "
+        "environments (e.g. LAB_RPT_LAST_UPDATE_DT on LAB_TEST/LAB100).",
+        category="env_timestamp",
+        id="IGN-env_timestamp-LAST_UPDATE_DT",
+    ),
+    IgnoreColumnRule(
+        "*_LAST_CHANGE_TIME",
+        "Environment timestamp: *_LAST_CHANGE_TIME values can differ by a few "
+        "days where NBS6 defects were corrected in NBS7 / RTR (e.g. "
+        "PATIENT_LAST_CHANGE_TIME on D_PATIENT); treated as env/timestamp.",
+        category="env_timestamp",
+        id="IGN-env_timestamp-LAST_CHANGE_TIME",
+    ),
+    IgnoreColumnRule(
+        "PHC_LAST_CHG_TIME",
+        "Environment timestamp: PHC_LAST_CHG_TIME can hold an outdated stamp in "
+        "legacy RDB (e.g. CASE_LAB_DATAMART); RTR populates correctly.",
+        category="env_timestamp",
+        id="IGN-env_timestamp-PHC_LAST_CHG_TIME",
+    ),
+]
+
+
+# =====================================================================
+# Expected Differences  -> ExpectedDiffRule
+# =====================================================================
+# Documented, by-design divergences. Many follow the "NULL in legacy RDB,
+# correctly populated in RDB_MODERN" shape (NBS6 defects fixed in NBS7),
+# so they carry the rdb_null_modern_set predicate.
+EXPECTED = [
+    # LDF_DIMENSIONAL_DATA vs staging existence note (APP-607).
+    ExpectedDiffRule(
+        "LDF_DIMENSIONAL_DATA",
+        "*",
+        "Expected: LDF_DIMENSIONAL_DATA does not exist in RDB but is populated "
+        "in RDB_MODERN; the S_LDF_DIMENSIONAL_DATA staging side is the inverse "
+        "(APP-607).",
+        id="EXP-LDF_DIMENSIONAL_DATA",
+    ),
+    # 3. EVENT_METRIC(_INC) ADD_USER_NAME / LAST_CHG_USER_NAME populated in modern.
+    ExpectedDiffRule(
+        "EVENT_METRIC*",
+        "ADD_USER_NAME",
+        "Expected: RDB EVENT_METRIC/EVENT_METRIC_INC is missing ADD_USER_NAME, "
+        "while RDB_Modern populates it correctly.",
+        predicate=rdb_null_modern_set,
+        id="EXP-EVENT_METRIC-ADD_USER_NAME",
+    ),
+    ExpectedDiffRule(
+        "EVENT_METRIC*",
+        "LAST_CHG_USER_NAME",
+        "Expected: RDB EVENT_METRIC/EVENT_METRIC_INC is missing "
+        "LAST_CHG_USER_NAME, while RDB_Modern populates it correctly.",
+        predicate=rdb_null_modern_set,
+        id="EXP-EVENT_METRIC-LAST_CHG_USER_NAME",
+    ),
+    # 8. CASE_LAB_DATAMART.EVENT_DATE_TYPE NULL in RDB, populated in modern.
+    ExpectedDiffRule(
+        "CASE_LAB_DATAMART",
+        "EVENT_DATE_TYPE",
+        "Expected: EVENT_DATE_TYPE is NULL in legacy RDB but populated (e.g. "
+        "'Illness Onset Date') in RDB_MODERN; RTR correctly derives it.",
+        predicate=rdb_null_modern_set,
+        id="EXP-CASE_LAB_DATAMART-EVENT_DATE_TYPE",
+    ),
+    # 9. D_INV_MEDICAL_HISTORY: three fields NULL in RDB, populated in modern.
+    ExpectedDiffRule(
+        "D_INV_MEDICAL_HISTORY",
+        "MDH_PREEXISTING_COND_IND",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN "
+        "(RTR consolidates question/answer combos to a single "
+        "nbs_case_answer_uid).",
+        predicate=rdb_null_modern_set,
+        id="EXP-D_INV_MEDICAL_HISTORY-MDH_PREEXISTING_COND_IND",
+    ),
+    ExpectedDiffRule(
+        "D_INV_MEDICAL_HISTORY",
+        "MDH_REASON_FOR_TEST",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN "
+        "(e.g. 'Screening').",
+        predicate=rdb_null_modern_set,
+        id="EXP-D_INV_MEDICAL_HISTORY-MDH_REASON_FOR_TEST",
+    ),
+    ExpectedDiffRule(
+        "D_INV_MEDICAL_HISTORY",
+        "MDH_SYMPTOMATIC",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN "
+        "(e.g. 'Yes').",
+        predicate=rdb_null_modern_set,
+        id="EXP-D_INV_MEDICAL_HISTORY-MDH_SYMPTOMATIC",
+    ),
+    # 11. D_INV_SOCIAL_HISTORY: pipe-doubled values cleaned up in NBS7.
+    ExpectedDiffRule(
+        "D_INV_SOCIAL_HISTORY",
+        "SOC_PLACES_TO_HAVE_SEX",
+        "Expected: legacy RDB stored doubled values (e.g. 'Yes|Yes'); NBS7/RTR "
+        "stores the de-duplicated value (e.g. 'Yes') -- a data-quality "
+        "improvement.",
+        id="EXP-D_INV_SOCIAL_HISTORY-SOC_PLACES_TO_HAVE_SEX",
+    ),
+    ExpectedDiffRule(
+        "D_INV_SOCIAL_HISTORY",
+        "PLACES_TO_MEET_PARTNER",
+        "Expected: legacy RDB stored 'Yes|Yes'; NBS7/RTR stores 'Yes' -- "
+        "data-quality improvement.",
+        id="EXP-D_INV_SOCIAL_HISTORY-PLACES_TO_MEET_PARTNER",
+    ),
+    ExpectedDiffRule(
+        "D_INV_SOCIAL_HISTORY",
+        "SOC_PRTNRS_PRD_MALE_IND",
+        "Expected: legacy RDB stored 'No|No'; NBS7/RTR stores 'No' -- "
+        "data-quality improvement.",
+        id="EXP-D_INV_SOCIAL_HISTORY-SOC_PRTNRS_PRD_MALE_IND",
+    ),
+    ExpectedDiffRule(
+        "D_INV_SOCIAL_HISTORY",
+        "SOC_PRTNRS_PRD_TRNSGNDR_IND",
+        "Expected: legacy RDB stored 'No|No'; NBS7/RTR stores 'No' -- "
+        "data-quality improvement.",
+        id="EXP-D_INV_SOCIAL_HISTORY-SOC_PRTNRS_PRD_TRNSGNDR_IND",
+    ),
+    # 12. D_INV_SUMM_DATAMART: NULL in RDB, populated in modern.
+    ExpectedDiffRule(
+        "D_INV_SUMM_DATAMART",
+        "EVENT_DATE_TYPE",
+        "Expected: NULL in legacy RDB, populated as 'Investigation Start Date' "
+        "in RDB_MODERN (RTR correct).",
+        predicate=rdb_null_modern_set,
+        id="EXP-D_INV_SUMM_DATAMART-EVENT_DATE_TYPE",
+    ),
+    ExpectedDiffRule(
+        "D_INV_SUMM_DATAMART",
+        "CONFIRMATION_METHOD",
+        "Expected: NULL in legacy RDB, populated as 'Active Surveillance' in "
+        "RDB_MODERN (RTR correct).",
+        predicate=rdb_null_modern_set,
+        id="EXP-D_INV_SUMM_DATAMART-CONFIRMATION_METHOD",
+    ),
+    # 13. DM_INV_GENERIC_V2: confirmation fields NULL in RDB, populated in modern.
+    ExpectedDiffRule(
+        "DM_INV_GENERIC_V2",
+        "CONFIRMATION_DT",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN.",
+        predicate=rdb_null_modern_set,
+        id="EXP-DM_INV_GENERIC_V2-CONFIRMATION_DT",
+    ),
+    ExpectedDiffRule(
+        "DM_INV_GENERIC_V2",
+        "CONFIRMATION_METHOD",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN.",
+        predicate=rdb_null_modern_set,
+        id="EXP-DM_INV_GENERIC_V2-CONFIRMATION_METHOD",
+    ),
+    ExpectedDiffRule(
+        "DM_INV_GENERIC_V2",
+        "EVENT_DATE_TYPE",
+        "Expected: NULL in legacy RDB, correctly populated in RDB_MODERN.",
+        predicate=rdb_null_modern_set,
+        id="EXP-DM_INV_GENERIC_V2-EVENT_DATE_TYPE",
+    ),
+    # 22. DM_INV_GENERIC_V2.BINATIONAL_RPTNG_CRIT: MasterETL not updating it.
+    ExpectedDiffRule(
+        "DM_INV_GENERIC_V2",
+        "BINATIONAL_RPTNG_CRIT",
+        "Expected: MasterETL does not update BINATIONAL_RPTNG_CRIT on "
+        "investigation changes; RTR updates it correctly.",
+        id="EXP-DM_INV_GENERIC_V2-BINATIONAL_RPTNG_CRIT",
+    ),
+    # 16. COVID_LAB_CELR_DATAMART.File_created_date uses GetDate() at insert.
+    ExpectedDiffRule(
+        "COVID_LAB_CELR_DATAMART",
+        "FILE_CREATED_DATE",
+        "Expected: File_created_date is set to insertion time via GetDate(), so "
+        "it never matches between Covid19ETL and RTR.",
+        id="EXP-COVID_LAB_CELR_DATAMART-FILE_CREATED_DATE",
+    ),
+    # 17. TB_HIV_DATAMART / TB_DATAMART: RDB values incorrect, modern correct.
+    ExpectedDiffRule(
+        "TB_HIV_DATAMART",
+        "PHYSICIAN_FIRST_NAME",
+        "Expected: RDB value is incorrect (e.g. 'Chung_FAKE'); RDB_MODERN "
+        "derives the correct value from Ordering Provider.",
+        id="EXP-TB_HIV_DATAMART-PHYSICIAN_FIRST_NAME",
+    ),
+    ExpectedDiffRule(
+        "TB_HIV_DATAMART",
+        "REPORTING_SOURCE_NAME",
+        "Expected: RDB value is incorrect (NULL); RDB_MODERN derives the "
+        "correct value from Reporting Facility.",
+        id="EXP-TB_HIV_DATAMART-REPORTING_SOURCE_NAME",
+    ),
+    ExpectedDiffRule(
+        "TB_DATAMART",
+        "PHYSICIAN_FIRST_NAME",
+        "Expected: same as TB_HIV_DATAMART -- RDB value incorrect, RDB_MODERN "
+        "correct (derived from Ordering Provider).",
+        id="EXP-TB_DATAMART-PHYSICIAN_FIRST_NAME",
+    ),
+    ExpectedDiffRule(
+        "TB_DATAMART",
+        "REPORTING_SOURCE_NAME",
+        "Expected: same as TB_HIV_DATAMART -- RDB value incorrect, RDB_MODERN "
+        "correct (derived from Reporting Facility).",
+        id="EXP-TB_DATAMART-REPORTING_SOURCE_NAME",
+    ),
+    # 18. LDF_DATAMART_COLUMN_REF.BUSINESS_OBJECT_NM null in RDB, populated modern.
+    ExpectedDiffRule(
+        "LDF_DATAMART_COLUMN_REF",
+        "BUSINESS_OBJECT_NM",
+        "Expected: BUSINESS_OBJECT_NM is NULL in RDB but populated (e.g. 'PHC') "
+        "in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-LDF_DATAMART_COLUMN_REF-BUSINESS_OBJECT_NM",
+    ),
+    # 19. INV_SUMM_DATAMART notification columns null in RDB, populated in modern.
+    ExpectedDiffRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_LAST_UPDATED_DATE",
+        "Expected: NULL in RDB, correctly populated in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-INV_SUMM_DATAMART-NOTIFICATION_LAST_UPDATED_DATE",
+    ),
+    ExpectedDiffRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_LAST_UPDATED_USER",
+        "Expected: NULL in RDB, correctly populated in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-INV_SUMM_DATAMART-NOTIFICATION_LAST_UPDATED_USER",
+    ),
+    ExpectedDiffRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_LOCAL_ID",
+        "Expected: NULL in RDB, correctly populated in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-INV_SUMM_DATAMART-NOTIFICATION_LOCAL_ID",
+    ),
+    ExpectedDiffRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_STATUS",
+        "Expected: NULL in RDB, correctly populated in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-INV_SUMM_DATAMART-NOTIFICATION_STATUS",
+    ),
+    ExpectedDiffRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_SUBMITTER",
+        "Expected: NULL in RDB, correctly populated in RDB_Modern.",
+        predicate=rdb_null_modern_set,
+        id="EXP-INV_SUMM_DATAMART-NOTIFICATION_SUBMITTER",
+    ),
+    # 20. D_PROVIDER.PROVIDER_PHONE_CELL: MasterETL keeps inactive phone, RTR fixed.
+    ExpectedDiffRule(
+        "D_PROVIDER",
+        "PROVIDER_PHONE_CELL",
+        "Expected: MasterETL does not filter out inactive phone records (keeps "
+        "most-recent cell even if inactive); RTR was fixed (APP-595).",
+        id="EXP-D_PROVIDER-PROVIDER_PHONE_CELL",
+    ),
+    # 21. D_ORGANIZATION audit columns: MasterETL not updating on typo edits.
+    ExpectedDiffRule(
+        "D_ORGANIZATION",
+        "ORGANIZATION_LAST_CHANGE_TIME",
+        "Expected: MasterETL does not update this on typographical org edits; "
+        "RTR updates it accurately.",
+        id="EXP-D_ORGANIZATION-ORGANIZATION_LAST_CHANGE_TIME",
+    ),
+    ExpectedDiffRule(
+        "D_ORGANIZATION",
+        "ORGANIZATION_LAST_UPDATED_BY",
+        "Expected: MasterETL does not update this on typographical org edits; "
+        "RTR updates it accurately.",
+        id="EXP-D_ORGANIZATION-ORGANIZATION_LAST_UPDATED_BY",
+    ),
+    # Consultant-reported corrections (not yet independently verified).
+    ExpectedDiffRule(
+        "D_PLACE",
+        "PLACE_ADDRESS_COMMENTS",
+        "Expected (consultant-reported): RDB sometimes swaps PLACE_PHONE_COMMENTS "
+        "into PLACE_ADDRESS_COMMENTS; RDB_MODERN reportedly does not have this "
+        "bug. NB: superseded by the D_PLACE not-populated KNOWN_BUG.",
+        id="EXP-D_PLACE-PLACE_ADDRESS_COMMENTS",
+    ),
+    ExpectedDiffRule(
+        "D_PLACE",
+        "PLACE_PHONE_COMMENTS",
+        "Expected (consultant-reported): RDB sometimes swaps "
+        "PLACE_ADDRESS_COMMENTS into PLACE_PHONE_COMMENTS; RDB_MODERN reportedly "
+        "correct.",
+        id="EXP-D_PLACE-PLACE_PHONE_COMMENTS",
+    ),
+    ExpectedDiffRule(
+        "D_PROVIDER",
+        "PROVIDER_ADDED_BY",
+        "Expected (consultant-reported): in RDB, PROVIDER_ADDED_BY and "
+        "PROVIDER_LAST_UPDATED_BY always match (incorrect); RDB_MODERN "
+        "reportedly has the correct distinct values.",
+        id="EXP-D_PROVIDER-PROVIDER_ADDED_BY",
+    ),
+    ExpectedDiffRule(
+        "D_PROVIDER",
+        "PROVIDER_LAST_UPDATED_BY",
+        "Expected (consultant-reported): in RDB always equals PROVIDER_ADDED_BY "
+        "(incorrect); RDB_MODERN reportedly correct.",
+        id="EXP-D_PROVIDER-PROVIDER_LAST_UPDATED_BY",
+    ),
+    ExpectedDiffRule(
+        "CONDITION",
+        "CONDITION_DESC",
+        "Expected (consultant-reported): for condition 11638, RDB has a "
+        "mis-encoded CONDITION_DESC ('JunAn...'); RDB_MODERN has the correct "
+        "UTF-8 'Junin hemorrhagic fever'.",
+        id="EXP-CONDITION-CONDITION_DESC",
+    ),
+    ExpectedDiffRule(
+        "HEP_MULTI_VALUE_FIELD",
+        "*",
+        "Expected (consultant-reported): RDB sometimes lacks expected values; "
+        "RDB_MODERN reportedly has the correct values.",
+        id="EXP-HEP_MULTI_VALUE_FIELD",
+    ),
+    ExpectedDiffRule(
+        "MORBIDITY_REPORT_EVENT",
+        "*",
+        "Expected (consultant-reported): RDB sometimes carries the wrong "
+        "treatment key for MORBIDITY_REPORT; RDB_MODERN reportedly correct.",
+        id="EXP-MORBIDITY_REPORT_EVENT-treatment_key",
+    ),
+]
+
+
+# =====================================================================
+# Unexpected Differences (Probable Bugs)  -> KnownBugRule
+# =====================================================================
+# Each item maps to the numbered list on the page; tickets reference
+# "RTR-diffs:bug-<n>" (plus real Jira IDs where the page gives them).
+KNOWN_BUGS = [
+    # 1. ORGANIZATION.ORGANIZATION_FACILITY_ID_AUTH not set.
+    KnownBugRule(
+        "ORGANIZATION",
+        "ORGANIZATION_FACILITY_ID_AUTH",
+        "RDB_MODERN..ORGANIZATION is not setting a value in "
+        "ORGANIZATION_FACILITY_ID_AUTH.",
+        ticket="RTR-diffs:bug-1",
+        predicate=modern_null_rdb_set,
+        id="BUG-ORGANIZATION-FACILITY_ID_AUTH",
+    ),
+    # 2. LAB_RPT_USER_COMMENT not including user comments (also item 26).
+    KnownBugRule(
+        "LAB_RPT_USER_COMMENT",
+        "*",
+        "RDB_MODERN..LAB_RPT_USER_COMMENT is not including user-added comments "
+        "and is not populated; there should be data here. DataCompareAPI does "
+        "not detect this.",
+        ticket="RTR-diffs:bug-2,26",
+        id="BUG-LAB_RPT_USER_COMMENT",
+    ),
+    # 3. LAB_TEST audit columns differ (APP-238) -- see also item 28.
+    KnownBugRule(
+        "LAB_TEST",
+        "LAB_RPT_LAST_UPDATE_BY",
+        "RDB_MODERN..LAB_TEST differs from RDB for LAB_RPT_LAST_UPDATE_BY; RTR "
+        "extracts LAST_CHG_USER_ID from NRT_OBSERVATION rather than "
+        "NEDSS_ENTRY_ID, yielding a different user id (APP-238).",
+        ticket="RTR-diffs:bug-3,28 / APP-238",
+        id="BUG-LAB_TEST-LAB_RPT_LAST_UPDATE_BY",
+    ),
+    # 28. LAB_TEST.SPECIMEN_SRC NULL in modern.
+    KnownBugRule(
+        "LAB_TEST",
+        "SPECIMEN_SRC",
+        "RDB_MODERN..LAB_TEST has SPECIMEN_SRC NULL where legacy RDB has a value "
+        "(e.g. 'Sputum').",
+        ticket="RTR-diffs:bug-28",
+        predicate=modern_null_rdb_set,
+        id="BUG-LAB_TEST-SPECIMEN_SRC",
+    ),
+    # 27. LAB_TEST_KEY offset significant (360+).
+    KnownBugRule(
+        "LAB_TEST",
+        "LAB_TEST_KEY",
+        "LAB_TEST_KEY has an expected offset, but the offsets discovered "
+        "(360+) are significant -- likely due to a lack of ELR data captured "
+        "in NBS7/RTR.",
+        ticket="RTR-diffs:bug-27",
+        id="BUG-LAB_TEST-LAB_TEST_KEY_OFFSET",
+    ),
+    # 8 / 33. D_CASE_MANAGEMENT.INIT_FUP_INITIAL_FOLL_UP: DEC in RDB, NULL in modern.
+    KnownBugRule(
+        "D_CASE_MANAGEMENT",
+        "INIT_FUP_INITIAL_FOLL_UP",
+        "Legacy RDB has 'DEC' for INIT_FUP_INITIAL_FOLL_UP while RDB_MODERN has "
+        "NULL (same discrepancy also seen in STD_HIV_DATAMART).",
+        ticket="RTR-diffs:bug-8,33",
+        id="BUG-D_CASE_MANAGEMENT-INIT_FUP_INITIAL_FOLL_UP",
+    ),
+    # 8. D_CASE_MANAGEMENT.INIT_FUP_CLOSED_DT: full ISO datetime vs date-only.
+    KnownBugRule(
+        "D_CASE_MANAGEMENT",
+        "INIT_FUP_CLOSED_DT",
+        "Legacy RDB has the full ISO 8601 date/time while RDB_MODERN only has "
+        "the formatted date (e.g. '2025-01-15 00:00:00' vs '2025-01-15').",
+        ticket="RTR-diffs:bug-8",
+        id="BUG-D_CASE_MANAGEMENT-INIT_FUP_CLOSED_DT",
+    ),
+    # 33. STD_HIV_DATAMART same INIT_FUP_INITIAL_FOLL_UP discrepancy.
+    KnownBugRule(
+        "STD_HIV_DATAMART",
+        "INIT_FUP_INITIAL_FOLL_UP",
+        "Same as D_CASE_MANAGEMENT: 'DEC' in legacy RDB, NULL in RDB_MODERN.",
+        ticket="RTR-diffs:bug-33",
+        id="BUG-STD_HIV_DATAMART-INIT_FUP_INITIAL_FOLL_UP",
+    ),
+    # 9. D_CONTACT_RECORD NULL-vs-empty note columns + CTT_EXPOSURE_TYPE.
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_EVAL_NOTES",
+        "NULL on legacy RDB vs empty string on RDB_MODERN; populates correctly "
+        "in both once note data is added via the UI (suspected RTR logic bug on "
+        "contact-record creation).",
+        ticket="RTR-diffs:bug-9",
+        predicate=null_vs_empty,
+        id="BUG-D_CONTACT_RECORD-CTT_EVAL_NOTES",
+    ),
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_RISK_NOTES",
+        "NULL on legacy RDB vs empty string on RDB_MODERN (see bug-9).",
+        ticket="RTR-diffs:bug-9",
+        predicate=null_vs_empty,
+        id="BUG-D_CONTACT_RECORD-CTT_RISK_NOTES",
+    ),
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_STMP_NOTES",
+        "NULL on legacy RDB vs empty string on RDB_MODERN (see bug-9).",
+        ticket="RTR-diffs:bug-9",
+        predicate=null_vs_empty,
+        id="BUG-D_CONTACT_RECORD-CTT_STMP_NOTES",
+    ),
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_TRT_NOTES",
+        "NULL on legacy RDB vs empty string on RDB_MODERN (see bug-9).",
+        ticket="RTR-diffs:bug-9",
+        predicate=null_vs_empty,
+        id="BUG-D_CONTACT_RECORD-CTT_TRT_NOTES",
+    ),
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_NOTES",
+        "NULL on legacy RDB vs empty string on RDB_MODERN (see bug-9).",
+        ticket="RTR-diffs:bug-9",
+        predicate=null_vs_empty,
+        id="BUG-D_CONTACT_RECORD-CTT_NOTES",
+    ),
+    KnownBugRule(
+        "D_CONTACT_RECORD",
+        "CTT_EXPOSURE_TYPE",
+        "CTT_EXPOSURE_TYPE was 'Social/Recreational' in legacy RDB but NULL on "
+        "RDB_MODERN (corrected once the note was added via the UI -- suspected "
+        "RTR stored-procedure logic bug on contact-record creation).",
+        ticket="RTR-diffs:bug-9",
+        id="BUG-D_CONTACT_RECORD-CTT_EXPOSURE_TYPE",
+    ),
+    # 10. D_INV_SYMPTOM fever fields NULL in modern.
+    KnownBugRule(
+        "D_INV_SYMPTOM",
+        "SYM_FEVER_HIGHEST_TEMP",
+        "RDB_MODERN had NULL while legacy RDB populated SYM_FEVER_HIGHEST_TEMP "
+        "(e.g. 102).",
+        ticket="RTR-diffs:bug-10",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_INV_SYMPTOM-SYM_FEVER_HIGHEST_TEMP",
+    ),
+    KnownBugRule(
+        "D_INV_SYMPTOM",
+        "SYM_FEVER_HIGHEST_TEMP_UNIT",
+        "RDB_MODERN had NULL while legacy RDB populated SYM_FEVER_HIGHEST_TEMP_UNIT "
+        "(e.g. 'Fahrenheit').",
+        ticket="RTR-diffs:bug-10",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_INV_SYMPTOM-SYM_FEVER_HIGHEST_TEMP_UNIT",
+    ),
+    # 11. D_INTERVIEW fields NULL in modern.
+    KnownBugRule(
+        "D_INTERVIEW",
+        "IX_CONTACTS_NAMED_IND",
+        "RDB_MODERN had NULL while legacy RDB populated it (e.g. 'Yes').",
+        ticket="RTR-diffs:bug-11",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_INTERVIEW-IX_CONTACTS_NAMED_IND",
+    ),
+    KnownBugRule(
+        "D_INTERVIEW",
+        "IX_INTERVENTION",
+        "RDB_MODERN had NULL while legacy RDB populated it (e.g. 'HIV "
+        "Intervention Value c').",
+        ticket="RTR-diffs:bug-11",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_INTERVIEW-IX_INTERVENTION",
+    ),
+    KnownBugRule(
+        "D_INTERVIEW",
+        "CLN_CARE_STATUS_IXS",
+        "RDB_MODERN had NULL while legacy RDB populated it (e.g. '1-In Care').",
+        ticket="RTR-diffs:bug-11",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_INTERVIEW-CLN_CARE_STATUS_IXS",
+    ),
+    # 12. D_INTERVIEW_NOTE not appearing though D_INTERVIEW has data.
+    KnownBugRule(
+        "D_INTERVIEW_NOTE",
+        "*",
+        "D_INTERVIEW exists in RDB_MODERN but the corresponding D_INTERVIEW_NOTE "
+        "rows are not appearing -- likely an RTR defect. DataCompareAPI does "
+        "not detect this.",
+        ticket="RTR-diffs:bug-12",
+        id="BUG-D_INTERVIEW_NOTE-not_populated",
+    ),
+    # 13. D_ORGANIZATION.ORGANIZATION_FACILITY_AUTH NULL in modern.
+    KnownBugRule(
+        "D_ORGANIZATION",
+        "ORGANIZATION_FACILITY_AUTH",
+        "ORGANIZATION_FACILITY_AUTH was 'NPI' in legacy RDB but NULL on "
+        "RDB_MODERN.",
+        ticket="RTR-diffs:bug-13",
+        predicate=modern_null_rdb_set,
+        id="BUG-D_ORGANIZATION-ORGANIZATION_FACILITY_AUTH",
+    ),
+    # 14. D_PLACE not populated in modern.
+    KnownBugRule(
+        "D_PLACE",
+        "*",
+        "D_PLACE is not populated in RDB_MODERN though it should be. "
+        "DataCompareAPI does not detect this.",
+        ticket="RTR-diffs:bug-14",
+        id="BUG-D_PLACE-not_populated",
+    ),
+    # 15. DM_INV_ARBO_HUMAN.EVENT_DATE_TYPE NULL in RDB vs populated in modern.
+    KnownBugRule(
+        "DM_INV_ARBO_HUMAN",
+        "EVENT_DATE_TYPE",
+        "A case where EVENT_DATE_TYPE was NULL in legacy RDB but 'Investigation "
+        "Start Date' in RDB_MODERN.",
+        ticket="RTR-diffs:bug-15",
+        predicate=rdb_null_modern_set,
+        id="BUG-DM_INV_ARBO_HUMAN-EVENT_DATE_TYPE",
+    ),
+    # 16. DM_INV_GENERIC_V2 not populated in modern.
+    KnownBugRule(
+        "DM_INV_GENERIC_V2",
+        "*",
+        "DM_INV_GENERIC_V2 is not populated in RDB_MODERN though it should be. "
+        "DataCompareAPI does not detect this.",
+        ticket="RTR-diffs:bug-16",
+        id="BUG-DM_INV_GENERIC_V2-not_populated",
+    ),
+    # 17. DM_INV_HIV.EVENT_DATE_TYPE NULL in RDB vs populated in modern.
+    KnownBugRule(
+        "DM_INV_HIV",
+        "EVENT_DATE_TYPE",
+        "A case where EVENT_DATE_TYPE was NULL in legacy RDB but 'Investigation "
+        "Start Date' in RDB_MODERN.",
+        ticket="RTR-diffs:bug-17",
+        predicate=rdb_null_modern_set,
+        id="BUG-DM_INV_HIV-EVENT_DATE_TYPE",
+    ),
+    # 18. D_INV_SUMM_DATAMART.INVESTIGATION_LAST_UPDTD_DATE incorrect in RDB.
+    KnownBugRule(
+        "D_INV_SUMM_DATAMART",
+        "INVESTIGATION_LAST_UPDTD_DATE",
+        "RDB has an incorrect INVESTIGATION_LAST_UPDTD_DATE (e.g. 2026-01-08 "
+        "21:23:58.027); RDB_MODERN has the correct value.",
+        ticket="RTR-diffs:bug-18",
+        id="BUG-D_INV_SUMM_DATAMART-INVESTIGATION_LAST_UPDTD_DATE",
+    ),
+    # 19. INVESTIGATION hospitalization fields NULL in modern.
+    KnownBugRule(
+        "INVESTIGATION",
+        "HSPTL_ADMISSION_DT",
+        "RDB_MODERN had NULL while legacy RDB populated HSPTL_ADMISSION_DT "
+        "(e.g. 2025-12-08).",
+        ticket="RTR-diffs:bug-19",
+        predicate=modern_null_rdb_set,
+        id="BUG-INVESTIGATION-HSPTL_ADMISSION_DT",
+    ),
+    KnownBugRule(
+        "INVESTIGATION",
+        "HSPTL_DISCHARGE_DT",
+        "RDB_MODERN had NULL while legacy RDB populated HSPTL_DISCHARGE_DT "
+        "(e.g. 2025-12-09).",
+        ticket="RTR-diffs:bug-19",
+        predicate=modern_null_rdb_set,
+        id="BUG-INVESTIGATION-HSPTL_DISCHARGE_DT",
+    ),
+    KnownBugRule(
+        "INVESTIGATION",
+        "HSPTL_DURATION_DAYS",
+        "RDB_MODERN had NULL while legacy RDB populated HSPTL_DURATION_DAYS "
+        "(e.g. 1).",
+        ticket="RTR-diffs:bug-19",
+        predicate=modern_null_rdb_set,
+        id="BUG-INVESTIGATION-HSPTL_DURATION_DAYS",
+    ),
+    # 20. L_CASE_MANAGEMENT populated in RDB, does not exist in modern.
+    KnownBugRule(
+        "L_CASE_MANAGEMENT",
+        "*",
+        "L_CASE_MANAGEMENT is populated in legacy RDB but does not exist in "
+        "RDB_MODERN.",
+        ticket="RTR-diffs:bug-20",
+        id="BUG-L_CASE_MANAGEMENT-missing",
+    ),
+    # 21. L_CONTACT_RECORD not populated in modern.
+    KnownBugRule(
+        "L_CONTACT_RECORD",
+        "*",
+        "L_CONTACT_RECORD is populated in legacy RDB but not in RDB_MODERN; "
+        "there should be data here.",
+        ticket="RTR-diffs:bug-21",
+        id="BUG-L_CONTACT_RECORD-not_populated",
+    ),
+    # 22. L_INTERVIEW not populated in modern.
+    KnownBugRule(
+        "L_INTERVIEW",
+        "*",
+        "L_INTERVIEW is populated in legacy RDB but not in RDB_MODERN; there "
+        "should be data here.",
+        ticket="RTR-diffs:bug-22",
+        id="BUG-L_INTERVIEW-not_populated",
+    ),
+    # 23. L_INTERVIEW_NOTE not populated in modern.
+    KnownBugRule(
+        "L_INTERVIEW_NOTE",
+        "*",
+        "L_INTERVIEW_NOTE is populated in legacy RDB but not in RDB_MODERN; "
+        "there should be data here.",
+        ticket="RTR-diffs:bug-23",
+        id="BUG-L_INTERVIEW_NOTE-not_populated",
+    ),
+    # 24. LAB_RESULT_COMMENT populated in modern, not in RDB.
+    KnownBugRule(
+        "LAB_RESULT_COMMENT",
+        "*",
+        "LAB_RESULT_COMMENT is populated in RDB_MODERN but not in legacy RDB.",
+        ticket="RTR-diffs:bug-24",
+        id="BUG-LAB_RESULT_COMMENT-modern_only",
+    ),
+    # 25. LAB_RESULT_VAL value-code fields NULL in modern.
+    KnownBugRule(
+        "LAB_RESULT_VAL",
+        "TEST_RESULT_VAL_CD",
+        "RDB_MODERN had NULL while legacy RDB populated TEST_RESULT_VAL_CD "
+        "(e.g. 260415000). DataCompareAPI does not detect this.",
+        ticket="RTR-diffs:bug-25",
+        predicate=modern_null_rdb_set,
+        id="BUG-LAB_RESULT_VAL-TEST_RESULT_VAL_CD",
+    ),
+    KnownBugRule(
+        "LAB_RESULT_VAL",
+        "TEST_RESULT_VAL_CD_DESC",
+        "RDB_MODERN had NULL while legacy RDB populated TEST_RESULT_VAL_CD_DESC "
+        "(e.g. 'Not Detected').",
+        ticket="RTR-diffs:bug-25",
+        predicate=modern_null_rdb_set,
+        id="BUG-LAB_RESULT_VAL-TEST_RESULT_VAL_CD_DESC",
+    ),
+    KnownBugRule(
+        "LAB_RESULT_VAL",
+        "TEST_RESULT_VAL_CD_SYS_CD",
+        "RDB_MODERN had NULL while legacy RDB populated TEST_RESULT_VAL_CD_SYS_CD "
+        "(e.g. 'SCT').",
+        ticket="RTR-diffs:bug-25",
+        predicate=modern_null_rdb_set,
+        id="BUG-LAB_RESULT_VAL-TEST_RESULT_VAL_CD_SYS_CD",
+    ),
+    # 30. LDF_DATAMART_COLUMN_REF unfinished-work marker rows.
+    KnownBugRule(
+        "LDF_DATAMART_COLUMN_REF",
+        "DATAMART_COLUMN_NM",
+        "Apparent unfinished work: rows where DATAMART_COLUMN_NM is "
+        "'L_10000007LDF_to_Fix_RDB' on both databases -- needs investigation.",
+        ticket="RTR-diffs:bug-30",
+        id="BUG-LDF_DATAMART_COLUMN_REF-DATAMART_COLUMN_NM",
+    ),
+    # 32. PHC_UIDS.CASE_MANAGEMENT_UID NULL in modern.
+    # RETIRED (APP-720): PHC_UIDS is now skip-listed (SKIP-PHC_PREFIX) as a
+    # transient SELECT INTO UID worklist, so this column-level known-bug rule can
+    # never fire (skip rules outrank known-bug in sort order). The underlying
+    # CASE_MANAGEMENT_UID NULL + non-STD/STD record-set observation (ticket
+    # RTR-diffs:bug-32) is preserved here for traceability; re-open it against a
+    # real comparand if PHC case-management linkage needs verification.
+    # 34. TREATMENT.TREATMENT_COMMENTS NULL vs empty.
+    KnownBugRule(
+        "TREATMENT",
+        "TREATMENT_COMMENTS",
+        "TREATMENT_COMMENTS is NULL on legacy RDB but empty string on "
+        "RDB_MODERN (representation-only difference).",
+        ticket="RTR-diffs:bug-34",
+        predicate=null_vs_empty,
+        id="BUG-TREATMENT-TREATMENT_COMMENTS",
+    ),
+    # 37. INV_SUMM_DATAMART.NOTIFICATION_CREATE_DATE NULL in modern.
+    KnownBugRule(
+        "INV_SUMM_DATAMART",
+        "NOTIFICATION_CREATE_DATE",
+        "NOTIFICATION_CREATE_DATE has the correct value in RDB but is NULL in "
+        "RDB_Modern.",
+        ticket="RTR-diffs:bug-37",
+        predicate=modern_null_rdb_set,
+        id="BUG-INV_SUMM_DATAMART-NOTIFICATION_CREATE_DATE",
+    ),
+]
+
+
+def build_default_registry() -> RuleRegistry:
+    """Build and return the fully populated default :class:`RuleRegistry`.
+
+    Assembles every rule transcribed from the "RTR reporting differences" page:
+    the skip-list tables/families, the surrogate-key and environment-timestamp
+    ignore rules, the documented expected differences, and the probable-bug
+    rules. The registry orders them by ``sort_key`` (skip < known-bug < expected
+    < ignore; exact before glob), so the first matching rule wins.
+    """
+    registry = RuleRegistry()
+    registry.extend(SKIP_TABLES)
+    registry.extend(IGNORE_COLUMNS)
+    registry.extend(EXPECTED)
+    registry.extend(KNOWN_BUGS)
+    return registry

--- a/testing-tools/rdb-compare/rdb_compare/rules/predicates.py
+++ b/testing-tools/rdb-compare/rdb_compare/rules/predicates.py
@@ -1,0 +1,50 @@
+"""Value-level predicates used by Expected/KnownBug rules.
+
+A predicate inspects a single :class:`~rdb_compare.models.CellDiff` and returns
+True when that mismatch fits the documented pattern. A rule with a predicate
+only classifies a column when the predicate holds for *all* of that column's
+mismatches -- so a column that mixes the documented pattern with other,
+unexplained value diffs stays NEW/actionable rather than being silently
+absorbed.
+
+Predicates are small named functions (not lambdas) so they are testable and
+render readably in rule definitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rdb_compare.models import CellDiff
+
+
+def _is_blank(v: Any) -> bool:
+    """SQL NULL (None) or an empty/whitespace-only string."""
+    return v is None or (isinstance(v, str) and v.strip() == "")
+
+
+def any_value(cell: CellDiff) -> bool:
+    """Unconditional -- the difference is explained regardless of values."""
+    return True
+
+
+def rdb_null_modern_set(cell: CellDiff) -> bool:
+    """RDB is NULL/blank, RDB_MODERN has a value (modern populated more)."""
+    return _is_blank(cell.rdb_value) and not _is_blank(cell.modern_value)
+
+
+def modern_null_rdb_set(cell: CellDiff) -> bool:
+    """RDB_MODERN is NULL/blank, RDB has a value (legacy populated more)."""
+    return _is_blank(cell.modern_value) and not _is_blank(cell.rdb_value)
+
+
+def null_vs_empty(cell: CellDiff) -> bool:
+    """One side NULL, the other an empty string (or vice versa) -- a
+    representation-only difference (e.g. TREATMENT_COMMENTS NULL vs '')."""
+    a, b = cell.rdb_value, cell.modern_value
+    return _is_blank(a) and _is_blank(b) and a != b
+
+
+def both_blank(cell: CellDiff) -> bool:
+    """Both sides blank but unequal representations (None vs '' vs ' ')."""
+    return _is_blank(cell.rdb_value) and _is_blank(cell.modern_value)

--- a/testing-tools/rdb-compare/rdb_compare/rules/types.py
+++ b/testing-tools/rdb-compare/rdb_compare/rules/types.py
@@ -1,0 +1,156 @@
+"""Typed, declarative rule classes for the known-differences registry.
+
+Each rule is a small data object that (a) matches a table and/or column by name
+pattern and (b) carries a fixed :class:`~rdb_compare.models.Verdict`. This is the
+"modular, extensible" alternative to if/else sprawl: new known differences are
+added by appending rule instances to the catalog, and each rule is independently
+unit-testable.
+
+Name matching is case-insensitive (SQL Server default) and glob-style via
+:func:`fnmatch.fnmatchcase` on upper-cased names, so patterns like ``"*_KEY"``,
+``"*_LAST_UPDATE_DT"`` or ``"D_*"`` work as expected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
+from typing import Callable, Optional
+
+from rdb_compare.models import Verdict
+from rdb_compare.rules.predicates import any_value
+
+
+def _match(pattern: str, name: str) -> bool:
+    return fnmatchcase((name or "").upper(), (pattern or "").upper())
+
+
+def _is_glob(pattern: str) -> bool:
+    return any(ch in (pattern or "") for ch in "*?[")
+
+
+@dataclass(frozen=True)
+class Rule:
+    """Base rule. Subclasses set ``scope`` and supply matching behaviour."""
+
+    id: str
+    reason: str
+    verdict: Verdict
+    scope: str = "column"            # "table" or "column"
+    base_priority: int = 50
+    table_pattern: str = "*"
+    column_pattern: str = "*"
+    predicate: Callable = field(default=any_value)
+    ticket: Optional[str] = None     # e.g. a Jira/PDF reference for KNOWN_BUG
+
+    # --- matching -------------------------------------------------------
+    def matches_table(self, table: str) -> bool:
+        return _match(self.table_pattern, table)
+
+    def matches_column(self, table: str, column: str) -> bool:
+        return _match(self.table_pattern, table) and _match(self.column_pattern, column)
+
+    def applies_to_cells(self, cells) -> bool:
+        """True when this rule explains *every* mismatch in the column.
+
+        Empty ``cells`` -> vacuously True (used by name-only rules).
+        """
+        return all(self.predicate(c) for c in cells)
+
+    # --- ordering -------------------------------------------------------
+    def sort_key(self) -> tuple:
+        # Lower sorts first (checked first, wins). More specific (no glob in
+        # table+column) beats glob within the same base priority.
+        glob = _is_glob(self.table_pattern) or _is_glob(self.column_pattern)
+        return (self.base_priority, 1 if glob else 0, self.id)
+
+
+# NB: the subclasses below are *plain* subclasses of the frozen ``Rule``
+# dataclass -- intentionally NOT re-decorated with @dataclass, which would
+# regenerate ``__init__`` and clobber these convenience constructors. They call
+# the parent's generated (object.__setattr__-based) ``__init__``, so instances
+# remain frozen.
+
+
+class SkipTableRule(Rule):
+    """Exclude an entire table from comparison (verdict IGNORED, scope table)."""
+
+    def __init__(self, table_pattern: str, reason: str, id: Optional[str] = None):
+        super().__init__(
+            id=id or f"SKIP-{table_pattern}",
+            reason=reason,
+            verdict=Verdict.IGNORED,
+            scope="table",
+            base_priority=10,
+            table_pattern=table_pattern,
+        )
+
+
+class IgnoreColumnRule(Rule):
+    """Ignore a column's differences by name (key offsets, env/timestamp, audit)."""
+
+    def __init__(
+        self,
+        column_pattern: str,
+        reason: str,
+        table_pattern: str = "*",
+        category: str = "",
+        id: Optional[str] = None,
+    ):
+        super().__init__(
+            id=id or f"IGN-{category or 'col'}-{column_pattern}",
+            reason=reason,
+            verdict=Verdict.IGNORED,
+            scope="column",
+            base_priority=40,
+            table_pattern=table_pattern,
+            column_pattern=column_pattern,
+        )
+
+
+class ExpectedDiffRule(Rule):
+    """A documented, by-design difference (verdict EXPECTED)."""
+
+    def __init__(
+        self,
+        table_pattern: str,
+        column_pattern: str,
+        reason: str,
+        predicate: Callable = any_value,
+        id: Optional[str] = None,
+    ):
+        super().__init__(
+            id=id or f"EXP-{table_pattern}.{column_pattern}",
+            reason=reason,
+            verdict=Verdict.EXPECTED,
+            scope="column",
+            base_priority=30,
+            table_pattern=table_pattern,
+            column_pattern=column_pattern,
+            predicate=predicate,
+        )
+
+
+class KnownBugRule(Rule):
+    """A documented probable bug (verdict KNOWN_BUG)."""
+
+    def __init__(
+        self,
+        table_pattern: str,
+        column_pattern: str,
+        reason: str,
+        ticket: Optional[str] = None,
+        predicate: Callable = any_value,
+        id: Optional[str] = None,
+    ):
+        super().__init__(
+            id=id or f"BUG-{table_pattern}.{column_pattern}",
+            reason=reason,
+            verdict=Verdict.KNOWN_BUG,
+            scope="column",
+            base_priority=20,
+            table_pattern=table_pattern,
+            column_pattern=column_pattern,
+            predicate=predicate,
+            ticket=ticket,
+        )

--- a/testing-tools/rdb-compare/scripts/clean_slate_to_comparison.sh
+++ b/testing-tools/rdb-compare/scripts/clean_slate_to_comparison.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# clean_slate_to_comparison.sh
+# ---------------------------------------------------------------------------
+# One command: clean slate -> populated RDB_MODERN (RTR) + RDB (MasterETL) ->
+# rdb-compare report on disk.
+#
+# THE THREE STAGES (order matters):
+#   1. merge_and_verify.sh   -> RDB_MODERN, via the real CDC/RTR pipeline.
+#                               Does `docker compose down -v` FIRST, so it WIPES
+#                               everything (incl. RDB). MUST run before MasterETL.
+#   2. run_masteretl_local.sh -> RDB, via the legacy SAS/MasterETL container,
+#                               reading the SAME NBS_ODSE that stage 1 loaded.
+#   3. rdb-compare           -> out/comparison.{json,md}: RDB vs RDB_MODERN.
+#
+# Both RDB and RDB_MODERN live in the one mssql instance (localhost,3433,
+# sa / PizzaIsGood33!), so the compare does cross-DB joins.
+#
+# RAM: the heavy combo is the full CDC stack + the SAS container at the same
+# time (this is what OOM'd a small host before). By default this script STOPS
+# the CDC pipeline services after stage 1 (RDB_MODERN is already persisted in
+# mssql) so only mssql + SAS are up during MasterETL — much lower peak. Pass
+# --keep-pipeline to leave them running. Watch `docker stats` if unsure.
+#
+# USAGE:
+#   ./clean_slate_to_comparison.sh                 # full run, stages 1->2->3
+#   ./clean_slate_to_comparison.sh --skip-merge    # RDB_MODERN already good
+#   ./clean_slate_to_comparison.sh --skip-masteretl# only refresh RDB_MODERN+compare
+#   ./clean_slate_to_comparison.sh --compare-only  # both DBs already populated
+#   ./clean_slate_to_comparison.sh --keep-pipeline # don't stop CDC svcs for SAS
+#
+# Logs: /tmp/c2c_*.log . Final report: testing-tools/rdb-compare/out/comparison.md
+# ---------------------------------------------------------------------------
+set -uo pipefail   # NOT -e: MasterETL returns non-zero on expected SAS errors.
+
+# --- paths ---
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+RDB_COMPARE_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+REPO_ROOT="$( cd "$RDB_COMPARE_DIR/../.." && pwd )"
+FIXTURES_DIR="$REPO_ROOT/testing-tools/synthetic-odse-fixtures"
+MERGE="$FIXTURES_DIR/scripts/merge_and_verify.sh"
+MASTERETL="$FIXTURES_DIR/scripts/run_masteretl_local.sh"
+MASTERETL_BRANCH="aw/masteretl-local-fixtures"
+
+# --- db ---
+SQLPASS='PizzaIsGood33!'
+sql() { docker compose -f "$REPO_ROOT/docker-compose.yaml" exec -T nbs-mssql \
+  /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$SQLPASS" -C -h -1 -W \
+  -Q "SET NOCOUNT ON; $1" 2>&1 | tr -d '\r'; }
+
+# --- flags ---
+SKIP_MERGE=0; SKIP_MASTERETL=0; KEEP_PIPELINE=0
+for a in "$@"; do case "$a" in
+  --skip-merge)     SKIP_MERGE=1 ;;
+  --skip-masteretl) SKIP_MASTERETL=1 ;;
+  --compare-only)   SKIP_MERGE=1; SKIP_MASTERETL=1 ;;
+  --keep-pipeline)  KEEP_PIPELINE=1 ;;
+  -h|--help)        sed -n '2,40p' "$0"; exit 0 ;;
+  *) echo "unknown flag: $a" >&2; exit 2 ;;
+esac; done
+
+log()  { printf '\033[1;36m[c2c]\033[0m %s\n' "$*"; }
+ram()  { free -h | awk '/^Mem:/{printf "RAM used=%s avail=%s\n",$3,$7}'; }
+die()  { printf '\033[1;31m[c2c] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+cd "$REPO_ROOT" || die "cannot cd to repo root $REPO_ROOT"
+command -v docker >/dev/null || die "docker not found"
+[[ -x "$MERGE" ]] || die "missing $MERGE"
+
+log "repo: $REPO_ROOT"; ram
+
+# ===========================================================================
+# STAGE 1 — RDB_MODERN via the RTR/CDC pipeline (down -v + full stack)
+# ===========================================================================
+if (( ! SKIP_MERGE )); then
+  log "STAGE 1: merge_and_verify.sh (down -v; populate RDB_MODERN via CDC). ~5-20 min."
+  if ! "$MERGE" 2>&1 | tee /tmp/c2c_merge.log | grep -E '\[merge\]|error|Error' ; then :; fi
+  grep -q "Merge complete" /tmp/c2c_merge.log || die "merge_and_verify did not reach 'Merge complete' — see /tmp/c2c_merge.log"
+  mp=$(sql "SELECT COUNT(*) FROM (SELECT t.name FROM RDB_MODERN.sys.tables t JOIN RDB_MODERN.sys.partitions p ON p.object_id=t.object_id AND p.index_id IN (0,1) GROUP BY t.name HAVING SUM(p.rows)>0) x;")
+  log "RDB_MODERN populated tables: $mp"; ram
+  [[ "${mp//[^0-9]/}" -gt 100 ]] || die "RDB_MODERN looks empty ($mp populated) after merge"
+else
+  log "STAGE 1 skipped (--skip-merge). Assuming RDB_MODERN already populated."
+fi
+
+# ===========================================================================
+# STAGE 1.5 — free RAM for SAS: stop the CDC pipeline (mssql keeps the data)
+# ===========================================================================
+if (( ! SKIP_MASTERETL )) && (( ! KEEP_PIPELINE )); then
+  log "STAGE 1.5: stopping CDC pipeline services (mssql stays up; RDB_MODERN persists) to free RAM for SAS."
+  docker compose stop kafka-connect debezium reporting-pipeline-service kafka wildfly >/dev/null 2>&1 || true
+  ram
+fi
+
+# ===========================================================================
+# STAGE 2 — RDB via MasterETL (SAS container). Heavy/RAM step.
+# ===========================================================================
+if (( ! SKIP_MASTERETL )); then
+  # Ensure the MasterETL wrapper exists (it lives on a sibling branch).
+  if [[ ! -f "$MASTERETL" ]]; then
+    log "extracting run_masteretl_local.sh from $MASTERETL_BRANCH"
+    git show "$MASTERETL_BRANCH:utilities/comparison-fixtures/scripts/run_masteretl_local.sh" \
+      > "$MASTERETL" 2>/dev/null || die "could not extract run_masteretl_local.sh from $MASTERETL_BRANCH"
+    chmod +x "$MASTERETL"
+  fi
+
+  # Known gotcha: a stale sas container from a prior run holds a dead network
+  # ref -> "network ... not found". Remove it so the new one attaches cleanly.
+  if docker ps -a --format '{{.Names}}' | grep -qx 'nedss-datareporting-sas-1'; then
+    log "removing stale sas container (network-ref guard)"
+    docker rm -f nedss-datareporting-sas-1 >/dev/null 2>&1 || true
+  fi
+
+  log "STAGE 2: run_masteretl_local.sh (SAS up, autoexec fix, MasterEtl.sh -> RDB). ~5-15 min."
+  log "  NOTE: MasterETL reports ~100+ SAS errors for disease families the fixtures don't seed"
+  log "  (BMIRD/strep, ABCs, congenital) and EXITS NON-ZERO. That is EXPECTED — we verify RDB"
+  log "  by row counts, not by exit code."
+  "$MASTERETL" 2>&1 | tee /tmp/c2c_masteretl.log | grep -E '\[masteretl\]|ERROR' || true
+
+  rp=$(sql "SELECT COUNT(*) FROM (SELECT t.name FROM RDB.sys.tables t JOIN RDB.sys.partitions p ON p.object_id=t.object_id AND p.index_id IN (0,1) GROUP BY t.name HAVING SUM(p.rows)>0) x;")
+  inv=$(sql "SELECT COUNT(*) FROM RDB.dbo.INVESTIGATION;")
+  log "RDB populated tables: $rp   (RDB.INVESTIGATION rows: $inv)"; ram
+  [[ "${rp//[^0-9]/}" -gt 100 ]] || die "RDB looks empty ($rp populated) after MasterETL — inspect /tmp/c2c_masteretl.log and the SAS logs"
+else
+  log "STAGE 2 skipped (--skip-masteretl). Assuming RDB already populated."
+fi
+
+# ===========================================================================
+# STAGE 3 — the comparison
+# ===========================================================================
+log "STAGE 3: rdb-compare RDB vs RDB_MODERN."
+cd "$RDB_COMPARE_DIR" || die "cannot cd to $RDB_COMPARE_DIR"
+uv run rdb-compare --host localhost --port 3433 --user sa \
+  --rdb RDB --modern RDB_MODERN --out ./out --progress --query-timeout 120 \
+  2>&1 | tee /tmp/c2c_compare.log
+
+echo
+log "DONE. Report: $RDB_COMPARE_DIR/out/comparison.md (+ comparison.json)"
+log "Interpret per testing-tools/synthetic-odse-fixtures/ docs:"
+log "  expect NEW diffs to cluster (encoding mojibake from SAS latin1, NULL-vs-''),"
+log "  and RDB-only/MODERN-only presence gaps that are legitimate RTR-vs-MasterETL"
+log "  coverage differences (catalog/odse_unknown_tables.md lists MasterETL-only tables)."
+ram

--- a/testing-tools/rdb-compare/scripts/make_sample.py
+++ b/testing-tools/rdb-compare/scripts/make_sample.py
@@ -1,0 +1,193 @@
+"""Build and write the example comparison report deliverables.
+
+Constructs a small, synthetic :class:`~rdb_compare.models.RunReport` that
+exercises every :class:`~rdb_compare.models.Verdict` -- a NEW value diff, an
+IGNORED ``*_LAST_UPDATE_DT`` column, a KNOWN_BUG, an EXPECTED by-design diff, a
+fully skipped staging table, and a row-count difference -- classifies it with a
+small inline :class:`~rdb_compare.rules.RuleRegistry`, then writes
+``examples/sample_comparison.json`` and ``examples/sample_comparison.md``.
+
+Run from anywhere::
+
+    uv run python scripts/make_sample.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from rdb_compare.classifier import classify_run
+from rdb_compare.models import (
+    CellDiff,
+    ColumnDiff,
+    Presence,
+    RunReport,
+    TableResult,
+)
+from rdb_compare.report import write_json, write_markdown
+from rdb_compare.rules import (
+    ExpectedDiffRule,
+    IgnoreColumnRule,
+    KnownBugRule,
+    RuleRegistry,
+    SkipTableRule,
+)
+from rdb_compare.rules.predicates import rdb_null_modern_set
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_EXAMPLES_DIR = os.path.join(_REPO_ROOT, "examples")
+
+
+def _col(table, name, compared, mismatches, pairs):
+    """A :class:`ColumnDiff` with capped CellDiff samples from ``(key, rdb, modern)``."""
+    samples = [
+        CellDiff(table=table, key=key, column=name, rdb_value=rdb, modern_value=modern)
+        for key, rdb, modern in pairs
+    ]
+    return ColumnDiff(
+        table=table,
+        column=name,
+        compared=compared,
+        mismatches=mismatches,
+        samples=samples,
+    )
+
+
+def _sample_registry() -> RuleRegistry:
+    """A tiny registry covering each non-NEW verdict for the sample."""
+    return RuleRegistry(
+        [
+            SkipTableRule("ETL_*", "ETL staging table -- not a reporting table"),
+            IgnoreColumnRule(
+                "*_LAST_UPDATE_DT", "ETL load timing, not a data difference", category="env"
+            ),
+            KnownBugRule(
+                "D_PLACE",
+                "PLACE_NM",
+                "D_PLACE place name not populated by RTR pipeline",
+                ticket="PDF-bug-12",
+            ),
+            ExpectedDiffRule(
+                "D_PATIENT",
+                "PATIENT_SUFFIX",
+                "RTR populates suffix the legacy ETL left NULL (by design)",
+                predicate=rdb_null_modern_set,
+            ),
+        ]
+    )
+
+
+def build_sample_report() -> RunReport:
+    """Construct and classify a synthetic run touching every verdict."""
+    report = RunReport(
+        rdb_db="RDB",
+        modern_db="RDB_MODERN",
+        generated_at="2026-06-05T12:00:00Z",
+        discovered=4,
+        skipped=1,
+        compared=3,
+        tables=[
+            # NEW: unexplained value diff. Also has an IGNORED audit column and a
+            # row-count difference (modern has one extra key).
+            TableResult(
+                table="D_PATIENT",
+                presence=Presence.BOTH,
+                key_columns=("PATIENT_UID",),
+                rdb_count=1000,
+                modern_count=1001,
+                matched_keys=1000,
+                rdb_only_keys=0,
+                modern_only_keys=1,
+                columns=[
+                    _col(
+                        "D_PATIENT",
+                        "FIRST_NM",
+                        compared=1000,
+                        mismatches=12,
+                        pairs=[
+                            (("PAT-001",), "ALICE", "ALICIA"),
+                            (("PAT-014",), "BOB", "ROBERT"),
+                            (("PAT-099",), "CHRIS", "CHRISTOPHER"),
+                            (("PAT-120",), "DEE", "DEANNA"),
+                        ],
+                    ),
+                    _col(
+                        "D_PATIENT",
+                        "RECORD_LAST_UPDATE_DT",
+                        compared=1000,
+                        mismatches=1000,
+                        pairs=[
+                            (("PAT-001",), "2024-01-01 03:00:00", "2024-01-01 09:15:22"),
+                            (("PAT-002",), "2024-01-01 03:00:00", "2024-01-01 09:15:23"),
+                        ],
+                    ),
+                    _col(
+                        "D_PATIENT",
+                        "PATIENT_SUFFIX",
+                        compared=1000,
+                        mismatches=37,
+                        pairs=[
+                            (("PAT-005",), None, "JR"),
+                            (("PAT-067",), None, "III"),
+                        ],
+                    ),
+                ],
+            ),
+            # KNOWN_BUG only.
+            TableResult(
+                table="D_PLACE",
+                presence=Presence.BOTH,
+                key_columns=("PLACE_UID",),
+                rdb_count=250,
+                modern_count=250,
+                matched_keys=250,
+                rdb_only_keys=0,
+                modern_only_keys=0,
+                columns=[
+                    _col(
+                        "D_PLACE",
+                        "PLACE_NM",
+                        compared=250,
+                        mismatches=250,
+                        pairs=[
+                            (("PLC-001",), "Mercy Hospital", None),
+                            (("PLC-002",), "County Clinic", None),
+                        ],
+                    ),
+                ],
+            ),
+            # Skipped staging table.
+            TableResult(
+                table="ETL_CONTROL",
+                presence=Presence.BOTH,
+                key_columns=("BATCH_ID",),
+                rdb_count=5,
+                modern_count=5,
+                columns=[
+                    _col(
+                        "ETL_CONTROL",
+                        "BATCH_STATUS",
+                        compared=5,
+                        mismatches=5,
+                        pairs=[(("B1",), "DONE", "PENDING")],
+                    ),
+                ],
+            ),
+        ],
+    )
+    return classify_run(report, _sample_registry())
+
+
+def main() -> None:
+    os.makedirs(_EXAMPLES_DIR, exist_ok=True)
+    report = build_sample_report()
+    json_path = os.path.join(_EXAMPLES_DIR, "sample_comparison.json")
+    md_path = os.path.join(_EXAMPLES_DIR, "sample_comparison.md")
+    write_json(report, json_path)
+    write_markdown(report, md_path)
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing-tools/rdb-compare/tests/test_catalog.py
+++ b/testing-tools/rdb-compare/tests/test_catalog.py
@@ -1,0 +1,115 @@
+"""Tests for the default known-differences catalog.
+
+These assert that :func:`build_default_registry` produces a healthy, populated
+registry and that representative rules from each section of the "RTR reporting
+differences" page classify as documented.
+"""
+
+from __future__ import annotations
+
+from rdb_compare.models import CellDiff, Verdict
+from rdb_compare.rules.catalog import (
+    EXPECTED,
+    IGNORE_COLUMNS,
+    KNOWN_BUGS,
+    SKIP_TABLES,
+    build_default_registry,
+)
+
+
+def cell(table, column, rdb=None, modern=None, key=(1,)):
+    return CellDiff(table=table, key=key, column=column, rdb_value=rdb, modern_value=modern)
+
+
+# --- registry shape ----------------------------------------------------
+def test_registry_is_non_empty_and_healthy():
+    reg = build_default_registry()
+    assert len(reg) >= 40
+    # No duplicate rule ids.
+    ids = [r.id for r in reg.rules]
+    assert len(ids) == len(set(ids))
+
+
+def test_section_lists_are_populated():
+    assert len(SKIP_TABLES) >= 10
+    assert len(IGNORE_COLUMNS) >= 5
+    assert len(EXPECTED) >= 20
+    assert len(KNOWN_BUGS) >= 30
+
+
+# --- skip-list ----------------------------------------------------------
+def test_skip_listed_tables_are_skipped():
+    reg = build_default_registry()
+    assert reg.is_skipped("ETL_DQ_LOG")
+    assert reg.is_skipped("ETL_PROCESS")
+    assert reg.is_skipped("EVENT_METRIC")
+    # Prefix families.
+    assert reg.is_skipped("S_INV_MEDICAL_HISTORY")   # staging S_
+    assert reg.is_skipped("SAS_WORK_TABLE")          # SAS_
+    assert reg.is_skipped("TEMP_SCRATCH")            # TEMP_
+    assert reg.is_skipped("nrt_investigation")       # RDB_MODERN-only nrt_
+    assert reg.is_skipped("LOOKUP_CONDITION")        # LOOKUP_
+    # A real dimension table is NOT skipped.
+    assert not reg.is_skipped("D_PATIENT")
+
+
+# --- _KEY offset --------------------------------------------------------
+def test_key_columns_are_ignored():
+    reg = build_default_registry()
+    c = reg.classify_column("D_INV_SYMPTOM", "D_INV_SYMPTOM_KEY",
+                            [cell("D_INV_SYMPTOM", "D_INV_SYMPTOM_KEY", rdb="5", modern="8")])
+    assert c.verdict == Verdict.IGNORED
+    assert "offset" in c.reason.lower()
+
+
+# --- environment / timestamp -------------------------------------------
+def test_env_timestamp_columns_are_ignored():
+    reg = build_default_registry()
+    c1 = reg.classify_column("LAB_TEST", "RDB_LAST_REFRESH_TIME",
+                            [cell("LAB_TEST", "RDB_LAST_REFRESH_TIME", rdb="a", modern="b")])
+    assert c1.verdict == Verdict.IGNORED
+
+    c2 = reg.classify_column("SOME_TABLE", "RECORD_LAST_REFRESH_TIME",
+                            [cell("SOME_TABLE", "RECORD_LAST_REFRESH_TIME", rdb="a", modern="b")])
+    assert c2.verdict == Verdict.IGNORED
+
+
+# --- known bugs ---------------------------------------------------------
+def test_d_place_is_known_bug():
+    reg = build_default_registry()
+    c = reg.classify_column("D_PLACE", "PLACE_NM",
+                            [cell("D_PLACE", "PLACE_NM", rdb="x", modern=None)])
+    assert c.verdict == Verdict.KNOWN_BUG
+    assert c.rule_id == "BUG-D_PLACE-not_populated"
+
+
+def test_d_inv_symptom_fever_is_known_bug():
+    reg = build_default_registry()
+    c = reg.classify_column("D_INV_SYMPTOM", "SYM_FEVER_HIGHEST_TEMP",
+                            [cell("D_INV_SYMPTOM", "SYM_FEVER_HIGHEST_TEMP", rdb="102", modern=None)])
+    assert c.verdict == Verdict.KNOWN_BUG
+
+
+def test_org_facility_auth_null_is_known_bug():
+    reg = build_default_registry()
+    c = reg.classify_column("D_ORGANIZATION", "ORGANIZATION_FACILITY_AUTH",
+                            [cell("D_ORGANIZATION", "ORGANIZATION_FACILITY_AUTH", rdb="NPI", modern=None)])
+    assert c.verdict == Verdict.KNOWN_BUG
+
+
+# --- expected differences ----------------------------------------------
+def test_documented_expected_diff():
+    reg = build_default_registry()
+    # INV_SUMM_DATAMART notification columns: NULL in RDB, populated in modern.
+    c = reg.classify_column("INV_SUMM_DATAMART", "NOTIFICATION_STATUS",
+                            [cell("INV_SUMM_DATAMART", "NOTIFICATION_STATUS", rdb=None, modern="Approved")])
+    assert c.verdict == Verdict.EXPECTED
+
+
+def test_expected_predicate_only_applies_to_documented_shape():
+    reg = build_default_registry()
+    # The rule expects RDB-null/modern-set; a real value-vs-value diff should
+    # NOT be absorbed and stays NEW.
+    cells = [cell("INV_SUMM_DATAMART", "NOTIFICATION_STATUS", rdb="Open", modern="Approved")]
+    c = reg.classify_column("INV_SUMM_DATAMART", "NOTIFICATION_STATUS", cells)
+    assert c.verdict == Verdict.NEW

--- a/testing-tools/rdb-compare/tests/test_classifier.py
+++ b/testing-tools/rdb-compare/tests/test_classifier.py
@@ -1,0 +1,69 @@
+from rdb_compare.classifier import classify_run, summarize
+from rdb_compare.models import (
+    CellDiff,
+    ColumnDiff,
+    Presence,
+    RunReport,
+    TableResult,
+    Verdict,
+)
+from rdb_compare.rules import IgnoreColumnRule, KnownBugRule, RuleRegistry, SkipTableRule
+
+
+def _col(table, name, rdb=None, modern=None):
+    samples = [CellDiff(table=table, key=(1,), column=name, rdb_value=rdb, modern_value=modern)]
+    return ColumnDiff(table=table, column=name, compared=10, mismatches=1, samples=samples)
+
+
+def _registry():
+    return RuleRegistry([
+        SkipTableRule("ETL_*", "staging table"),
+        IgnoreColumnRule("*_LAST_UPDATE_DT", "ETL timing", category="env"),
+        KnownBugRule("D_PLACE", "*", "D_PLACE not populated by RTR", ticket="PDF-bug-1"),
+    ])
+
+
+def test_skipped_table_is_marked_and_columns_left_unclassified():
+    rpt = RunReport(rdb_db="RDB", modern_db="RDB_MODERN", tables=[
+        TableResult(table="ETL_CONTROL", columns=[_col("ETL_CONTROL", "X")]),
+    ])
+    classify_run(rpt, _registry())
+    t = rpt.tables[0]
+    assert t.skipped
+    assert t.classification.verdict == Verdict.IGNORED
+
+
+def test_column_verdicts_assigned():
+    rpt = RunReport(rdb_db="RDB", modern_db="RDB_MODERN", compared=2, tables=[
+        TableResult(table="D_PATIENT", presence=Presence.BOTH, columns=[
+            _col("D_PATIENT", "FIRST_NM", rdb="ALICE", modern="BOB"),       # NEW
+            _col("D_PATIENT", "RECORD_LAST_UPDATE_DT", rdb="1", modern="2"),  # IGNORED
+        ]),
+        TableResult(table="D_PLACE", presence=Presence.BOTH, columns=[
+            _col("D_PLACE", "PLACE_NM", rdb="x", modern="y"),                # KNOWN_BUG
+        ]),
+    ])
+    classify_run(rpt, _registry())
+    verdicts = {
+        (t.table, c.column): c.classification.verdict
+        for t in rpt.tables for c in t.columns
+    }
+    assert verdicts[("D_PATIENT", "FIRST_NM")] == Verdict.NEW
+    assert verdicts[("D_PATIENT", "RECORD_LAST_UPDATE_DT")] == Verdict.IGNORED
+    assert verdicts[("D_PLACE", "PLACE_NM")] == Verdict.KNOWN_BUG
+
+
+def test_summarize_counts_and_actionable():
+    rpt = RunReport(rdb_db="RDB", modern_db="RDB_MODERN", discovered=3, skipped=1, compared=2, tables=[
+        TableResult(table="D_PATIENT", columns=[
+            _col("D_PATIENT", "FIRST_NM", rdb="ALICE", modern="BOB"),
+            _col("D_PATIENT", "RECORD_LAST_UPDATE_DT", rdb="1", modern="2"),
+        ]),
+        TableResult(table="D_PLACE", columns=[_col("D_PLACE", "PLACE_NM", rdb="x", modern="y")]),
+    ])
+    classify_run(rpt, _registry())
+    s = summarize(rpt)
+    assert s["verdict_counts"][Verdict.NEW.value] == 1
+    assert s["verdict_counts"][Verdict.IGNORED.value] == 1
+    assert s["verdict_counts"][Verdict.KNOWN_BUG.value] == 1
+    assert s["actionable_tables"] == 1  # only D_PATIENT has a NEW diff

--- a/testing-tools/rdb-compare/tests/test_discovery.py
+++ b/testing-tools/rdb-compare/tests/test_discovery.py
@@ -1,0 +1,99 @@
+import rdb_compare.db as db
+from rdb_compare.discovery import discover
+from rdb_compare.rules import RuleRegistry, SkipTableRule
+
+
+def _fake_list_tables(monkeypatch, rdb_set, modern_set):
+    """Stub rdb_compare.db.list_tables to return canned sets per database."""
+    def fake(conn, database):
+        return set(rdb_set) if database == "RDB" else set(modern_set)
+
+    monkeypatch.setattr(db, "list_tables", fake)
+
+
+def test_intersection_only(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "INVESTIGATION", "RDB_ONLY"},
+        modern_set={"D_PATIENT", "INVESTIGATION", "NRT_INVESTIGATION"},
+    )
+    reg = RuleRegistry()  # no skip rules
+    out = discover(object(), "RDB", "RDB_MODERN", reg)
+    assert out == ["D_PATIENT", "INVESTIGATION"]
+
+
+def test_sorted_output(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"Z_TABLE", "A_TABLE", "M_TABLE"},
+        modern_set={"Z_TABLE", "A_TABLE", "M_TABLE"},
+    )
+    out = discover(object(), "RDB", "RDB_MODERN", RuleRegistry())
+    assert out == ["A_TABLE", "M_TABLE", "Z_TABLE"]
+
+
+def test_skip_rule_excludes_table(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "ETL_PROCESS", "S_PATIENT"},
+        modern_set={"D_PATIENT", "ETL_PROCESS", "S_PATIENT"},
+    )
+    reg = RuleRegistry([
+        SkipTableRule("ETL_*", "ETL bookkeeping"),
+        SkipTableRule("S_*", "staging table"),
+    ])
+    out = discover(object(), "RDB", "RDB_MODERN", reg)
+    assert out == ["D_PATIENT"]
+
+
+def test_include_globs_keep_only_matches(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "D_PROVIDER", "INVESTIGATION", "LAB_TEST"},
+        modern_set={"D_PATIENT", "D_PROVIDER", "INVESTIGATION", "LAB_TEST"},
+    )
+    out = discover(
+        object(), "RDB", "RDB_MODERN", RuleRegistry(), include=["D_*"]
+    )
+    assert out == ["D_PATIENT", "D_PROVIDER"]
+
+
+def test_include_is_case_insensitive(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "LAB_TEST"},
+        modern_set={"D_PATIENT", "LAB_TEST"},
+    )
+    out = discover(
+        object(), "RDB", "RDB_MODERN", RuleRegistry(), include=["lab_*"]
+    )
+    assert out == ["LAB_TEST"]
+
+
+def test_exclude_globs_drop_matches(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "D_PROVIDER", "LAB_TEST"},
+        modern_set={"D_PATIENT", "D_PROVIDER", "LAB_TEST"},
+    )
+    out = discover(
+        object(), "RDB", "RDB_MODERN", RuleRegistry(), exclude=["D_*"]
+    )
+    assert out == ["LAB_TEST"]
+
+
+def test_include_and_exclude_combine(monkeypatch):
+    _fake_list_tables(
+        monkeypatch,
+        rdb_set={"D_PATIENT", "D_PROVIDER", "D_INV_SYMPTOM"},
+        modern_set={"D_PATIENT", "D_PROVIDER", "D_INV_SYMPTOM"},
+    )
+    out = discover(
+        object(),
+        "RDB",
+        "RDB_MODERN",
+        RuleRegistry(),
+        include=["D_*"],
+        exclude=["*_PROVIDER"],
+    )
+    assert out == ["D_INV_SYMPTOM", "D_PATIENT"]

--- a/testing-tools/rdb-compare/tests/test_engine.py
+++ b/testing-tools/rdb-compare/tests/test_engine.py
@@ -1,0 +1,187 @@
+"""Engine tests: SQL shape (build_value_diff_sql) and folding (compare_table).
+
+``compare_table`` is exercised against a fake connection whose ``run_query``
+returns canned rows keyed off substrings of the SQL it is handed, so the test
+needs no live SQL Server.
+"""
+
+from __future__ import annotations
+
+from rdb_compare import db, engine
+from rdb_compare.engine import build_value_diff_sql, compare_table
+from rdb_compare.models import Presence
+
+
+# --- SQL shape ---------------------------------------------------------
+def test_build_value_diff_sql_shape():
+    sql = build_value_diff_sql(
+        "LAB_TEST",
+        ["LAB_TEST_UID"],
+        ["RESULT", "STATUS"],
+        "RDB",
+        "RDB_MODERN",
+    )
+    # Table + both databases appear.
+    assert "LAB_TEST" in sql
+    assert "[RDB]" in sql
+    assert "[RDB_MODERN]" in sql
+    # Join on the key column.
+    assert "L.[LAB_TEST_UID] = M.[LAB_TEST_UID]" in sql
+    # NULL-safe EXCEPT difference test.
+    assert "EXISTS (SELECT L.[RESULT] EXCEPT SELECT M.[RESULT])" in sql
+    # Values cast to NVARCHAR.
+    assert "CAST(L.[RESULT] AS NVARCHAR(4000))" in sql
+    # One branch per value column, joined with UNION ALL.
+    assert sql.count("UNION ALL") == 1
+    assert "N'RESULT' AS [column_name]" in sql
+    assert "N'STATUS' AS [column_name]" in sql
+
+
+def test_build_value_diff_sql_composite_key():
+    sql = build_value_diff_sql(
+        "LAB100",
+        ["LAB_RPT_LOCAL_ID", "LAB_RPT_UID"],
+        ["COMMENTS"],
+        "RDB",
+        "RDB_MODERN",
+    )
+    assert (
+        "L.[LAB_RPT_LOCAL_ID] = M.[LAB_RPT_LOCAL_ID] "
+        "AND L.[LAB_RPT_UID] = M.[LAB_RPT_UID]"
+    ) in sql
+
+
+# --- compare_table folding --------------------------------------------
+class FakeConn:
+    """Stands in for a pymssql connection; dispatches on SQL substrings."""
+
+    def __init__(self, counts, overlap, diffs, key_dup=False):
+        self._counts = list(counts)  # consumed in call order: RDB then MODERN
+        self._overlap = overlap
+        self._diffs = diffs
+        self._key_dup = key_dup       # True => key-uniqueness probe reports a dup
+
+
+def _fake_run_query(conn, sql):
+    if "[dup]" in sql:  # key-uniqueness probe: one row iff non-unique
+        return [{"dup": 1}] if conn._key_dup else []
+    if "COUNT(*)" in sql and "matched_keys" not in sql:
+        return [{"n": conn._counts.pop(0)}]
+    if "matched_keys" in sql:
+        return [conn._overlap]
+    if "column_name" in sql:
+        return conn._diffs
+    raise AssertionError(f"unexpected SQL: {sql[:60]}")
+
+
+def test_compare_table_folds_counts_and_diffs(monkeypatch):
+    monkeypatch.setattr(db, "run_query", _fake_run_query)
+
+    diffs = [
+        {"LAB_TEST_UID": "1", "column_name": "RESULT",
+         "rdb_value": "pos", "modern_value": "neg"},
+        {"LAB_TEST_UID": "2", "column_name": "RESULT",
+         "rdb_value": "a", "modern_value": "b"},
+        {"LAB_TEST_UID": "3", "column_name": "STATUS",
+         "rdb_value": None, "modern_value": "X"},
+    ]
+    conn = FakeConn(
+        counts=[100, 98],
+        overlap={"matched_keys": 95, "rdb_only_keys": 5, "modern_only_keys": 3},
+        diffs=diffs,
+    )
+
+    res = compare_table(
+        conn, "LAB_TEST", ["LAB_TEST_UID"], ["RESULT", "STATUS"],
+        "RDB", "RDB_MODERN",
+    )
+
+    assert res.error is None
+    assert res.rdb_count == 100
+    assert res.modern_count == 98
+    assert res.matched_keys == 95
+    assert res.rdb_only_keys == 5
+    assert res.modern_only_keys == 3
+    assert res.presence == Presence.BOTH
+    assert res.key_columns == ("LAB_TEST_UID",)
+
+    # Two columns mismatched; ordered per value_cols.
+    cols = {c.column: c for c in res.columns}
+    assert [c.column for c in res.columns] == ["RESULT", "STATUS"]
+    assert cols["RESULT"].mismatches == 2
+    assert cols["RESULT"].compared == 95
+    assert cols["STATUS"].mismatches == 1
+    # Sample CellDiff captured correctly.
+    s = cols["RESULT"].samples[0]
+    assert s.key == ("1",)
+    assert s.rdb_value == "pos"
+    assert s.modern_value == "neg"
+
+
+def test_compare_table_caps_samples(monkeypatch):
+    monkeypatch.setattr(db, "run_query", _fake_run_query)
+
+    diffs = [
+        {"LAB_TEST_UID": str(i), "column_name": "RESULT",
+         "rdb_value": f"l{i}", "modern_value": f"m{i}"}
+        for i in range(50)
+    ]
+    conn = FakeConn(
+        counts=[60, 60],
+        overlap={"matched_keys": 50, "rdb_only_keys": 0, "modern_only_keys": 0},
+        diffs=diffs,
+    )
+
+    res = compare_table(
+        conn, "LAB_TEST", ["LAB_TEST_UID"], ["RESULT"],
+        "RDB", "RDB_MODERN", sample_cap=20,
+    )
+    col = res.columns[0]
+    assert col.mismatches == 50          # every differing row counted
+    assert len(col.samples) == 20        # but samples capped
+
+
+def test_compare_table_no_key_counts_only(monkeypatch):
+    monkeypatch.setattr(db, "run_query", _fake_run_query)
+    conn = FakeConn(counts=[10, 10], overlap=None, diffs=[])
+
+    res = compare_table(conn, "SOME_TABLE", [], ["A", "B"], "RDB", "RDB_MODERN")
+
+    assert res.rdb_count == 10
+    assert res.modern_count == 10
+    assert res.columns == []
+    assert res.error == "no usable key; counts only"
+
+
+def test_compare_table_nonunique_key_degrades_to_counts(monkeypatch):
+    """A resolved key that repeats (reference table) must not fan out: the probe
+    trips and the table degrades to counts-only instead of joining."""
+    monkeypatch.setattr(db, "run_query", _fake_run_query)
+    # diffs/overlap would be wrong to reach; key_dup=True trips the probe first.
+    conn = FakeConn(
+        counts=[158776, 125548], overlap=None, diffs=[], key_dup=True
+    )
+
+    res = compare_table(
+        conn, "REF_FORMCODE_TRANSLATION", ["NBS_QUESTION_UID"],
+        ["CODE", "CODE_SHORT_DESC_TXT"], "RDB", "RDB_MODERN",
+    )
+
+    assert res.rdb_count == 158776
+    assert res.modern_count == 125548
+    assert res.columns == []                 # never ran the fan-out join
+    assert res.matched_keys == 0
+    assert "not unique" in res.error
+    assert "RDB" in res.error
+
+
+def test_compare_table_records_sql_error(monkeypatch):
+    def boom(conn, sql):
+        raise RuntimeError("Invalid object name 'RDB.dbo.MISSING'")
+
+    monkeypatch.setattr(db, "run_query", boom)
+    conn = FakeConn(counts=[], overlap=None, diffs=[])
+
+    res = compare_table(conn, "MISSING", ["UID"], ["A"], "RDB", "RDB_MODERN")
+    assert res.error is not None
+    assert "MISSING" in res.error

--- a/testing-tools/rdb-compare/tests/test_keys.py
+++ b/testing-tools/rdb-compare/tests/test_keys.py
@@ -1,0 +1,90 @@
+from rdb_compare.keys import KEY_CONFIG, resolve_keys
+
+
+# --- (1) KEY_CONFIG hits -------------------------------------------------
+def test_config_single_uid_hit_lab_test():
+    # LAB_TEST is pinned to LAB_TEST_UID by the single-UID SQL template.
+    cols = ["LAB_TEST_KEY", "LAB_TEST_UID", "TEST_METHOD_CD"]
+    assert resolve_keys("LAB_TEST", cols) == ("LAB_TEST_UID",)
+
+
+def test_config_two_id_hit_lab100():
+    # LAB100 needs both LAB_RPT_LOCAL_ID and LAB_RPT_UID (2-id template).
+    cols = ["LAB_RPT_LOCAL_ID", "LAB_RPT_UID", "RESULTED_LAB_TEST_KEY"]
+    assert resolve_keys("LAB100", cols) == ("LAB_RPT_LOCAL_ID", "LAB_RPT_UID")
+
+
+def test_config_lookup_is_case_insensitive_in_both_directions():
+    # Lowercase table name and mixed-case columns still resolve, returning the
+    # columns spelled as they actually appear in available_columns.
+    cols = ["Lab_Test_Uid", "test_method_cd"]
+    assert resolve_keys("lab_test", cols) == ("Lab_Test_Uid",)
+
+
+def test_config_d_inv_uses_nbs_case_answer_uid():
+    # D_INV_* tables key on NBS_CASE_ANSWER_UID per the offset section, never
+    # the D_INV_*_KEY surrogate.
+    cols = ["D_INV_SYMPTOM_KEY", "NBS_CASE_ANSWER_UID", "SYMPTOM_TXT"]
+    assert resolve_keys("D_INV_SYMPTOM", cols) == ("NBS_CASE_ANSWER_UID",)
+
+
+def test_config_falls_through_when_configured_column_missing():
+    # MORBIDITY_REPORT is configured for MORBIDITY_REPORT_LOCAL_ID; if that
+    # column is absent the config is skipped and the heuristic takes over.
+    cols = ["MORBIDITY_REPORT_KEY", "MORB_RPT_UID"]
+    # No *_LOCAL_ID -> falls to *_UID (and never the *_KEY surrogate).
+    assert resolve_keys("MORBIDITY_REPORT", cols) == ("MORB_RPT_UID",)
+
+
+# --- (2) *_LOCAL_ID preference ------------------------------------------
+def test_local_id_preferred_over_uid():
+    # An unconfigured table with both a LOCAL_ID and a UID picks the LOCAL_ID.
+    cols = ["PROVIDER_KEY", "PROVIDER_UID", "PROVIDER_LOCAL_ID"]
+    assert resolve_keys("D_PROVIDER", cols) == ("PROVIDER_LOCAL_ID",)
+
+
+def test_local_id_prefers_entity_matching_prefix():
+    # When several *_LOCAL_ID columns exist, prefer the one whose prefix
+    # matches the table entity (PATIENT), not the first-listed one.
+    cols = ["INVESTIGATION_LOCAL_ID", "PATIENT_LOCAL_ID", "PATIENT_KEY"]
+    assert resolve_keys("D_PATIENT", cols) == ("PATIENT_LOCAL_ID",)
+
+
+def test_local_id_falls_back_to_first_when_no_prefix_match():
+    cols = ["FOO_LOCAL_ID", "BAR_LOCAL_ID"]
+    assert resolve_keys("UNRELATED_TABLE", cols) == ("FOO_LOCAL_ID",)
+
+
+# --- (3) *_UID fallback --------------------------------------------------
+def test_uid_fallback_when_no_local_id():
+    cols = ["SOMETHING_KEY", "EVENT_UID", "DESCRIPTION"]
+    assert resolve_keys("SOME_FACT", cols) == ("EVENT_UID",)
+
+
+# --- (4) *_KEY is never returned ----------------------------------------
+def test_key_surrogate_never_returned():
+    # Only a surrogate *_KEY is available -> no usable business key.
+    cols = ["PATIENT_KEY", "FIRST_NM", "LAST_NM"]
+    assert resolve_keys("D_PATIENT", cols) is None
+
+
+def test_key_with_uid_suffix_is_not_treated_as_uid():
+    # A column ending in _KEY must not be picked even though "_UID" matching is
+    # the fallback tier; there is no real *_UID here.
+    cols = ["RESULTED_LAB_TEST_KEY", "LAB_TEST_KEY"]
+    assert resolve_keys("SOME_BRIDGE", cols) is None
+
+
+# --- (5) None when nothing usable ---------------------------------------
+def test_none_when_no_usable_key():
+    cols = ["FIRST_NM", "LAST_NM", "BIRTH_DT"]
+    assert resolve_keys("D_PATIENT", cols) is None
+
+
+# --- sanity on the seed --------------------------------------------------
+def test_key_config_is_uppercase_and_tuples():
+    for table, key in KEY_CONFIG.items():
+        assert table == table.upper()
+        assert isinstance(key, tuple) and key
+        # No surrogate *_KEY columns are ever configured as keys.
+        assert not any(c.upper().endswith("_KEY") for c in key)

--- a/testing-tools/rdb-compare/tests/test_report.py
+++ b/testing-tools/rdb-compare/tests/test_report.py
@@ -1,0 +1,140 @@
+"""Tests for the report layer (JSON + Markdown rendering)."""
+
+from __future__ import annotations
+
+import json
+
+from rdb_compare.classifier import classify_run
+from rdb_compare.models import (
+    CellDiff,
+    ColumnDiff,
+    Presence,
+    RunReport,
+    TableResult,
+)
+from rdb_compare.report import render_markdown, to_dict
+from rdb_compare.rules import IgnoreColumnRule, KnownBugRule, RuleRegistry, SkipTableRule
+
+
+def _col(table, name, rdb=None, modern=None):
+    samples = [CellDiff(table=table, key=("PAT-1",), column=name, rdb_value=rdb, modern_value=modern)]
+    return ColumnDiff(table=table, column=name, compared=10, mismatches=1, samples=samples)
+
+
+def _registry():
+    return RuleRegistry(
+        [
+            SkipTableRule("ETL_*", "staging table"),
+            IgnoreColumnRule("*_LAST_UPDATE_DT", "ETL timing", category="env"),
+            KnownBugRule("D_PLACE", "*", "D_PLACE not populated by RTR", ticket="PDF-bug-1"),
+        ]
+    )
+
+
+def _classified_report():
+    rpt = RunReport(
+        rdb_db="RDB",
+        modern_db="RDB_MODERN",
+        generated_at="2026-06-05T00:00:00Z",
+        discovered=3,
+        skipped=1,
+        compared=2,
+        tables=[
+            TableResult(
+                table="D_PATIENT",
+                presence=Presence.BOTH,
+                key_columns=("PATIENT_UID",),
+                rdb_count=100,
+                modern_count=101,
+                matched_keys=100,
+                rdb_only_keys=0,
+                modern_only_keys=1,
+                columns=[
+                    _col("D_PATIENT", "FIRST_NM", rdb="ALICE", modern="BOB"),
+                    _col("D_PATIENT", "RECORD_LAST_UPDATE_DT", rdb="1", modern="2"),
+                ],
+            ),
+            TableResult(
+                table="D_PLACE",
+                presence=Presence.BOTH,
+                key_columns=("PLACE_UID",),
+                columns=[_col("D_PLACE", "PLACE_NM", rdb="x", modern="y")],
+            ),
+            TableResult(
+                table="ETL_CONTROL",
+                presence=Presence.BOTH,
+                columns=[_col("ETL_CONTROL", "BATCH_STATUS", rdb="A", modern="B")],
+            ),
+        ],
+    )
+    return classify_run(rpt, _registry())
+
+
+def test_to_dict_is_json_serializable_and_round_trips():
+    rpt = _classified_report()
+    d = to_dict(rpt)
+
+    # json.dumps must succeed without a custom encoder.
+    text = json.dumps(d)
+    back = json.loads(text)
+
+    assert back["rdb_db"] == "RDB"
+    assert back["modern_db"] == "RDB_MODERN"
+    assert back["generated_at"] == "2026-06-05T00:00:00Z"
+    # summarize() ignores skipped tables' columns: the skipped ETL_CONTROL table
+    # contributes a single IGNORED (the table itself), not a NEW, so only the
+    # genuine D_PATIENT.FIRST_NM rolls up as NEW.
+    assert back["summary"]["verdict_counts"]["NEW"] == 1
+    assert back["summary"]["verdict_counts"]["IGNORED"] == 2  # env column + skipped table
+    assert back["summary"]["verdict_counts"]["KNOWN_BUG"] == 1
+
+    by_name = {t["table"]: t for t in back["tables"]}
+    patient = by_name["D_PATIENT"]
+    # tuples became lists
+    assert patient["key_columns"] == ["PATIENT_UID"]
+    assert patient["presence"] == "both"
+    assert patient["row_count_matches"] is False
+
+    cols = {c["column"]: c for c in patient["columns"]}
+    assert cols["FIRST_NM"]["classification"]["verdict"] == "NEW"
+    assert cols["RECORD_LAST_UPDATE_DT"]["classification"]["verdict"] == "IGNORED"
+    assert cols["FIRST_NM"]["samples"][0]["rdb_value"] == "ALICE"
+    assert cols["FIRST_NM"]["samples"][0]["modern_value"] == "BOB"
+    assert cols["FIRST_NM"]["samples"][0]["key"] == ["PAT-1"]
+
+    # skipped table marked
+    assert by_name["ETL_CONTROL"]["skipped"] is True
+
+
+def test_render_markdown_has_expected_structure():
+    rpt = _classified_report()
+    md = render_markdown(rpt)
+
+    # H1 title + metadata
+    assert "# RDB vs RDB_MODERN Comparison Report" in md
+    assert "RDB_MODERN" in md
+
+    # Summary section + verdict labels
+    assert "## Summary" in md
+    assert "NEW" in md
+    assert "KNOWN_BUG" in md
+    assert "IGNORED" in md
+
+    # Attention section comes first and names the NEW table + column row
+    assert "## Tables needing attention (NEW differences)" in md
+    assert "`D_PATIENT`" in md
+    assert "FIRST_NM" in md
+
+    # Known-bug section names the bug table
+    assert "## Known-bug differences" in md
+    assert "`D_PLACE`" in md
+
+    # Skipped table is mentioned in its own section
+    assert "## Skipped / ignored tables" in md
+    assert "ETL_CONTROL" in md
+
+    # NEW ordering: within D_PATIENT, FIRST_NM (NEW) precedes the IGNORED audit col
+    assert md.index("FIRST_NM") < md.index("RECORD_LAST_UPDATE_DT")
+
+    # Attention section precedes the known-bug section
+    assert md.index("## Tables needing attention") < md.index("## Known-bug differences")

--- a/testing-tools/rdb-compare/tests/test_rules.py
+++ b/testing-tools/rdb-compare/tests/test_rules.py
@@ -1,0 +1,101 @@
+from rdb_compare.models import CellDiff, Verdict
+from rdb_compare.rules import (
+    ExpectedDiffRule,
+    IgnoreColumnRule,
+    KnownBugRule,
+    RuleRegistry,
+    SkipTableRule,
+)
+from rdb_compare.rules import predicates as P
+
+
+def cell(table="T", column="C", rdb=None, modern=None, key=(1,)):
+    return CellDiff(table=table, key=key, column=column, rdb_value=rdb, modern_value=modern)
+
+
+# --- name matching -----------------------------------------------------
+def test_skip_table_glob_matches_case_insensitively():
+    r = SkipTableRule("ETL_*", "staging table")
+    assert r.matches_table("ETL_CONTROL")
+    assert r.matches_table("etl_control")
+    assert not r.matches_table("D_PATIENT")
+    assert r.scope == "table"
+    assert r.verdict == Verdict.IGNORED
+
+
+def test_ignore_column_matches_suffix_glob_any_table():
+    r = IgnoreColumnRule("*_LAST_UPDATE_DT", "ETL timing", category="env")
+    assert r.matches_column("D_PATIENT", "RECORD_LAST_UPDATE_DT")
+    assert not r.matches_column("D_PATIENT", "PATIENT_KEY")
+
+
+def test_ignore_column_scoped_to_table():
+    r = IgnoreColumnRule("*_KEY", "surrogate offset", table_pattern="D_PATIENT", category="key")
+    assert r.matches_column("D_PATIENT", "PATIENT_KEY")
+    assert not r.matches_column("D_PROVIDER", "PROVIDER_KEY")
+
+
+# --- predicates --------------------------------------------------------
+def test_rdb_null_modern_set_predicate():
+    assert P.rdb_null_modern_set(cell(rdb=None, modern="X"))
+    assert P.rdb_null_modern_set(cell(rdb="  ", modern="X"))
+    assert not P.rdb_null_modern_set(cell(rdb="Y", modern="X"))
+    assert not P.rdb_null_modern_set(cell(rdb=None, modern=None))
+
+
+def test_null_vs_empty_predicate():
+    assert P.null_vs_empty(cell(rdb=None, modern=""))
+    assert P.null_vs_empty(cell(rdb="", modern=None))
+    assert not P.null_vs_empty(cell(rdb="a", modern=""))
+
+
+# --- registry ordering & classification --------------------------------
+def test_known_bug_beats_generic_ignore_on_same_column():
+    # A generic env-timestamp ignore and a specific known-bug both match;
+    # the bug (base_priority 20) must win over ignore (40).
+    reg = RuleRegistry([
+        IgnoreColumnRule("*_DT", "env timestamp", category="env"),
+        KnownBugRule("D_FOO", "BAR_DT", "bug: never populated", ticket="PDF-37"),
+    ])
+    cls = reg.classify_column("D_FOO", "BAR_DT", [cell(table="D_FOO", column="BAR_DT")])
+    assert cls.verdict == Verdict.KNOWN_BUG
+    assert cls.rule_id == "BUG-D_FOO.BAR_DT"
+
+
+def test_unmatched_column_is_new():
+    reg = RuleRegistry([SkipTableRule("ETL_*", "staging")])
+    cls = reg.classify_column("D_PATIENT", "FIRST_NM", [cell()])
+    assert cls.verdict == Verdict.NEW
+    assert cls.rule_id is None
+
+
+def test_predicate_rule_only_applies_when_all_cells_match():
+    reg = RuleRegistry([
+        ExpectedDiffRule(
+            "TREATMENT", "TREATMENT_COMMENTS",
+            "NULL vs empty representation only",
+            predicate=P.null_vs_empty,
+        ),
+    ])
+    # All cells fit the NULL-vs-empty pattern -> EXPECTED.
+    good = [cell(table="TREATMENT", column="TREATMENT_COMMENTS", rdb=None, modern="")]
+    assert reg.classify_column("TREATMENT", "TREATMENT_COMMENTS", good).verdict == Verdict.EXPECTED
+    # One cell is a real value diff -> the rule does NOT apply -> NEW.
+    mixed = good + [cell(table="TREATMENT", column="TREATMENT_COMMENTS", rdb="aspirin", modern="ibuprofen")]
+    assert reg.classify_column("TREATMENT", "TREATMENT_COMMENTS", mixed).verdict == Verdict.NEW
+
+
+def test_classify_table_returns_none_when_not_skipped():
+    reg = RuleRegistry([SkipTableRule("ETL_*", "staging")])
+    assert reg.classify_table("D_PATIENT") is None
+    assert reg.is_skipped("ETL_CONTROL")
+    assert reg.classify_table("ETL_CONTROL").verdict == Verdict.IGNORED
+
+
+def test_exact_table_beats_glob_within_same_priority():
+    reg = RuleRegistry([
+        ExpectedDiffRule("*", "STATUS", "generic status diff", id="EXP-generic"),
+        ExpectedDiffRule("D_INV", "STATUS", "specific", id="EXP-specific"),
+    ])
+    cls = reg.classify_column("D_INV", "STATUS", [cell(table="D_INV", column="STATUS")])
+    assert cls.rule_id == "EXP-specific"


### PR DESCRIPTION
## Description
Adds `rdb-compare`, a local tool for comparing the legacy **RDB** (MasterETL/SAS) against **RDB_MODERN** (the RTR pipeline). It matches rows on each table's business/UID key (never the surrogate `*_KEY` columns, which carry documented offsets), compares every other column NULL-aware via a cross-database join, and classifies each difference as **NEW** (unexplained, needs attention), **EXPECTED** (by design), **KNOWN_BUG**, or **IGNORED**. The known/expected differences live in a declarative rule registry (`rdb_compare/rules/`) rather than scattered if/else, so the report keeps the spotlight on the unexplained diffs. It emits a machine-readable `comparison.json` and a human-readable `comparison.md`.

It is the local-development counterpart to [CDCgov/NEDSS-DataCompare](https://github.com/CDCgov/NEDSS-DataCompare): the same key columns and comparison approach, but a single tool that reads two databases in one SQL Server instance, without the S3/Kafka/Spring machinery.

## Related Issue
[APP-720](https://cdc-nbs.atlassian.net/browse/APP-720)

## Additional Notes
This work was heavily influenced by @eliSkylight's comparison-testing work and his local testing tool.

Split out of the APP-471 synthetic ODSE fixtures work so it can be reviewed on its own. It is the comparison tool that pairs with that work, not the APP-471 PR itself. The engine, rule registry, classifier, and report renderers are unit-tested without a live database (`uv run pytest`); the DB layer is integration-tested against the dev SQL Server.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
