### PR TITLE
add flag to pause test

### DIFF
--- a/testing-tools/functional-test/README.md
+++ b/testing-tools/functional-test/README.md
@@ -140,6 +140,7 @@ uv run functional-test -S localhost:3433 -U rtr_admin \
 | `--max-retry` | `40` | Maximum polls per query before failing. |
 | `--retry-delay` | `6` | Seconds between polls. |
 | `--fail-fast` | off | Stop after the first failing test. |
+| `--pause` | off | Pause and wait for Enter after each step completes (Ctrl-C to abort), so you can inspect the database between steps. |
 | `--debug` | off | Live-print each query's SQL and its expected vs actual results on every poll attempt. |
 | `--list` | off | List discovered tests and exit (no DB connection). |
 

--- a/testing-tools/functional-test/src/functional_test/cli.py
+++ b/testing-tools/functional-test/src/functional_test/cli.py
@@ -14,6 +14,7 @@ from .runner import (
     DEFAULT_RETRY_DELAY,
     Database,
     QueryResult,
+    StepResult,
     TestResult,
     discover_tests,
     parse_address,
@@ -155,6 +156,12 @@ def build_parser(defaults: dict[str, str] | None = None) -> argparse.ArgumentPar
         help="Stop after the first failing test.",
     )
     parser.add_argument(
+        "--pause",
+        action="store_true",
+        help="Pause and wait for Enter after each step completes (Ctrl-C to abort), so "
+        "you can inspect the database between steps.",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Live-print each query's SQL and its expected vs actual results on every poll "
@@ -278,6 +285,16 @@ def main(argv: list[str] | None = None) -> int:
             _print_query_detail(index, query, expected, actual, note)
             sys.stdout.flush()
 
+    def on_step_complete(step: StepResult) -> None:
+        if not args.pause:
+            return
+        try:
+            input(_dim(f"      -- step {step.name} done; press Enter to continue "
+                       "(Ctrl-C to abort) --"))
+        except EOFError:
+            # No interactive stdin (e.g. piped input) — don't block.
+            pass
+
     results: list[TestResult] = []
     try:
         for test_dir in test_dirs:
@@ -293,6 +310,7 @@ def main(argv: list[str] | None = None) -> int:
                 shift_id=args.shift_id,
                 on_query=on_query,
                 on_poll=on_poll,
+                on_step_complete=on_step_complete,
             )
             results.append(result)
             _print_test_result(result)

--- a/testing-tools/functional-test/src/functional_test/runner.py
+++ b/testing-tools/functional-test/src/functional_test/runner.py
@@ -321,6 +321,7 @@ def run_test(
     shift_id: Optional[int] = None,
     on_query: Optional[Callable[["QueryResult"], None]] = None,
     on_poll: Optional[Callable[[int, str, Any, int, Any, bool], None]] = None,
+    on_step_complete: Optional[Callable[["StepResult"], None]] = None,
 ) -> TestResult:
     result = TestResult(name=test_dir.name)
     try:
@@ -356,6 +357,9 @@ def run_test(
             db, step_dir, max_retry, retry_delay, on_event, remapper, on_query, on_poll
         )
         result.steps.append(step_result)
+        # Give callers a chance to pause/inspect after each step (e.g. --pause).
+        if on_step_complete:
+            on_step_complete(step_result)
         # Later steps depend on this one; stop the test at the first failure.
         if not step_result.passed:
             break


### PR DESCRIPTION
## Description
Small change to add a flag --pause to python test runner to pause the test after each step so the database can be examine after each step.

## Related Issue
[Jira Ticket](url)

## Additional Notes
Additional notes and context if necessary

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
