### PR TITLE
Fix: CVE-2026-54515

### DIFF
--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -19,7 +19,7 @@ ext['commons-lang3.version'] = '3.20.0'
 
 // Override the Spring Boot managed Jackson version to address CVE-2026-54513.
 // jackson-bom.version controls all Jackson modules (databind, core, annotations, dataformats)
-ext['jackson-bom.version'] = '2.21.4'
+ext['jackson-bom.version'] = '2.21.5'
 
 group = 'gov.cdc.etldatapipeline'
 version = '0.0.1-SNAPSHOT'


### PR DESCRIPTION
## Description
Update jackson-bom from 2.21.4 to 2.21.5 to address CVE-2026-54515.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.