### PR TITLE
Set ctrl_cd_display_form on the two foundation Order observations

### DIFF
--- a/testing-tools/synthetic-odse-fixtures/fixtures/00_foundation/00_foundation.sql
+++ b/testing-tools/synthetic-odse-fixtures/fixtures/00_foundation/00_foundation.sql
@@ -356,11 +356,17 @@ VALUES
 --   Per edge_types.md, RTR disambiguates Lab vs Morbidity by joining the
 --   source observation's `obs_domain_cd_st_1` ('Order' = lab order root).
 --   subject_person_uid is a soft FK to person; we point at Patient.
+--   ctrl_cd_display_form='LabReport' matches the v2 lab order (20070010).
+--   sp_d_lab_test_postprocessing (018) includes an Order-domain obs when
+--   its display form is in ('LabReport','LabReportMorb') OR IS NULL, so a
+--   NULL here let this land in LAB_TEST as a MODERN-ONLY row (MasterETL
+--   keys on the display form and skipped it). Setting 'LabReport' makes
+--   MasterETL emit the matching row too, so both sides agree.
 -- =====================================================================
 INSERT INTO [dbo].[observation]
     ([observation_uid], [add_time], [add_user_id], [cd], [cd_desc_txt],
      [last_chg_time], [last_chg_user_id], [local_id],
-     [obs_domain_cd_st_1], [record_status_cd], [record_status_time],
+     [obs_domain_cd_st_1], [ctrl_cd_display_form], [record_status_cd], [record_status_time],
      [status_cd], [status_time], [subject_person_uid],
      [shared_ind], [version_ctrl_nbr], [prog_area_cd], [jurisdiction_cd],
      [electronic_ind])
@@ -368,18 +374,24 @@ VALUES
     (@dbo_Act_lab_uid, '2026-04-01T00:00:00', @superuser_id,
      N'LAB100', N'Foundation lab report',
      CAST(GETDATE() AS DATE), @superuser_id, N'OBS20000120GA01',
-     N'Order', N'ACTIVE', '2026-04-01T00:00:00',
+     N'Order', N'LabReport', N'ACTIVE', '2026-04-01T00:00:00',
      N'A', '2026-04-01T00:00:00', @dbo_Entity_patient_uid,
      N'F', 1, N'STD', N'1', N'N');
 
 -- =====================================================================
 -- MORBIDITY REPORT — Observation with obs_domain_cd_st_1='Order'
 --   Same shape as Lab; cd / cd_desc_txt distinguish at fixture level.
+--   ctrl_cd_display_form='MorbReport' matches the v2 morb order (20080010).
+--   A NULL display form let this Order-domain morb row fall through the
+--   'IS NULL' branch of sp_d_lab_test_postprocessing (018) and land in
+--   LAB_TEST (MODERN-ONLY) — a morb report is not a lab test. 'MorbReport'
+--   is not in that SP's allow-list, so RTR now excludes it from LAB_TEST,
+--   matching MasterETL (and the v2 morb order, which is absent there too).
 -- =====================================================================
 INSERT INTO [dbo].[observation]
     ([observation_uid], [add_time], [add_user_id], [cd], [cd_desc_txt],
      [last_chg_time], [last_chg_user_id], [local_id],
-     [obs_domain_cd_st_1], [record_status_cd], [record_status_time],
+     [obs_domain_cd_st_1], [ctrl_cd_display_form], [record_status_cd], [record_status_time],
      [status_cd], [status_time], [subject_person_uid],
      [shared_ind], [version_ctrl_nbr], [prog_area_cd], [jurisdiction_cd],
      [electronic_ind])
@@ -387,7 +399,7 @@ VALUES
     (@dbo_Act_morbidity_uid, '2026-04-01T00:00:00', @superuser_id,
      N'MOR100', N'Foundation morbidity report',
      CAST(GETDATE() AS DATE), @superuser_id, N'OBS20000130GA01',
-     N'Order', N'ACTIVE', '2026-04-01T00:00:00',
+     N'Order', N'MorbReport', N'ACTIVE', '2026-04-01T00:00:00',
      N'A', '2026-04-01T00:00:00', @dbo_Entity_patient_uid,
      N'F', 1, N'STD', N'1', N'N');
 


### PR DESCRIPTION
## Set ctrl_cd_display_form on the two foundation Order observations

The foundation Lab Order (`20000120`) and Morb Order (`20000130`) in `00_foundation.sql` were inserted with `ctrl_cd_display_form` NULL, while their v2 siblings `20070010` and `20080010` set it (`LabReport` / `MorbReport`).

`sp_d_lab_test_postprocessing` (routine 018) includes an Order-domain observation when its display form is in `('LabReport','LabReportMorb')` OR IS NULL. Both foundation orders fell through that `IS NULL` branch and landed in `RDB_MODERN.LAB_TEST` as modern-only rows, since MasterETL keys on the display form and skipped them. They're two of the modern-only LAB_TEST rows called out on [APP-718](https://cdc-nbs.atlassian.net/browse/APP-718).

### Change
Each order now gets the display form its v2 sibling already uses:
- `20000120` to `LabReport`: MasterETL now emits the matching LAB_TEST row, so it becomes a matched row instead of modern-only. RTR keeps emitting it.
- `20000130` to `MorbReport`: a morbidity report isn't a lab test, and `MorbReport` isn't in the SP allow-list, so RTR now excludes it from LAB_TEST, matching MasterETL and the v2 morb order `20080010` (absent from LAB_TEST on both sides).

### Verification
Reloaded the fixtures through the full pipeline and checked the SP's own decision against the resulting `nrt_observation`:
- `20000120` (LabReport) resolves to INCLUDED in LAB_TEST; `20000130` (MorbReport) resolves to EXCLUDED. That's the intended split.
- Pre-change live data confirmed the target shapes: `20070010` (Order + LabReport) is matched on both sides, `20080010` (Order + MorbReport) is absent from LAB_TEST on both sides.
- Ripple check: `20000130` now populates MORBIDITY_REPORT as a well-formed row (local id `OBS20000130GA01`), the same way the matched v2 morb order `20080010` does. The `MORB_RPT_KEY=1` NULL row there is the standard dimension sentinel, which the datamart SP excludes.

A full end-to-end count/coverage diff wasn't reliable from a single fresh reload: the datamart drain races the coverage snapshot (a known harness behavior), so global table totals under-report until the pipeline settles. The SP-level verification above is deterministic and independent of that timing.

Expected steady-state effect: two fewer modern-only LAB_TEST rows, no coverage change.
