### PR TITLE
(debezium): update snapshot mode to schema_only

### DIFF
--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
@@ -17,7 +17,7 @@
     "key.converter.schemas.enable": "true",
     "producer.max.request.size": "10000000",
     "producer.message.max.bytes": "10000000",
-    "snapshot.mode": "initial",
+    "snapshot.mode": "schema_only",
     "schema.history.internal.kafka.topic": "odse-main-schema-history",
     "schema.history.internal.kafka.bootstrap.servers": "${connector.kafka.bootstrap-servers}",
     "table.include.list": "dbo.Person,dbo.Organization,dbo.Observation,dbo.Public_health_case,dbo.Treatment,dbo.state_defined_field_data,dbo.Notification,dbo.Interview,dbo.Place,dbo.CT_contact,dbo.Auth_user,dbo.Intervention",


### PR DESCRIPTION
## Description
Change the Debezium connector snapshot mode from "initial" to "schema_only" for the odse_main connector to prevent performing a full data snapshot on startup.

## Additional Notes
Additional notes and context if necessary

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
