### PR TITLE
fix(debezium): support case-insensitive prefix drop

### DIFF
--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
@@ -33,7 +33,7 @@
     "topic.creation.default.cleanup.policy": "delete",
     "time.precision.mode": "connect",
     "transforms": "dropPrefix, convertTimezone, hoistPayload",
-    "transforms.dropPrefix.regex": "cdc_odse_main\\.NBS_ODSE\\.dbo\\.(.+)",
+    "transforms.dropPrefix.regex": "(?i)^cdc_odse_main\\.NBS_ODSE\\.dbo\\.(.+)",
     "transforms.dropPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
     "transforms.dropPrefix.replacement": "nbs_$1",
     "transforms.convertTimezone.type": "io.debezium.transforms.TimezoneConverter",

--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_meta_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_meta_connector.json
@@ -28,7 +28,7 @@
     "topic.creation.default.cleanup.policy": "compact",
     "time.precision.mode": "connect",
     "transforms": "dropPrefix, convertTimezone, unwrap, convertTimestampsConfig_add_time,convertTimestampsConfig_last_chg_time, convertTimestampsConfig_record_status_time",
-    "transforms.dropPrefix.regex": "cdc_odse_meta\\.NBS_ODSE\\.dbo\\.(.+)",
+    "transforms.dropPrefix.regex": "(?i)^cdc_odse_meta\\.NBS_ODSE\\.dbo\\.(.+)",
     "transforms.dropPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
     "transforms.dropPrefix.replacement": "nrt_odse_$1",
     "transforms.convertTimezone.type": "io.debezium.transforms.TimezoneConverter",

--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_schema_only_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_schema_only_connector.json
@@ -29,7 +29,7 @@
     "topic.creation.default.cleanup.policy": "delete",
     "time.precision.mode": "connect",
     "transforms": "dropPrefix, convertTimezone, hoistPayload",
-    "transforms.dropPrefix.regex": "cdc_odse_act_rel\\.NBS_ODSE\\.dbo\\.(.+)",
+    "transforms.dropPrefix.regex": "(?i)^cdc_odse_act_rel\\.NBS_ODSE\\.dbo\\.(.+)",
     "transforms.dropPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
     "transforms.dropPrefix.replacement": "nbs_$1",
     "transforms.convertTimezone.type": "io.debezium.transforms.TimezoneConverter",

--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/srte_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/srte_connector.json
@@ -29,7 +29,7 @@
     "time.precision.mode": "connect",
     "transforms": "dropPrefix, dropPrefixConfig, unwrapConfig, valueToKey, convertTimezone, unwrap, convertTimestamps_add_time, convertTimestamps_concept_status_time, convertTimestamps_effective_from_time,convertTimestamps_effective_to_time, convertTimestamps_status_time, convertTimestamps_status_to_time,convertTimestamps_value_set_status_time, convertTimestampsConfig_effective_from_time,convertTimestampsConfig_effective_to_time, convertTimestampsConfig_status_time",
     "predicates": "isConfigTable",
-    "transforms.dropPrefix.regex": "cdc_srte\\.NBS_SRTE\\.dbo\\.(.+)",
+    "transforms.dropPrefix.regex": "(?i)^cdc_srte\\.NBS_SRTE\\.dbo\\.(.+)",
     "transforms.dropPrefix.type": "org.apache.kafka.connect.transforms.RegexRouter",
     "transforms.dropPrefix.replacement": "nrt_srte_$1",
     "transforms.dropPrefixConfig.regex": "cdc_srte\\.NBS_SRTE\\.dbo\\.Snomed_condition",


### PR DESCRIPTION
## Description
Update Debezium connector configurations to use case-insensitive and start-anchored regex for drop-prefix transforms, ensuring robust topic name routing.

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
