### PR TITLE
Fix build failures caused by base image drift on `amazoncorretto:21`

### DIFF
--- a/reporting-pipeline-service/Dockerfile
+++ b/reporting-pipeline-service/Dockerfile
@@ -20,7 +20,6 @@ RUN ./gradlew :reporting-pipeline-service:buildNeeded -x test --no-daemon
 
 FROM amazoncorretto:21
 WORKDIR /
-RUN yum update -y && yum install -y --allowerasing curl-8.3.0 && yum clean all
 
 COPY --from=builder /usr/src/reporting-pipeline-service/build/libs/reporting-pipeline-service*.jar reporting-pipeline-service.jar
 

--- a/reporting-pipeline-service/Dockerfile
+++ b/reporting-pipeline-service/Dockerfile
@@ -20,7 +20,7 @@ RUN ./gradlew :reporting-pipeline-service:buildNeeded -x test --no-daemon
 
 FROM amazoncorretto:21
 WORKDIR /
-RUN yum update -y && yum install -y curl-8.3.0 && yum clean all
+RUN yum update -y && yum install -y --allowerasing curl-8.3.0 && yum clean all
 
 COPY --from=builder /usr/src/reporting-pipeline-service/build/libs/reporting-pipeline-service*.jar reporting-pipeline-service.jar
 

--- a/reporting-pipeline-service/Dockerfile
+++ b/reporting-pipeline-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:21 AS builder
 WORKDIR /usr/src/
-RUN yum update -y && yum clean all
+RUN yum update -y && yum install -y findutils && yum clean all
 
 #Copy project config
 COPY gradle gradle


### PR DESCRIPTION
## Description
### What broke
Building the RPS image is failing with the following:
```
Problem: problem with installed package curl-minimal-8.17.0-1.amzn2023.0.3.x86_64
 - package curl-minimal-...x86_64 from @System conflicts with curl provided by curl-8.3.0-...
```

```
RUN ./gradlew :reporting-pipeline-service:dependencies --no-daemon
xargs is not available
```

No changes were made to this Dockerfile or the branch — [a build from 2 days ago](https://github.com/CDCgov/NEDSS-DataReporting/actions/runs/29954082395) on the same commit passed.

### Root cause
`FROM amazoncorretto:21` is a floating tag. Comparing logs between the passing and failing runs shows the underlying OS changed out from under us: the passing run resolved `curl-8.3.0-1.amzn2.0.12` (Amazon Linux 2 versioning), while the failing run pulled from the `Amazon Linux 2023 repository` explicitly. AWS moved what `amazoncorretto:21` points to between the two builds.

Both failures trace back to this same shift:
* AL2023 ships `curl-minimal` preinstalled, which conflicts with installing the full curl package — they provide overlapping files and can't coexist without an explicit swap. AL2 has no such package, so `yum install curl` was a normal upgrade there.
* AL2023's base image also doesn't include `findutils` (which provides `xargs`) by default, unlike AL2, where it's present out of the box. The Gradle wrapper script requires `xargs`.

### Fix
Add `--allowerasing` to the install so it works correctly on either OS generation. This is a no-op on AL2 (nothing to erase) and correctly swaps `curl-minimal` for `curl` on AL2023.
Explicitly install `findutils` in the builder stage rather than relying on it being present by default.

### Open questions
- **Should we pin to a specific tag** (e.g. `amazoncorretto:21-al2023`) or digest instead of floating on `:21`? This fix makes the build resilient to the OS drift we just hit, but doesn't prevent future silent changes under the same tag (package versions, transitive deps, etc.) that might not fail as loudly as this one did.
- **Why is `curl` pinned to `8.3.0` specifically**, and can we drop the pin?

## Related Issue
n/a

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~I have updated the documentation, if applicable.~
- [ ] ~I have added or updated test cases to cover my changes, if applicable.~
 
