### PR TITLE
Backport fix for build failures caused by base image drift on `amazoncorretto:21`

### DIFF
--- a/reporting-pipeline-service/Dockerfile
+++ b/reporting-pipeline-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:21 AS builder
 WORKDIR /usr/src/
-RUN yum update -y && yum clean all
+RUN yum update -y && yum install -y findutils && yum clean all
 
 #Copy project config
 COPY gradle gradle
@@ -20,7 +20,6 @@ RUN ./gradlew :reporting-pipeline-service:buildNeeded -x test --no-daemon
 
 FROM amazoncorretto:21
 WORKDIR /
-RUN yum update -y && yum install -y curl-8.3.0 && yum clean all
 
 COPY --from=builder /usr/src/reporting-pipeline-service/build/libs/reporting-pipeline-service*.jar reporting-pipeline-service.jar
 


### PR DESCRIPTION
## Description
Backport changes from #964 

## Additional Notes
This is not blocking the 7.13 beta, but if we want to release a GA with any additional changes we'll need the build working in this branch as well

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] ~I have updated the documentation, if applicable.~
- [ ] ~I have added or updated test cases to cover my changes, if applicable.~
 
