### PR TITLE
set minimum max text repl size

### DIFF
--- a/.github/workflows/run-functional-tests.yaml
+++ b/.github/workflows/run-functional-tests.yaml
@@ -9,6 +9,7 @@ on:
       - "docker-compose.yaml"
       - ".github/workflows/**"
       - "containers/db/**"
+      - "bootstrap/*.sql"
 
 jobs:
   pipeline:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -7,6 +7,7 @@ on:
       - "settings.gradle"
       - "gradle/**"
       - "docker-compose.yaml"
+      - "bootstrap/*.sql"
       - ".github/workflows/**"
 
 jobs:

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -9,6 +9,7 @@ on:
       - "docker-compose.yaml"
       - ".github/workflows/**"
       - "containers/db/**"
+      - "bootstrap/*.sql"
 
 jobs:
   pipeline:

--- a/bootstrap/101-enable_cdc_on_odse_srte_databases-001.sql
+++ b/bootstrap/101-enable_cdc_on_odse_srte_databases-001.sql
@@ -7,7 +7,7 @@ IF IS_SRVROLEMEMBER('sysadmin') <> 1
 GO
 
 -- ------------------------------------------------------------
--- Configure the minimum LOB size that SQL Server can replicate
+-- Ensure SQL Server's replication LOB size limit is at least 512 KiB
 -- ------------------------------------------------------------
 -- This is an instance-wide setting. A 512 KiB binary value expands to about
 -- 683 KiB when Debezium's JSON converter base64-encodes it, leaving room for
@@ -21,8 +21,10 @@ SELECT @currentMaxTextReplicationSizeBytes = CONVERT(INT, VALUE_IN_USE)
 FROM SYS.CONFIGURATIONS
 WHERE NAME = 'max text repl size (B)';
 
-IF @currentMaxTextReplicationSizeBytes <> -1
-    AND @currentMaxTextReplicationSizeBytes < @minimumMaxTextReplicationSizeBytes
+IF
+    @currentMaxTextReplicationSizeBytes <> -1
+    AND @currentMaxTextReplicationSizeBytes
+    < @minimumMaxTextReplicationSizeBytes
     BEGIN
         SELECT @showAdvancedOptionsWasEnabled = CONVERT(BIT, VALUE_IN_USE)
         FROM SYS.CONFIGURATIONS
@@ -35,9 +37,9 @@ IF @currentMaxTextReplicationSizeBytes <> -1
             END
 
         PRINT 'Increasing max text repl size (B) from '
-            + CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
-            + ' to '
-            + CONVERT(VARCHAR(20), @minimumMaxTextReplicationSizeBytes);
+        + CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
+        + ' to '
+        + CONVERT(VARCHAR(20), @minimumMaxTextReplicationSizeBytes);
 
         EXEC SYS.SP_CONFIGURE
             'max text repl size (B)',
@@ -53,10 +55,10 @@ IF @currentMaxTextReplicationSizeBytes <> -1
 ELSE
     BEGIN
         PRINT 'max text repl size (B) already satisfies the RTR minimum: '
-            + CASE
-                WHEN @currentMaxTextReplicationSizeBytes = -1 THEN 'unlimited'
-                ELSE CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
-            END;
+        + CASE
+            WHEN @currentMaxTextReplicationSizeBytes = -1 THEN 'unlimited'
+            ELSE CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
+        END;
     END
 GO
 

--- a/bootstrap/101-enable_cdc_on_odse_srte_databases-001.sql
+++ b/bootstrap/101-enable_cdc_on_odse_srte_databases-001.sql
@@ -6,6 +6,60 @@ IF IS_SRVROLEMEMBER('sysadmin') <> 1
     END
 GO
 
+-- ------------------------------------------------------------
+-- Configure the minimum LOB size that SQL Server can replicate
+-- ------------------------------------------------------------
+-- This is an instance-wide setting. A 512 KiB binary value expands to about
+-- 683 KiB when Debezium's JSON converter base64-encodes it, leaving room for
+-- the record key, value schema, and other columns under Kafka's default
+-- 1,048,588-byte broker record limit.
+DECLARE @minimumMaxTextReplicationSizeBytes INT = 524288;
+DECLARE @currentMaxTextReplicationSizeBytes INT;
+DECLARE @showAdvancedOptionsWasEnabled BIT;
+
+SELECT @currentMaxTextReplicationSizeBytes = CONVERT(INT, VALUE_IN_USE)
+FROM SYS.CONFIGURATIONS
+WHERE NAME = 'max text repl size (B)';
+
+IF @currentMaxTextReplicationSizeBytes <> -1
+    AND @currentMaxTextReplicationSizeBytes < @minimumMaxTextReplicationSizeBytes
+    BEGIN
+        SELECT @showAdvancedOptionsWasEnabled = CONVERT(BIT, VALUE_IN_USE)
+        FROM SYS.CONFIGURATIONS
+        WHERE NAME = 'show advanced options';
+
+        IF @showAdvancedOptionsWasEnabled = 0
+            BEGIN
+                EXEC SYS.SP_CONFIGURE 'show advanced options', 1;
+                RECONFIGURE;
+            END
+
+        PRINT 'Increasing max text repl size (B) from '
+            + CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
+            + ' to '
+            + CONVERT(VARCHAR(20), @minimumMaxTextReplicationSizeBytes);
+
+        EXEC SYS.SP_CONFIGURE
+            'max text repl size (B)',
+            @minimumMaxTextReplicationSizeBytes;
+        RECONFIGURE;
+
+        IF @showAdvancedOptionsWasEnabled = 0
+            BEGIN
+                EXEC SYS.SP_CONFIGURE 'show advanced options', 0;
+                RECONFIGURE;
+            END
+    END
+ELSE
+    BEGIN
+        PRINT 'max text repl size (B) already satisfies the RTR minimum: '
+            + CASE
+                WHEN @currentMaxTextReplicationSizeBytes = -1 THEN 'unlimited'
+                ELSE CONVERT(VARCHAR(20), @currentMaxTextReplicationSizeBytes)
+            END;
+    END
+GO
+
 -- Enable Snapshot Isolation for NBS_ODSE for
 -- Debezium Seeding
 -- ------------------------------------------

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -31,6 +31,10 @@ The bootstrap script in this directory (CDC enablement, SQL Agent job creation) 
 
 Enables Change Data Capture at the database level on `NBS_ODSE` and `NBS_SRTE`, then enables CDC tracking on each RTR-relevant table. Handles both AWS RDS (`rds_cdc_enable_db`) and standard SQL Server (`sp_cdc_enable_db`) automatically.
 
+The script also ensures SQL Server's instance-wide `max text repl size (B)` is at least 524,288 bytes. This permits the observed `NBS_ODSE.dbo.NBS_page.jsp_payload` values to enter CDC while keeping their base64-encoded Debezium records comfortably below Kafka's default 1,048,588-byte broker record limit. Because this setting affects the entire SQL Server instance, the script does not reduce an existing larger or unlimited value.
+
+The 524,288-byte value assumes Kafka's broker/topic maximum remains at least 1,048,588 bytes. If larger ODSE LOB values must be replicated, increase the Kafka broker, topic, Debezium producer, Kafka Connect consumer, and RPS consumer limits together before increasing the SQL Server setting.
+
 **Run against:** `NBS_ODSE` and `NBS_SRTE`
 
 ## Prerequisites

--- a/containers/db/initialize/006-set-max-text-repl-size.sql
+++ b/containers/db/initialize/006-set-max-text-repl-size.sql
@@ -6,18 +6,6 @@
 USE [master];
 GO
 
-DECLARE @showAdvancedOptionsWasEnabled BIT;
-
-SELECT @showAdvancedOptionsWasEnabled = CONVERT(BIT, VALUE_IN_USE)
-FROM SYS.CONFIGURATIONS
-WHERE NAME = 'show advanced options';
-
-IF @showAdvancedOptionsWasEnabled = 0
-    BEGIN
-        EXEC SYS.SP_CONFIGURE 'show advanced options', 1;
-        RECONFIGURE;
-    END
-
 EXEC SYS.SP_CONFIGURE 'max text repl size (B)', 65536;
 RECONFIGURE;
 
@@ -29,10 +17,3 @@ IF (
     BEGIN
         THROW 50000, 'Could not set max text repl size (B) to 65536.', 1;
     END
-
-IF @showAdvancedOptionsWasEnabled = 0
-    BEGIN
-        EXEC SYS.SP_CONFIGURE 'show advanced options', 0;
-        RECONFIGURE;
-    END
-GO

--- a/containers/db/initialize/006-set-max-text-repl-size.sql
+++ b/containers/db/initialize/006-set-max-text-repl-size.sql
@@ -1,0 +1,38 @@
+-- ==========================================
+-- Dev/CI CDC bootstrap verification baseline
+-- Ensures bootstrap script 101 must raise the 64 KiB default.
+-- ==========================================
+
+USE [master];
+GO
+
+DECLARE @showAdvancedOptionsWasEnabled BIT;
+
+SELECT @showAdvancedOptionsWasEnabled = CONVERT(BIT, VALUE_IN_USE)
+FROM SYS.CONFIGURATIONS
+WHERE NAME = 'show advanced options';
+
+IF @showAdvancedOptionsWasEnabled = 0
+    BEGIN
+        EXEC SYS.SP_CONFIGURE 'show advanced options', 1;
+        RECONFIGURE;
+    END
+
+EXEC SYS.SP_CONFIGURE 'max text repl size (B)', 65536;
+RECONFIGURE;
+
+IF (
+    SELECT CONVERT(INT, VALUE_IN_USE)
+    FROM SYS.CONFIGURATIONS
+    WHERE NAME = 'max text repl size (B)'
+) <> 65536
+    BEGIN
+        THROW 50000, 'Could not set max text repl size (B) to 65536.', 1;
+    END
+
+IF @showAdvancedOptionsWasEnabled = 0
+    BEGIN
+        EXEC SYS.SP_CONFIGURE 'show advanced options', 0;
+        RECONFIGURE;
+    END
+GO

--- a/containers/db/initialize/README.md
+++ b/containers/db/initialize/README.md
@@ -4,7 +4,7 @@ These scripts are executed automatically by the `nbs-mssql` container on startup
 
 ## Buckets
 
-### 001–005 — Dev/CI Setup
+### 001–006 — Dev/CI Setup
 
 Custom scripts that prepare the SQL Server instance for local development and CI. These run first and establish the baseline database state that everything else depends on.
 
@@ -15,6 +15,7 @@ Custom scripts that prepare the SQL Server instance for local development and CI
 | `003-fix-lab-test.sql` | Fixes lab test data |
 | `004-prep-for-masterEtl-trace.sql` | Prepares trace settings for MasterETL |
 | `005-clear-job_flow_log.sql` | Clears the job flow log table |
+| `006-set-max-text-repl-size.sql` | Sets the 64 KiB baseline used to verify that bootstrap script 101 raises the CDC LOB replication limit |
 
 # 099 — User Account
 


### PR DESCRIPTION
## Description
Ensure SQL Server's instance-wide `max text repl size (B)` is at least
524,288 bytes (512 KiB) during bootstrap. This permits large LOB values
(such as `NBS_page.jsp_payload`) to enter CDC while keeping base64-encoded
Debezium messages within Kafka's default 1,048,588-byte limit. Existing
larger or unlimited values are preserved.

## Related Issue
[APP-883](https://cdc-nbs.atlassian.net/browse/APP-883)

## Additional Notes
Added a local/CI database initialization script that sets SQL Server’s max text repl size (B) to its 64 KiB default before the RTR bootstrap runs. This ensures containerized tests exercise and verify that the bootstrap raises the limit to 512 KiB. The initialization script preserves the existing show advanced options setting and does not affect production bootstrap behavior.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
