### PR TITLE
Mp/app 909/act relationship tombstone

### DIFF
--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
@@ -252,6 +252,11 @@ public class InvestigationService {
       String typeCd;
       String operationType = extractChangeDataCaptureOperation(value);
 
+      if (operationType == null) {
+        // possible tombstone message, nothing to process
+        return;
+      }
+
       if (operationType.equals("d")) {
         sourceActUid = extractUid(value, "source_act_uid", "before");
         typeCd = extractValue(value, "type_cd", "before");

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataService.java
@@ -134,6 +134,10 @@ public class LdfDataService {
           try {
             JsonNode jsonNode = objectMapper.readTree(value).get("payload");
             String operationType = extractChangeDataCaptureOperation(value);
+            if (operationType == null) {
+              // possible tombstone message, nothing to process
+              return;
+            }
             JsonNode payloadNode =
                 operationType.equals("d") ? jsonNode.path("before") : jsonNode.path("after");
             payloadNode = payloadNode.isMissingNode() ? jsonNode : payloadNode;

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
@@ -217,6 +217,10 @@ public class ObservationService {
       String typeCd;
       String targetClassCd;
       String operationType = extractChangeDataCaptureOperation(value);
+      if (operationType == null) {
+        // possible tombstone message, nothing to process
+        return;
+      }
 
       if (operationType.equals("d")) {
         sourceActUid = extractUid(value, "source_act_uid", BEFORE_PATH);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/UtilHelper.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/UtilHelper.java
@@ -55,7 +55,13 @@ public class UtilHelper {
   public static String extractChangeDataCaptureOperation(String message)
       throws JsonProcessingException {
     JsonNode jsonNode = objectMapper.readTree(message);
-    return jsonNode.get(PAYLOAD_KEY).path("op").asText();
+    JsonNode payload = jsonNode.get(PAYLOAD_KEY);
+    if (payload == null || payload.isNull()) {
+      // payload key is not present OR the payload content is null indicating a probable tombstone
+      // message
+      return null;
+    }
+    return payload.path("op").asText();
   }
 
   public static String errorMessage(String entityName, String ids, Exception e) {

--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_main_connector.json
@@ -27,6 +27,7 @@
     "table.include.list": "dbo.Person,dbo.Organization,dbo.Observation,dbo.Public_health_case,dbo.Treatment,dbo.state_defined_field_data,dbo.Notification,dbo.Interview,dbo.Place,dbo.CT_contact,dbo.Auth_user,dbo.Intervention",
     "column.include.list": "dbo\\.Person\\.(person_uid|cd),dbo\\.Organization\\.organization_uid,dbo\\.Observation\\.observation_uid,dbo\\.Public_health_case\\.public_health_case_uid,dbo\\.Treatment\\.treatment_uid,dbo\\.state_defined_field_data\\.(ldf_uid|business_object_uid|business_object_nm),dbo\\.Notification\\.notification_uid,dbo\\.Interview\\.interview_uid,dbo\\.Place\\.place_uid,dbo\\.CT_contact\\.ct_contact_uid,dbo\\.Auth_user\\.auth_user_uid,dbo\\.Intervention\\.intervention_uid",
     "tasks.max": 1,
+    "tombstones.on.delete": "false",
     "topic.prefix": "cdc_odse_main",
     "topic.creation.default.replication.factor": 1,
     "topic.creation.default.partitions": 10,

--- a/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_schema_only_connector.json
+++ b/reporting-pipeline-service/src/main/resources/connectors/debezium/odse_schema_only_connector.json
@@ -23,6 +23,7 @@
     "table.include.list": "dbo.Act_relationship",
     "column.include.list": "dbo\\.Act_relationship\\.(source_act_uid|target_act_uid|type_cd|target_class_cd)",
     "tasks.max": 1,
+    "tombstones.on.delete": "false",
     "topic.prefix": "cdc_odse_act_rel",
     "topic.creation.default.replication.factor": 1,
     "topic.creation.default.partitions": 10,

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
@@ -478,6 +478,15 @@ class InvestigationServiceTest {
     verifyNoInteractions(kafkaTemplate);
   }
 
+  @Test
+  void testProcessActRelationshipTombstoneNull() {
+    String payload = null;
+
+    ConsumerRecord<String, String> rec = getRecord(actRelationshipTopic, payload);
+    investigationService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
+  }
+
   @ParameterizedTest
   @CsvSource({"c,1180", "u,1180", "u,1180", "d,1180", "c,OTHER"})
   void testProcessActRelationshipVaccination(String op, String typeCd)

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
@@ -2,9 +2,11 @@ package gov.cdc.nbs.report.pipeline.investigation.service;
 
 import static gov.cdc.nbs.report.pipeline.investigation.service.InvestigationService.toBatchId;
 import static gov.cdc.nbs.report.pipeline.investigation.utils.TestUtils.*;
-import static gov.cdc.nbs.report.pipeline.investigation.utils.TestUtils.FILE_PATH_PREFIX;
 import static gov.cdc.nbs.report.pipeline.util.TestUtils.readFileData;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -446,6 +448,34 @@ class InvestigationServiceTest {
   void testProcessVaccinationNoDataException() {
     String payload = "{\"payload\": {\"after\": {\"intervention_uid\": \"\"}}}";
     checkException(vaccinationTopic, payload, NoDataException.class);
+  }
+
+  @Test
+  void testProcessActRelationshipTombstone() {
+    String payload =
+        """
+        {
+          "payload": null
+        }
+        """;
+
+    ConsumerRecord<String, String> rec = getRecord(actRelationshipTopic, payload);
+    investigationService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
+  }
+
+  @Test
+  void testProcessActRelationshipTombstoneNoPayload() {
+    String payload =
+        """
+        {
+
+        }
+        """;
+
+    ConsumerRecord<String, String> rec = getRecord(actRelationshipTopic, payload);
+    investigationService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
   }
 
   @ParameterizedTest

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
@@ -169,6 +169,16 @@ class LdfDataServiceTest {
     verifyNoInteractions(kafkaTemplate);
   }
 
+  @Test
+  void testProcessEmptyTombstoneNull() {
+    String ldfTopic = "LdfData";
+    String payload = null;
+
+    ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
+    ldfDataService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
+  }
+
   private void testEmptyMessage(String ldfTopic, String ldfTopicOutput, String payload) {
     ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
     setupLdfService(ldfTopic, ldfTopicOutput);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
@@ -142,6 +142,33 @@ class LdfDataServiceTest {
     testEmptyMessage(ldfTopic, ldfTopicOutput, "");
   }
 
+  @Test
+  void testProcessEmptyTombstone() {
+    String ldfTopic = "LdfData";
+    String payload =
+        """
+        {
+          "payload": null
+        }
+        """;
+    ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
+    ldfDataService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
+  }
+
+  @Test
+  void testProcessEmptyTombstoneEmpty() {
+    String ldfTopic = "LdfData";
+    String payload =
+        """
+        {
+        }
+        """;
+    ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
+    ldfDataService.processMessage(rec);
+    verifyNoInteractions(kafkaTemplate);
+  }
+
   private void testEmptyMessage(String ldfTopic, String ldfTopicOutput, String payload) {
     ConsumerRecord<String, String> rec = getRecord(payload, ldfTopic);
     setupLdfService(ldfTopic, ldfTopicOutput);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
@@ -188,6 +188,15 @@ class ObservationServiceTest {
   }
 
   @Test
+  void testProcessActRelationshipTombstoneNull() {
+    String payload = null;
+
+    ConsumerRecord<String, String> rec = getRecord(payload, inputTopicNameActRelationship);
+    observationService.processMessage(rec);
+    verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+  }
+
+  @Test
   void testProcessMessageUnknownTopic() {
     ConsumerRecord<String, String> rec = getRecord(null, "dummyTopicName");
 

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
@@ -4,6 +4,8 @@ import static gov.cdc.nbs.report.pipeline.observation.service.ObservationService
 import static gov.cdc.nbs.report.pipeline.util.TestUtils.readFileData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -150,6 +152,35 @@ class ObservationServiceTest {
   @Test
   void testProcessActRelationshipNullPayload() {
     ConsumerRecord<String, String> rec = getRecord(null, inputTopicNameActRelationship);
+
+    observationService.processMessage(rec);
+
+    verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void testProcessActRelationshipTombstone() {
+    String payload =
+        """
+        {
+          "payload": null
+        }
+        """;
+    ConsumerRecord<String, String> rec = getRecord(payload, inputTopicNameActRelationship);
+
+    observationService.processMessage(rec);
+
+    verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void testProcessActRelationshipTombstoneNoPayload() {
+    String payload =
+        """
+        {
+        }
+        """;
+    ConsumerRecord<String, String> rec = getRecord(payload, inputTopicNameActRelationship);
 
     observationService.processMessage(rec);
 

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/UtilHelperTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/UtilHelperTest.java
@@ -146,4 +146,27 @@ class UtilHelperTest {
     String value = UtilHelper.extractChangeDataCaptureOperation(sampleJson);
     assertEquals("d", value);
   }
+
+  @Test
+  void testExtractCdcOperationNullPayload() throws JsonProcessingException {
+    String json =
+        """
+        {
+          "payload": null
+        }
+        """;
+    String value = UtilHelper.extractChangeDataCaptureOperation(json);
+    assertEquals(null, value);
+  }
+
+  @Test
+  void testExtractCdcOperationNoPayload() throws JsonProcessingException {
+    String json =
+        """
+        {
+        }
+        """;
+    String value = UtilHelper.extractChangeDataCaptureOperation(json);
+    assertEquals(null, value);
+  }
 }


### PR DESCRIPTION
## Description
Updates the `odse_main_connector.json` and `odse_schema_only_connector.json` connectors to specify 

```
tombstones.on.delete": "false"
```

Adds some `null` and tombstone message checking to the services that process the `act_relationship` topic.

## Related Issue
[APP-909](https://cdc-nbs.atlassian.net/browse/APP-909)

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
