### PR TITLE
bulk load functional test setup data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ testing-tools/local-db-tracing/known_replay_associations.json
 # Local docker-compose overrides (e.g. comparison-fixtures fast-drain tuning), not for PR
 docker-compose.override.yaml
 docker-compose.override.yml
+
+# functional-test --bulk staging (bind-mounted into nbs-mssql at /staging)
+testing-tools/functional-test/out/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,9 +18,12 @@ services:
     volumes:
       - ./containers/db/initialize:/tmp/sql/initialize
       - ./bootstrap:/tmp/sql/bootstrap
+      # odse-volume-generator staging: the server reads generated Parquet
+      # directly via OPENROWSET instead of docker-cp'ing files in.
+      - ./testing-tools/odse-volume-generator/out:/staging:ro
     ports:
       - 3433:1433
-    mem_limit: 2.5G
+    mem_limit: 12G
 
   wildfly:
     image: ghcr.io/cdcent/nedssdev:6.0.18.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,9 +18,9 @@ services:
     volumes:
       - ./containers/db/initialize:/tmp/sql/initialize
       - ./bootstrap:/tmp/sql/bootstrap
-      # odse-volume-generator staging: the server reads generated Parquet
-      # directly via OPENROWSET instead of docker-cp'ing files in.
-      - ./testing-tools/odse-volume-generator/out:/staging:ro
+      # Bulk-load staging: the server reads generated Parquet directly via
+      # OPENROWSET (functional-test --bulk output; DATA_DIR=/staging/...).
+      - ./testing-tools/functional-test/out:/staging:ro
     ports:
       - 3433:1433
     mem_limit: 12G

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,12 +18,12 @@ services:
     volumes:
       - ./containers/db/initialize:/tmp/sql/initialize
       - ./bootstrap:/tmp/sql/bootstrap
-      # Bulk-load staging: the server reads generated Parquet directly via
-      # OPENROWSET (functional-test --bulk output; DATA_DIR=/staging/...).
-      - ./testing-tools/functional-test/out:/staging:ro
+      # uncomment the below when bulk loading with testing-tools/functional-test
+      #- ./testing-tools/functional-test/out:/staging:ro
     ports:
       - 3433:1433
-    mem_limit: 12G
+    # increase the below value when adding large amounts of data to the local db
+    mem_limit: 2.5G
 
   wildfly:
     image: ghcr.io/cdcent/nedssdev:6.0.18.1

--- a/testing-tools/functional-test/README.md
+++ b/testing-tools/functional-test/README.md
@@ -167,8 +167,12 @@ setup scripts into MSSQL bulk-load files instead of executing them:
 
 ```sh
 uv run functional-test -d ../../reporting-pipeline-service/src/test/resources/testData/functional \
-    --bulk 10000 --bulk-out /tmp/bulkdata
+    --bulk 10000 --bulk-out out/bulkdata
 ```
+
+(`out/` is bind-mounted read-only into the local mssql container at `/staging`
+— see `docker-compose.yaml` — so output written there is immediately readable
+by the server as `/staging/bulkdata`.)
 
 No database connection is made. The setup scripts are *evaluated* offline by a
 small T-SQL interpreter (variables, `OUTPUT INSERTED` identity captures,
@@ -208,7 +212,7 @@ as-is. The output directory contains:
   ```
 
   `DATA_DIR` is the path where the **server** sees the `.parquet` files —
-  e.g. bind-mount the output directory into the mssql container. With
+  with the compose mount, `--bulk-out out/<name>` is `/staging/<name>`. With
   `mssql-tools18`, also set `SQLCMD_OPTS=-C` to trust a self-signed server
   certificate.
 - `load.sql` — the same load as one sequential script for plain

--- a/testing-tools/functional-test/README.md
+++ b/testing-tools/functional-test/README.md
@@ -140,6 +140,9 @@ uv run functional-test -S localhost:3433 -U rtr_admin \
 | `--max-retry` | `40` | Maximum polls per query before failing. |
 | `--retry-delay` | `6` | Seconds between polls. |
 | `--skip-query` | off | Run each step's `setup.sql` but skip the query/expected polling — just load the test data without waiting for the pipeline to process it. |
+| `--bulk` | — | Generate MSSQL bulk-load files instead of running tests: COPIES shifted copies of every selected test's final setup rows (see below). Requires `--bulk-out`. |
+| `--bulk-out` | — | Output directory for `--bulk`. |
+| `--identity-base` | `500000000` | First synthetic value for identity columns in `--bulk` output (loaded with `KEEPIDENTITY`). |
 | `--fail-fast` | off | Stop after the first failing test. |
 | `--pause` | off | Pause and wait for Enter after each step completes (Ctrl-C to abort), so you can inspect the database between steps. |
 | `--debug` | off | Live-print each query's SQL and its expected vs actual results on every poll attempt. |
@@ -156,6 +159,69 @@ the fastest way to see *why* a query isn't matching.
 
 The process exits `0` when all tests pass, `1` when any test fails, and `2` on
 a usage/connection error.
+
+## Bulk data generation (`--bulk`)
+
+To mass-generate data (e.g. for volume/performance testing), `--bulk` turns the
+setup scripts into MSSQL bulk-load files instead of executing them:
+
+```sh
+uv run functional-test -d ../../reporting-pipeline-service/src/test/resources/testData/functional \
+    --bulk 10000 --bulk-out /tmp/bulkdata
+```
+
+No database connection is made. The setup scripts are *evaluated* offline by a
+small T-SQL interpreter (variables, `OUTPUT INSERTED` identity captures,
+UPDATEs and DELETEs are all applied), producing each test's **final-state
+rows**. Those rows are then written `COPIES` times, each copy shifted to a
+fresh UID range using a collision-free pattern derived from the tests' ID
+blocks (tile each 1000-wide block in strides of the widest test, then jump
+past the whole occupied range and repeat) — so any number of copies can be
+loaded next to the original data and next to each other. `-s` offsets the
+whole series, e.g. past data from earlier normal runs.
+
+Generation is sharded over `--bulk-workers` processes (default `min(8, CPUs)`;
+copy offsets and identity values are pure functions of the global copy index,
+so shards are independent and deterministic). Rows are written as **Parquet**
+— one file per table column-set per shard — and loaded with SQL Server 2022's
+native reader: `INSERT INTO t (cols) SELECT cols FROM OPENROWSET(BULK ...,
+FORMAT='PARQUET')`, one set-based statement per file. Inserts that use
+different column subsets get separate files, so omitted columns take their
+column defaults, and NULL / empty-string / `T`-separator timestamp values load
+as-is. The output directory contains:
+
+- `<Table>[__N]__s<K>.parquet` — table (column-set `N`) rows for shard `K`.
+- `pre.sql` / `shard_<K>.sql` / `post.sql` — the per-shard loads. `pre.sql`
+  turns off FK/CHECK validation on the target tables (as bcp's bulk path
+  implicitly does; `post.sql` re-enables without validating, leaving them
+  untrusted — the same end-state as a bcp load) and, with `--manage-indexes`,
+  disables non-unique nonclustered indexes for `post.sql` to rebuild. Each
+  shard loads the tables in a rotated order to reduce lock contention, wraps
+  every insert in a deadlock-retry block, guards identity tables with
+  `IDENTITY_INSERT`, and `post.sql` reseeds identity tables.
+- `load.sh` — runs `pre.sql`, then the shard scripts in parallel
+  (`LOAD_WORKERS`, default 6), then `post.sql` and `fixup.sql`:
+
+  ```sh
+  SERVER=localhost,3433 DBUSER=sa DBPASSWORD=... \
+      DATA_DIR=/staging/bulkdata sh load.sh
+  ```
+
+  `DATA_DIR` is the path where the **server** sees the `.parquet` files —
+  e.g. bind-mount the output directory into the mssql container. With
+  `mssql-tools18`, also set `SQLCMD_OPTS=-C` to trust a self-signed server
+  certificate.
+- `load.sql` — the same load as one sequential script for plain
+  `sqlcmd -v DataDir=... -i load.sql`.
+- `fixup.sql` — the few INSERTs whose values read seed data that only exists
+  on a real database, generated set-based (one statement covers all copies).
+
+Caveats: needs SQL Server 2022+ (`OPENROWSET ... FORMAT='PARQUET'`);
+identity-column values are synthesized starting at `--identity-base` (pick a
+range unused on the target; `DBCC CHECKIDENT` afterwards moves the tables'
+identity seeds past it); recorded UPDATE/DELETEs that no-op on a real replay
+(stale recorded state, or rows seeded outside the tests) are skipped with a
+warning.
 
 ## Development
 

--- a/testing-tools/functional-test/README.md
+++ b/testing-tools/functional-test/README.md
@@ -169,8 +169,12 @@ setup scripts into MSSQL bulk-load files instead of executing them:
 
 ```sh
 uv run functional-test -d ../../reporting-pipeline-service/src/test/resources/testData/functional \
-    --bulk 10000 --bulk-out out/bulkdata
+    --bulk 10000 --bulk-out out/bulkdata --manage-indexes
 ```
+
+Use `--manage-indexes` for any sizable load — inserting through the tables'
+non-unique nonclustered indexes slows the bulk path badly, and
+disabling/rebuilding them is much faster at volume.
 
 (`out/` is bind-mounted read-only into the local mssql container at `/staging`
 — see `docker-compose.yaml` — so output written there is immediately readable

--- a/testing-tools/functional-test/README.md
+++ b/testing-tools/functional-test/README.md
@@ -142,6 +142,8 @@ uv run functional-test -S localhost:3433 -U rtr_admin \
 | `--skip-query` | off | Run each step's `setup.sql` but skip the query/expected polling — just load the test data without waiting for the pipeline to process it. |
 | `--bulk` | — | Generate MSSQL bulk-load files instead of running tests: COPIES shifted copies of every selected test's final setup rows (see below). Requires `--bulk-out`. |
 | `--bulk-out` | — | Output directory for `--bulk`. |
+| `--bulk-workers` | `min(8, CPUs)` | Parallel worker processes for `--bulk` generation; the copies are sharded across workers (each shard also loads in parallel via `load.sh`). |
+| `--manage-indexes` | off | With `--bulk`: emit load-script sections that disable non-unique nonclustered indexes on the target tables during the load and rebuild them after. |
 | `--identity-base` | `500000000` | First synthetic value for identity columns in `--bulk` output (loaded with `KEEPIDENTITY`). |
 | `--fail-fast` | off | Stop after the first failing test. |
 | `--pause` | off | Pause and wait for Enter after each step completes (Ctrl-C to abort), so you can inspect the database between steps. |

--- a/testing-tools/functional-test/pyproject.toml
+++ b/testing-tools/functional-test/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pymssql>=2.3.0",
+    "pyarrow>=17.0.0",
 ]
 
 [project.scripts]

--- a/testing-tools/functional-test/src/functional_test/bulk.py
+++ b/testing-tools/functional-test/src/functional_test/bulk.py
@@ -1,0 +1,94 @@
+"""Layout planning for bulk data generation (``--bulk``).
+
+Each *copy* of the suite is every selected test's setup data shifted to a
+fresh UID range. Copies are laid out so they can never collide with the
+originals or with each other:
+
+  * ``stride`` — the widest test's ID footprint within its 1000-wide block.
+    Consecutive copies shift by ``stride``, tiling each block.
+  * ``slots`` — how many copies fit inside one block (``1000 // stride``).
+  * ``span`` — once a block region is full, the next copy jumps past the
+    whole occupied range (highest block end minus lowest block start), where
+    the tiling starts over.
+
+Copy ``i`` therefore uses offset ``base + (i // slots) * span +
+(i % slots) * stride``: regions tile disjointly, blocks are distinct within
+a region, and slots tile within a block, so every copy lands on virgin IDs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .remapper import (
+    BLOCK_SIZE,
+    SETUP_FILE,
+    _detect_block_start,
+    _detect_declared_ids,
+)
+
+
+@dataclass
+class TestSetup:
+    """One test's setup scripts plus its detected UID block."""
+
+    name: str
+    block_start: int
+    block_width: int  # IDs actually used: max in-block id - block_start + 1
+    steps: list[tuple[str, str]]  # (step name, setup.sql text) in step order
+
+
+def load_test_setup(test_dir: Path) -> TestSetup:
+    steps = []
+    for step_dir in sorted(p for p in test_dir.iterdir() if p.is_dir()):
+        setup_path = step_dir / SETUP_FILE
+        if setup_path.is_file():
+            steps.append((step_dir.name, setup_path.read_text()))
+    if not steps:
+        raise ValueError(f"No {SETUP_FILE} files found under {test_dir}")
+
+    start = _detect_block_start(test_dir)
+    declared = _detect_declared_ids(sorted(test_dir.rglob(SETUP_FILE)))
+    in_block = {i for i in declared if start <= i < start + BLOCK_SIZE}
+    return TestSetup(
+        name=test_dir.name,
+        block_start=start,
+        block_width=max(in_block) - start + 1,
+        steps=steps,
+    )
+
+
+@dataclass
+class BulkPlan:
+    tests: list[TestSetup]
+    stride: int
+    slots: int
+    span: int
+
+    def offset_for(self, copy_index: int, base: int = 0) -> int:
+        region, slot = divmod(copy_index, self.slots)
+        return base + region * self.span + slot * self.stride
+
+
+def build_bulk_plan(test_dirs: list[Path]) -> BulkPlan:
+    tests = [load_test_setup(d) for d in test_dirs]
+
+    ordered = sorted(tests, key=lambda t: t.block_start)
+    for prev, cur in zip(ordered, ordered[1:]):
+        if cur.block_start < prev.block_start + BLOCK_SIZE:
+            raise ValueError(
+                f"Tests {prev.name!r} (block {prev.block_start}) and {cur.name!r} "
+                f"(block {cur.block_start}) have overlapping UID blocks; their bulk "
+                f"copies would collide. Select only one of them with -t."
+            )
+
+    stride = max(t.block_width for t in tests)
+    lo = min(t.block_start for t in tests)
+    hi = max(t.block_start for t in tests)
+    return BulkPlan(
+        tests=tests,
+        stride=stride,
+        slots=max(1, BLOCK_SIZE // stride),
+        span=hi + BLOCK_SIZE - lo,
+    )

--- a/testing-tools/functional-test/src/functional_test/bulkgen.py
+++ b/testing-tools/functional-test/src/functional_test/bulkgen.py
@@ -1,0 +1,817 @@
+"""Generate MSSQL bulk-load files from the functional tests' setup scripts.
+
+The setup scripts are full T-SQL (variables, ``OUTPUT INSERTED`` identity
+captures, UPDATEs and DELETEs), so the final rows cannot be read straight off
+the INSERT statements. Instead each test's scripts are *evaluated* once by a
+small interpreter that covers exactly the constructs the corpus uses:
+
+  * ``DECLARE @x bigint|nvarchar = <literal or string-concat expression>``
+  * ``DECLARE @t TABLE (...)`` + ``INSERT ... OUTPUT INSERTED.[col] INTO @t``
+    + ``SELECT TOP 1 @x = [value] FROM @t`` — the identity capture pattern.
+    When the captured column is not in the INSERT's column list the value is
+    database-generated; a synthetic value is allocated instead (loaded later
+    with KEEPIDENTITY) so downstream references stay consistent.
+  * ``INSERT INTO [dbo].[T] (cols) VALUES (...), (...)``
+  * ``UPDATE``/``DELETE`` with conjunctive equality WHERE clauses (including
+    ``(SELECT TOP 1 ...)`` scalar subqueries), applied to the in-memory rows.
+
+The evaluated rows are rendered N times — each copy's block IDs shifted per
+the BulkPlan, each copy's synthetic identities drawn from a fresh range. The
+Parquet output and load scripts live in :mod:`.parquet_out`; this module owns
+evaluation, the column-set parts, per-copy rendering, and the set-based
+``fixup.sql`` for seed-data-dependent INSERTs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+from .bulk import BulkPlan, TestSetup
+from .remapper import BLOCK_SIZE
+
+_IDENT = r"\[?([A-Za-z0-9_]+)\]?"
+_QUALIFIED = r"(?:\[?[A-Za-z0-9_]+\]?\.)*" + _IDENT
+
+
+class BulkGenError(ValueError):
+    """A setup construct the evaluator does not support."""
+
+
+class _SubqueryMiss(Exception):
+    """A scalar subquery matched no evaluated row.
+
+    Either the subquery reads seed data that only exists on a real database,
+    or the recorded WHERE captured state that a prior statement in the replay
+    already changed (in which case the statement no-ops on a real run too).
+    """
+
+    def __init__(self, table: str):
+        super().__init__(table)
+        self.table = table
+
+
+# ---------------------------------------------------------------------------
+# Values
+#
+# A value is None (SQL NULL) or a list of parts; a part is a plain string or
+# an IdRef placeholder for a synthesized identity. Block IDs stay as digits
+# inside the strings and are shifted at render time.
+
+
+@dataclass(frozen=True)
+class IdRef:
+    table: str
+    seq: int  # per-table sequence within one copy of the suite
+
+
+Part = Union[str, IdRef]
+Value = Optional[list]
+
+
+def _text(value: Value) -> str:
+    if value is None:
+        return "<NULL>"
+    return "".join(p if isinstance(p, str) else f"<id:{p.table}:{p.seq}>" for p in value)
+
+
+def _values_equal(a: Value, b: Value) -> bool:
+    if a is None or b is None:
+        return a is b
+    return _text(a) == _text(b)
+
+
+# ---------------------------------------------------------------------------
+# Statement splitting: ';' outside string literals, with '--' comments
+# dropped (outside literals only — XML payloads may contain either).
+
+
+def split_sql(sql: str) -> list[str]:
+    statements: list[str] = []
+    buf: list[str] = []
+    i, n = 0, len(sql)
+    in_string = False
+    while i < n:
+        ch = sql[i]
+        if in_string:
+            buf.append(ch)
+            if ch == "'":
+                in_string = False
+            i += 1
+        elif ch == "'":
+            in_string = True
+            buf.append(ch)
+            i += 1
+        elif ch == "-" and sql.startswith("--", i):
+            while i < n and sql[i] != "\n":
+                i += 1
+        elif ch == ";":
+            statements.append("".join(buf))
+            buf = []
+            i += 1
+        else:
+            buf.append(ch)
+            i += 1
+    statements.append("".join(buf))
+    return [s.strip() for s in statements if s.strip()]
+
+
+def _split_top_level(text: str, is_sep: Callable[[str, int], int]) -> list[str]:
+    """Split on separators found outside quotes and parentheses.
+
+    ``is_sep(text, i)`` returns the separator length at ``i`` (0 = no match).
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    in_string = False
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            buf.append(ch)
+            if ch == "'":
+                in_string = False
+            i += 1
+            continue
+        if ch == "'":
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if depth == 0 and not in_string:
+            sep_len = is_sep(text, i)
+            if sep_len:
+                parts.append("".join(buf))
+                buf = []
+                i += sep_len
+                continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return [p.strip() for p in parts]
+
+
+def _split_commas(text: str) -> list[str]:
+    return _split_top_level(text, lambda t, i: 1 if t[i] == "," else 0)
+
+
+def _split_ands(text: str) -> list[str]:
+    def is_and(t: str, i: int) -> int:
+        if t[i : i + 3].upper() == "AND" and (i == 0 or not t[i - 1].isalnum()):
+            after = i + 3
+            if after >= len(t) or not (t[after].isalnum() or t[after] == "_"):
+                return 3
+        return 0
+
+    return _split_top_level(text, is_and)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+
+
+@dataclass
+class Table:
+    name: str
+    first_seen: int
+    columns: list[str] = field(default_factory=list)  # union, in first-seen order
+    rows: list[dict] = field(default_factory=list)  # col -> Value
+    identity_col: Optional[str] = None
+    identity_count: int = 0  # synthesized values per copy of the suite
+    _by_lower: dict[str, str] = field(default_factory=dict)
+
+    def add_column(self, col: str) -> str:
+        """Register a column and return its canonical (first-seen) spelling.
+
+        SQL Server column names are case-insensitive; different tests spell
+        the same column differently, and a duplicate in the union would make
+        the bulkload view invalid.
+        """
+        canonical = self._by_lower.get(col.lower())
+        if canonical is None:
+            canonical = col
+            self._by_lower[col.lower()] = col
+            self.columns.append(col)
+        return canonical
+
+
+def _row_get(row: dict, col: str) -> Value:
+    """Case-insensitive row lookup (row keys hold canonical spellings)."""
+    if col in row:
+        return row[col]
+    lower = col.lower()
+    for key, value in row.items():
+        if key.lower() == lower:
+            return value
+    return None
+
+
+@dataclass
+class SuiteData:
+    """Final-state rows for the whole suite, still holding original block IDs."""
+
+    plan: BulkPlan
+    tables: dict[str, Table] = field(default_factory=dict)
+    test_rows: dict[str, list[tuple[str, dict]]] = field(default_factory=dict)
+    # INSERT rows with values only the target database can supply (seed-data
+    # subqueries). Loaded via a staging table + one set-based INSERT..SELECT.
+    deferred_rows: list["DeferredRow"] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def table(self, name: str) -> Table:
+        key = name.lower()
+        if key not in self.tables:
+            self.tables[key] = Table(name=name, first_seen=len(self.tables))
+        return self.tables[key]
+
+    @property
+    def load_order(self) -> list[Table]:
+        return sorted(self.tables.values(), key=lambda t: t.first_seen)
+
+    @property
+    def rows_per_copy(self) -> int:
+        return sum(len(t.rows) for t in self.tables.values())
+
+
+@dataclass
+class DeferredRow:
+    """One INSERT row whose seed-dependent columns resolve at load time."""
+
+    test: str
+    table_key: str
+    columns: list[str]  # literal columns, canonical, insert order
+    values: list  # parallel to columns
+    seed_cols: list[tuple[str, list]]  # (canonical column, expr as parts)
+
+
+_DECLARE_ASSIGN = re.compile(
+    r"DECLARE\s+(@\w+)\s+[A-Za-z]+(?:\s*\(\s*(?:\d+|MAX)\s*\))?\s*=\s*", re.I
+)
+_DECLARE_TABLE = re.compile(r"DECLARE\s+(@\w+)\s+TABLE\s*\(", re.I)
+_DECLARE_BARE = re.compile(
+    r"DECLARE\s+(@\w+)\s+[A-Za-z]+(?:\s*\(\s*(?:\d+|MAX)\s*\))?\s*(?=$|;|\n|DECLARE)", re.I
+)
+_STRING = re.compile(r"N?'((?:[^']|'')*)'", re.S)
+_INSERT = re.compile(
+    rf"INSERT\s+INTO\s+{_QUALIFIED}\s*\((?P<cols>[^)]*)\)\s*"
+    r"(?:OUTPUT\s+INSERTED\.\[?(?P<outcol>[A-Za-z0-9_]+)\]?"
+    r"\s+INTO\s+(?P<tv>@\w+)\s*(?:\([^)]*\))?\s*)?"
+    r"VALUES\s*(?P<values>.*)$",
+    re.I | re.S,
+)
+_CAPTURE = re.compile(
+    rf"SELECT\s+TOP\s*\(?\s*1\s*\)?\s+(?P<var>@\w+)\s*=\s*{_IDENT}\s+FROM\s+(?P<tv>@\w+)\s*$",
+    re.I,
+)
+_UPDATE = re.compile(
+    rf"UPDATE\s+{_QUALIFIED}\s+SET\s+(?P<set>.*?)\s+WHERE\s+(?P<where>.*)$", re.I | re.S
+)
+_DELETE = re.compile(
+    rf"DELETE\s+FROM\s+{_QUALIFIED}\s*(?:WHERE\s+(?P<where>.*))?$", re.I | re.S
+)
+_SUBQUERY = re.compile(
+    rf"\(\s*SELECT\s+TOP\s*\(?\s*1\s*\)?\s+{_IDENT}\s+FROM\s+{_QUALIFIED}\s*"
+    r"(?:WHERE\s+(?P<where>.*?))?\s*(?:ORDER\s+BY\s+[^)]*)?\)$",
+    re.I | re.S,
+)
+
+
+class _Evaluator:
+    def __init__(self, suite: SuiteData, test: TestSetup, now: str):
+        self.suite = suite
+        self.test = test
+        self.now = now
+        self.env: dict[str, Value] = {}
+        self.table_vars: dict[str, list[Value]] = {}
+
+    def warn(self, msg: str) -> None:
+        self.suite.warnings.append(f"{self.test.name}: {msg}")
+
+    # -- expressions --------------------------------------------------------
+
+    def eval_expr(self, text: str, row: Optional[dict] = None) -> Value:
+        text = text.strip()
+        sub = _SUBQUERY.match(text)
+        if sub:
+            return self._eval_subquery(sub)
+        parts = _split_top_level(text, lambda t, i: 1 if t[i] == "+" else 0)
+        if len(parts) > 1:
+            values = [self.eval_expr(part, row) for part in parts]
+            if any(v is None for v in values):
+                return None  # SQL: NULL propagates through + (either meaning)
+            texts = [_text(v) for v in values]
+            if all(re.fullmatch(r"-?\d+", t) for t in texts):
+                return [str(sum(int(t) for t in texts))]
+            out: list = []
+            for value in values:
+                out.extend(value)
+            return out
+        return self._eval_primary(text, row)
+
+    def _eval_primary(self, text: str, row: Optional[dict]) -> Value:
+        text = text.strip()
+        m = _STRING.fullmatch(text)
+        if m:
+            return [m.group(1).replace("''", "'")]
+        if re.fullmatch(r"-?\d+(\.\d+)?", text):
+            return [text]
+        if re.fullmatch(r"NULL", text, re.I):
+            return None
+        if text.startswith("@"):
+            if text not in self.env:
+                raise BulkGenError(f"reference to unset variable {text}")
+            return self.env[text]
+        if re.fullmatch(r"GETDATE\s*\(\s*\)", text, re.I):
+            return [self.now]
+        m = re.fullmatch(r"ABS\s*\((.*)\)", text, re.I | re.S)
+        if m:
+            value = self.eval_expr(m.group(1), row)
+            if value is None:
+                return None
+            return [str(abs(int(_text(value))))]
+        m = re.fullmatch(
+            r"CONVERT\s*\(\s*\w+(?:\s*\(\s*(?:\d+|MAX)\s*\))?\s*,(.*)\)", text, re.I | re.S
+        )
+        if m:
+            return self.eval_expr(m.group(1), row)
+        m = re.fullmatch(r"ISNULL\s*\((.*)\)", text, re.I | re.S)
+        if m:
+            args = _split_commas(m.group(1))
+            if len(args) == 2:
+                value = self.eval_expr(args[0], row)
+                return value if value is not None else self.eval_expr(args[1], row)
+        if row is not None:
+            m = re.fullmatch(_IDENT, text)
+            if m:
+                return _row_get(row, m.group(1))
+        raise BulkGenError(f"unsupported expression: {text[:80]!r}")
+
+    def _eval_subquery(self, m: re.Match) -> Value:
+        col, table_name = m.group(1), m.group(2)
+        table = self.suite.table(table_name)
+        conditions = self._parse_where(m.group("where")) if m.group("where") else []
+        for row in table.rows:
+            if all(_values_equal(_row_get(row, c), v) for c, v in conditions):
+                return _row_get(row, col)
+        raise _SubqueryMiss(table_name)
+
+    def _parse_where(self, where: str) -> list[tuple[str, Value]]:
+        conditions = []
+        for clause in _split_ands(where):
+            m = re.fullmatch(rf"\s*{_IDENT}\s*=\s*(.*)", clause, re.S)
+            if not m:
+                raise BulkGenError(f"unsupported WHERE clause: {clause[:80]!r}")
+            conditions.append((m.group(1), self.eval_expr(m.group(2))))
+        return conditions
+
+    # -- statements ---------------------------------------------------------
+
+    def run(self, sql: str) -> None:
+        for statement in split_sql(sql):
+            keyword = statement.split(None, 1)[0].upper()
+            if keyword in ("USE", "ALTER", "SET"):
+                continue
+            handler = getattr(self, f"_do_{keyword.lower()}", None)
+            if handler is None:
+                raise BulkGenError(f"unsupported statement: {statement[:80]!r}")
+            handler(statement)
+
+    def _do_declare(self, statement: str) -> None:
+        remaining = statement
+        for m in _DECLARE_TABLE.finditer(remaining):
+            self.table_vars[m.group(1)] = []
+        remaining = _DECLARE_TABLE.sub("DECLARED_TABLE (", remaining)
+        # Assigned declares: the expression runs to the end of the statement
+        # (statements were already split on ';'), one DECLARE per statement in
+        # this corpus once table declares are removed.
+        m = _DECLARE_ASSIGN.search(remaining)
+        if m:
+            self.env[m.group(1)] = self.eval_expr(remaining[m.end():])
+            return
+        for m in _DECLARE_BARE.finditer(remaining):
+            self.env.setdefault(m.group(1), None)
+
+    def _do_insert(self, statement: str) -> None:
+        m = _INSERT.match(statement)
+        if not m:
+            raise BulkGenError(f"unsupported INSERT: {statement[:80]!r}")
+        table = self.suite.table(m.group(1))
+        columns = [c.strip().strip("[]") for c in m.group("cols").split(",")]
+        out_col, out_tv = m.group("outcol"), m.group("tv")
+
+        rows = []
+        for tuple_text in _split_commas(m.group("values").strip()):
+            if not (tuple_text.startswith("(") and tuple_text.endswith(")")):
+                raise BulkGenError(f"unsupported VALUES tuple: {tuple_text[:80]!r}")
+            raw_values = _split_commas(tuple_text[1:-1])
+            if len(raw_values) != len(columns):
+                raise BulkGenError(
+                    f"column/value count mismatch inserting into {table.name}"
+                )
+            literals: list[tuple[str, Value]] = []
+            seeds: list[tuple[str, list]] = []
+            miss_table = ""
+            for col, value_text in zip(columns, raw_values):
+                canonical = table.add_column(col)
+                try:
+                    literals.append((canonical, self.eval_expr(value_text)))
+                except _SubqueryMiss as miss:
+                    # A value only the target database can supply (seed-data
+                    # lookup): resolve at load time via a set-based INSERT.
+                    seeds.append((canonical, self._inline_vars(value_text)))
+                    miss_table = miss.table
+            if seeds:
+                if out_col:
+                    raise BulkGenError(
+                        f"OUTPUT capture on seed-dependent INSERT into {table.name}"
+                    )
+                self.suite.deferred_rows.append(DeferredRow(
+                    test=self.test.name,
+                    table_key=table.name.lower(),
+                    columns=[c for c, _ in literals],
+                    values=[v for _, v in literals],
+                    seed_cols=seeds,
+                ))
+                self.warn(
+                    f"INSERT into {table.name} deferred to fixup.sql "
+                    f"(subquery on {miss_table} reads seed data)"
+                )
+                continue
+            rows.append(dict(literals))
+
+        for row in rows:
+            if out_col:
+                out_key = table.add_column(out_col)
+                if out_key in row:
+                    captured = row[out_key]
+                else:
+                    # Database-generated (identity): synthesize a stable value.
+                    table.identity_col = out_key
+                    captured = [IdRef(table.name, table.identity_count)]
+                    table.identity_count += 1
+                    row[out_key] = captured
+                self.table_vars.setdefault(out_tv, []).append(captured)
+            table.rows.append(row)
+            self.suite.test_rows.setdefault(self.test.name, []).append(
+                (table.name.lower(), row)
+            )
+
+    def _inline_vars(self, statement: str) -> list:
+        """Replace @variables with SQL literals, keeping IdRefs as parts."""
+        parts: list = []
+        pos = 0
+        for m in re.finditer(r"@\w+", statement):
+            parts.append(statement[pos : m.start()])
+            value = self.env.get(m.group(0))
+            if value is None:
+                if m.group(0) not in self.env:
+                    raise BulkGenError(f"reference to unset variable {m.group(0)}")
+                parts.append("NULL")
+            elif len(value) == 1 and isinstance(value[0], IdRef):
+                parts.append(value[0])
+            elif re.fullmatch(r"-?\d+(\.\d+)?", _text(value)):
+                parts.append(_text(value))
+            else:
+                parts.append("N'" + _text(value).replace("'", "''") + "'")
+            pos = m.end()
+        parts.append(statement[pos:])
+        return parts
+
+    def _do_select(self, statement: str) -> None:
+        m = _CAPTURE.match(statement)
+        if not m:
+            raise BulkGenError(f"unsupported SELECT: {statement[:80]!r}")
+        tv = m.group("tv")
+        if tv not in self.table_vars or not self.table_vars[tv]:
+            raise BulkGenError(f"capture from empty/unknown table variable {tv}")
+        self.env[m.group("var")] = self.table_vars[tv][-1]
+
+    def _do_update(self, statement: str) -> None:
+        m = _UPDATE.match(statement)
+        if not m:
+            raise BulkGenError(f"unsupported UPDATE: {statement[:80]!r}")
+        table = self.suite.table(m.group(1))
+        try:
+            conditions = self._parse_where(m.group("where"))
+        except _SubqueryMiss as miss:
+            # A no-op on a real replay too: the recorded WHERE state was
+            # already changed by an earlier statement (or targets seed data).
+            self.warn(f"UPDATE {table.name} skipped (subquery on {miss.table} "
+                      f"matched no rows)")
+            return
+        assignments = []
+        for clause in _split_commas(m.group("set")):
+            am = re.fullmatch(rf"\s*{_IDENT}\s*=\s*(.*)", clause, re.S)
+            if not am:
+                raise BulkGenError(f"unsupported SET clause: {clause[:80]!r}")
+            assignments.append((am.group(1), am.group(2)))
+        matched = 0
+        try:
+            for row in table.rows:
+                if all(_values_equal(_row_get(row, c), v) for c, v in conditions):
+                    matched += 1
+                    # SQL evaluates every RHS against the pre-update row.
+                    new_values = [(c, self.eval_expr(e, row)) for c, e in assignments]
+                    for col, value in new_values:
+                        row[table.add_column(col)] = value
+        except _SubqueryMiss as miss:
+            self.warn(f"UPDATE {table.name} skipped (subquery on {miss.table} "
+                      f"matched no rows)")
+            return
+        if matched == 0:
+            self.warn(f"UPDATE {table.name} matched no rows")
+
+    def _do_delete(self, statement: str) -> None:
+        m = _DELETE.match(statement)
+        if not m:
+            raise BulkGenError(f"unsupported DELETE: {statement[:80]!r}")
+        table = self.suite.table(m.group(1))
+        try:
+            conditions = self._parse_where(m.group("where")) if m.group("where") else []
+        except _SubqueryMiss as miss:
+            self.warn(f"DELETE from {table.name} skipped (subquery on {miss.table} "
+                      f"matched no rows)")
+            return
+        kept = [
+            row
+            for row in table.rows
+            if not all(_values_equal(_row_get(row, c), v) for c, v in conditions)
+        ]
+        removed = {id(r) for r in table.rows} - {id(r) for r in kept}
+        table.rows = kept
+        for rows in self.suite.test_rows.values():
+            rows[:] = [(t, r) for t, r in rows if id(r) not in removed]
+
+
+def evaluate_suite(plan: BulkPlan, now: Optional[str] = None) -> SuiteData:
+    """Run every test's setup scripts through the interpreter once."""
+    suite = SuiteData(plan=plan)
+    now = now or datetime.now().strftime("%Y-%m-%dT%H:%M:%S.000")
+    for test in plan.tests:
+        evaluator = _Evaluator(suite, test, now)
+        for step_name, sql in test.steps:
+            try:
+                evaluator.run(sql)
+            except BulkGenError as exc:
+                raise BulkGenError(f"{test.name}/{step_name}: {exc}") from exc
+
+    # Once a table is known to have an identity column, EVERY row must carry
+    # a synthesized value — not only the OUTPUT-captured ones. Loading with
+    # IDENTITY_INSERT advances the table's identity seed (unlike bcp's
+    # KEEPIDENTITY), so a row left for the server to number would draw a
+    # value inside the synthesized range another copy explicitly claims.
+    for table in suite.tables.values():
+        if not table.identity_col:
+            continue
+        for row in table.rows:
+            if table.identity_col not in row:
+                row[table.identity_col] = [IdRef(table.name, table.identity_count)]
+                table.identity_count += 1
+    return suite
+
+
+# ---------------------------------------------------------------------------
+# Rendering: per-copy ID shifting via precompiled segments
+
+
+_NUMBER = re.compile(r"(?<!\d)\d+(?!\d)")
+
+
+def _compile_parts(parts: list, block_start: int, block_end: int) -> list:
+    """Split string parts around in-block numbers so shifting is a cheap join.
+
+    Returns a list of: plain str | int (in-block ID, shift me) | IdRef.
+    """
+    compiled: list = []
+    for part in parts:
+        if isinstance(part, IdRef):
+            compiled.append(part)
+            continue
+        pos = 0
+        for m in _NUMBER.finditer(part):
+            number = int(m.group(0))
+            if block_start <= number < block_end:
+                compiled.append(part[pos : m.start()])
+                compiled.append(number)
+                pos = m.end()
+        compiled.append(part[pos:])
+    return compiled
+
+
+@dataclass
+class TablePart:
+    """Rows of one table sharing the exact same column set.
+
+    Different inserts into a table use different column subsets; loading them
+    through one union view would turn absent columns into NULLs where a real
+    INSERT applies the column default (and NOT NULL columns would reject the
+    load). Each distinct column set gets its own data file and view instead.
+    """
+
+    table: Table
+    name: str  # e.g. "Person" or "Person__2"
+    columns: list[str]
+    index: int = 1  # 1-based position among the table's parts
+
+    @property
+    def keep_identity(self) -> bool:
+        return self.table.identity_col in self.columns
+
+
+def _build_parts(suite: SuiteData) -> dict[tuple[str, frozenset], TablePart]:
+    """Assign every distinct (table, column-set) to a TablePart, in row order."""
+    parts: dict[tuple[str, frozenset], TablePart] = {}
+    per_table: dict[str, int] = {}
+    for test in suite.plan.tests:
+        for table_key, row in suite.test_rows.get(test.name, []):
+            key = (table_key, frozenset(c.lower() for c in row))
+            if key in parts:
+                continue
+            table = suite.tables[table_key]
+            per_table[table_key] = per_table.get(table_key, 0) + 1
+            parts[key] = TablePart(
+                table=table,
+                name=table.name,  # renamed below if the table splits
+                columns=[c for c in table.columns if c in row],
+            )
+    # Deterministic names: number the parts of any table that split.
+    counters: dict[str, int] = {}
+    for key, part in parts.items():
+        table_key = key[0]
+        counters[table_key] = counters.get(table_key, 0) + 1
+        part.index = counters[table_key]
+        if per_table[table_key] > 1:
+            part.name = f"{part.table.name}__{part.index}"
+    return parts
+
+
+@dataclass
+class _CompiledRow:
+    part: TablePart
+    fields: list  # one compiled parts-list (or None) per part column
+
+
+def _compile_rows(
+    suite: SuiteData, parts: dict[tuple[str, frozenset], TablePart]
+) -> dict[str, list[_CompiledRow]]:
+    by_test: dict[str, list[_CompiledRow]] = {}
+    for test in suite.plan.tests:
+        lo, hi = test.block_start, test.block_start + BLOCK_SIZE
+        compiled = []
+        for table_key, row in suite.test_rows.get(test.name, []):
+            part = parts[(table_key, frozenset(c.lower() for c in row))]
+            fields = [
+                None if row.get(col) is None else _compile_parts(row[col], lo, hi)
+                for col in part.columns
+            ]
+            compiled.append(_CompiledRow(part, fields))
+        by_test[test.name] = compiled
+    return by_test
+
+
+def build_ordered_parts(
+    suite: SuiteData,
+) -> tuple[dict[tuple[str, frozenset], TablePart], list[TablePart]]:
+    """Part registry plus parts in FK-safe (first-insert, part-index) order."""
+    part_map = _build_parts(suite)
+    order = {t.name.lower(): t.first_seen for t in suite.tables.values()}
+    all_parts = sorted(
+        part_map.values(), key=lambda p: (order[p.table.name.lower()], p.index)
+    )
+    return part_map, all_parts
+
+
+def _render_field(compiled: list, offset: int, id_base: dict[str, int]) -> str:
+    out = []
+    for part in compiled:
+        if isinstance(part, int):
+            out.append(str(part + offset))
+        elif isinstance(part, IdRef):
+            out.append(str(id_base[part.table.lower()] + part.seq))
+        else:
+            out.append(part)
+    return "".join(out)
+
+
+# fixup.sql resolves seed-dependent INSERTs set-based: a numbers CTE yields
+# one row per copy, every column becomes an expression in the copy index i
+# (shifted IDs are base + (i/slots)*span + (i%slots)*stride), and the seed
+# subquery appears once — constant script size regardless of copy count.
+
+
+def _copy_offset_sql(plan: BulkPlan, base_shift: int) -> str:
+    expr = f"(n.i / {plan.slots}) * {plan.span} + (n.i % {plan.slots}) * {plan.stride}"
+    return f"{base_shift} + {expr}" if base_shift else expr
+
+
+def _sql_string(text: str) -> str:
+    return "N'" + text.replace("'", "''") + "'"
+
+
+def _part_exprs(compiled: list, offset_sql: str, identity_base: int, suite: SuiteData) -> list[str]:
+    exprs = []
+    for part in compiled:
+        if isinstance(part, int):
+            exprs.append(f"({part} + {offset_sql})")
+        elif isinstance(part, IdRef):
+            count = suite.tables[part.table.lower()].identity_count
+            exprs.append(f"({identity_base + part.seq} + n.i * {count})")
+        elif part:
+            exprs.append(_sql_string(part))
+    return exprs
+
+
+def _value_expr(
+    value: Value, lo: int, hi: int, offset_sql: str, identity_base: int, suite: SuiteData
+) -> str:
+    if value is None:
+        return "NULL"
+    exprs = _part_exprs(_compile_parts(value, lo, hi), offset_sql, identity_base, suite)
+    if not exprs:
+        return "N''"
+    if len(exprs) == 1:
+        expr = exprs[0]
+        # A plain numeric literal needs no quoting.
+        if expr.startswith("N'") and re.fullmatch(r"-?\d+(\.\d+)?", _text(value)):
+            return _text(value)
+        return expr
+    return "CONCAT(" + ", ".join(exprs) + ")"
+
+
+def _seed_expr(
+    parts: list, lo: int, hi: int, offset_sql: str, identity_base: int, suite: SuiteData
+) -> str:
+    # The parts are SQL text (variables already inlined); only embedded block
+    # IDs and identity references are rewritten as expressions in n.i.
+    out = []
+    for part in _compile_parts(parts, lo, hi):
+        if isinstance(part, int):
+            out.append(f"({part} + {offset_sql})")
+        elif isinstance(part, IdRef):
+            count = suite.tables[part.table.lower()].identity_count
+            out.append(f"({identity_base + part.seq} + n.i * {count})")
+        else:
+            out.append(part)
+    return "".join(out)
+
+
+def _write_fixup_sql(
+    out_dir: Path,
+    suite: SuiteData,
+    copies: int,
+    base_shift: int,
+    identity_base: int,
+    database: str,
+) -> Path:
+    plan = suite.plan
+    blocks = {t.name: (t.block_start, t.block_start + BLOCK_SIZE) for t in plan.tests}
+    offset_sql = _copy_offset_sql(plan, base_shift)
+    lines = [
+        "-- INSERTs whose values read seed data on the target database,",
+        "-- generated set-based (one statement per deferred row, all copies).",
+        "-- Run AFTER load.sql / load.sh.",
+        f"USE [{database}];",
+    ]
+    for row in suite.deferred_rows:
+        lo, hi = blocks[row.test]
+        table = suite.tables[row.table_key]
+        columns = list(row.columns) + [c for c, _ in row.seed_cols]
+        exprs = [
+            _value_expr(v, lo, hi, offset_sql, identity_base, suite) for v in row.values
+        ] + [
+            _seed_expr(parts, lo, hi, offset_sql, identity_base, suite)
+            for _, parts in row.seed_cols
+        ]
+        lines.append(
+            "WITH d AS (SELECT 0 AS z FROM (VALUES (0),(0),(0),(0),(0),(0),(0),(0)) v(z)),"
+        )
+        lines.append(
+            f"     nums(i) AS (SELECT TOP ({copies}) "
+            "ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) - 1 "
+            "FROM d a, d b, d c, d e, d f, d g, d h, d j)"
+        )
+        lines.append(
+            f"INSERT INTO [dbo].[{table.name}] ("
+            + ", ".join(f"[{c}]" for c in columns)
+            + ")"
+        )
+        lines.append("SELECT " + ",\n       ".join(exprs))
+        lines.append("FROM nums AS n;")
+    path = out_dir / "fixup.sql"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _reseed_tables(parts: list[TablePart]) -> list[str]:
+    """Tables (deduped, in order) whose identity seeds need re-aligning."""
+    seen = []
+    for part in parts:
+        name = part.table.name
+        if part.table.identity_col and name not in seen:
+            seen.append(name)
+    return seen

--- a/testing-tools/functional-test/src/functional_test/cli.py
+++ b/testing-tools/functional-test/src/functional_test/cli.py
@@ -162,6 +162,53 @@ def build_parser(defaults: dict[str, str] | None = None) -> argparse.ArgumentPar
         "you can inspect the database between steps.",
     )
     parser.add_argument(
+        "--bulk",
+        type=int,
+        default=None,
+        metavar="COPIES",
+        help="Bulk-file generation: evaluate every selected test's setup.sql offline and "
+        "write COPIES shifted copies of the resulting rows as sharded Parquet plus "
+        "OPENROWSET loader scripts (SQL Server 2022+). No database connection is "
+        "made. Requires --bulk-out.",
+    )
+    parser.add_argument(
+        "--bulk-out",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Output directory for --bulk files.",
+    )
+    parser.add_argument(
+        "--bulk-workers",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Parallel generation worker processes for --bulk; the copies are "
+        "sharded and each shard also loads in parallel via load.sh. "
+        "Defaults to min(8, CPU count).",
+    )
+    parser.add_argument(
+        "--manage-indexes",
+        action="store_true",
+        help="Emit load-script sections that disable non-unique nonclustered indexes "
+        "on the target tables during the load and rebuild them after (parquet format).",
+    )
+    parser.add_argument(
+        "--identity-base",
+        type=int,
+        default=500_000_000,
+        metavar="N",
+        help="First synthetic value for identity columns captured via OUTPUT INSERTED "
+        "in the setup scripts (loaded with KEEPIDENTITY). Pick a range unused on the "
+        "target database.",
+    )
+    parser.add_argument(
+        "--skip-query",
+        action="store_true",
+        help="Run each step's setup.sql but skip the query/expected polling entirely — "
+        "useful for just loading test data without waiting for the pipeline to process it.",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Live-print each query's SQL and its expected vs actual results on every poll "
@@ -217,6 +264,71 @@ def _print_test_result(result: TestResult) -> None:
             print(_dim(f"        {step.setup_error}"))
 
 
+def _run_bulk_generation(args, test_dirs: list[Path]) -> int:
+    import time
+    from collections import Counter
+
+    from .bulk import build_bulk_plan
+    from .bulkgen import BulkGenError, evaluate_suite
+    from .parquet_out import write_bulk_parquet
+
+    base = args.shift_id or 0
+    try:
+        plan = build_bulk_plan(test_dirs)
+        suite = evaluate_suite(plan)
+    except (ValueError, BulkGenError) as exc:
+        print(_red(str(exc)), file=sys.stderr)
+        return 2
+
+    identity_total = sum(t.identity_count for t in suite.tables.values())
+    print(_bold(
+        f"Evaluated {len(plan.tests)} test(s): {suite.rows_per_copy} rows/copy across "
+        f"{len(suite.tables)} tables ({identity_total} synthesized identity values/copy)."
+    ))
+    print(_dim(
+        f"  shift pattern: base {base:+d}, stride {plan.stride}, "
+        f"{plan.slots} copies per region, region span {plan.span}"
+    ))
+    print(_dim(
+        f"  copy offsets {plan.offset_for(0, base)} .. {plan.offset_for(args.bulk - 1, base)}; "
+        f"identity values from {args.identity_base}"
+    ))
+    for warning, count in Counter(suite.warnings).items():
+        prefix = f"{count}x " if count > 1 else ""
+        print(_dim(f"  warning: {prefix}{warning}"))
+
+    start = time.monotonic()
+    workers = args.bulk_workers or min(8, os.cpu_count() or 1)
+
+    def on_shard(done: int, total: int) -> None:
+        print(_dim(f"  shard {done}/{total} written "
+                   f"({time.monotonic() - start:.1f}s elapsed)"))
+        sys.stdout.flush()
+
+    written = write_bulk_parquet(
+        suite,
+        args.bulk_out,
+        args.bulk,
+        base_shift=base,
+        identity_base=args.identity_base,
+        database=args.database,
+        workers=workers,
+        manage_indexes=args.manage_indexes,
+        on_progress=on_shard,
+    )
+    hint = ("  load with: SERVER=... DBUSER=... DBPASSWORD=... "
+            "DATA_DIR=<server-visible path> sh load.sh "
+            "(OPENROWSET, SQL Server 2022+; parallel shard loaders)")
+
+    total_bytes = sum(p.stat().st_size for p in written)
+    print(_bold(_green(
+        f"Wrote {len(written)} files ({total_bytes / 2**20:.1f} MiB, "
+        f"{suite.rows_per_copy * args.bulk} rows) to {args.bulk_out}"
+    )))
+    print(_dim(hint))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -240,6 +352,16 @@ def main(argv: list[str] | None = None) -> int:
         for test_dir in test_dirs:
             print(f"  {test_dir.name}")
         return 0
+
+    if (args.bulk is None) != (args.bulk_out is None):
+        print(_red("--bulk and --bulk-out must be used together."), file=sys.stderr)
+        return 2
+    if args.bulk is not None:
+        if args.start_id is not None:
+            print(_red("--bulk cannot be combined with -i/--id; use -s for a base shift."),
+                  file=sys.stderr)
+            return 2
+        return _run_bulk_generation(args, test_dirs)
 
     if not args.user:
         print(
@@ -265,7 +387,8 @@ def main(argv: list[str] | None = None) -> int:
         print(_red(f"Failed to connect: {type(exc).__name__}: {exc}"), file=sys.stderr)
         return 2
 
-    print(_bold(f"Running {len(test_dirs)} functional test(s)\n"))
+    print(_bold(f"Running {len(test_dirs)} functional test(s)"
+                + (" (setup only, queries skipped)" if args.skip_query else "") + "\n"))
 
     def emit(msg: str) -> None:
         print(_dim(msg))
@@ -311,6 +434,7 @@ def main(argv: list[str] | None = None) -> int:
                 on_query=on_query,
                 on_poll=on_poll,
                 on_step_complete=on_step_complete,
+                skip_query=args.skip_query,
             )
             results.append(result)
             _print_test_result(result)

--- a/testing-tools/functional-test/src/functional_test/parquet_out.py
+++ b/testing-tools/functional-test/src/functional_test/parquet_out.py
@@ -1,0 +1,394 @@
+"""Parquet + OPENROWSET output for --bulk.
+
+Targets SQL Server 2022+, modeled on the odse-volume-generator load pipeline:
+
+  * Rows are written as Parquet (string columns; the server converts in the
+    INSERT..SELECT). Parquet distinguishes NULL from empty string and needs
+    no terminator or timestamp workarounds.
+  * Each table part loads with one set-based statement per shard file:
+    INSERT INTO t (cols) SELECT cols FROM OPENROWSET(BULK ..., PARQUET).
+    The explicit column list handles column subsets directly — no views.
+    Files must be visible to the SERVER (e.g. the compose bind mount).
+  * Generation is sharded over worker processes: copy range [start, start+n)
+    is deterministic (offsets and identity values are pure functions of the
+    global copy index), so shards are generated and loaded independently.
+  * --manage-indexes emits pre/post scripts that disable non-unique
+    nonclustered indexes on the target tables during the load and rebuild
+    them after — the same dynamic-SQL approach as odse-volume-generator.
+
+Output layout: <Part>__s<K>.parquet per shard, shard_<K>.sql per shard,
+pre.sql / post.sql, fixup.sql (set-based, from bulkgen), load.sql (sequential
+all-in-one) and load.sh (parallel shard loaders via xargs -P).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+from typing import Callable, Optional
+
+from .bulkgen import (
+    SuiteData,
+    TablePart,
+    _compile_rows,
+    _render_field,
+    _reseed_tables,
+    _write_fixup_sql,
+    build_ordered_parts,
+)
+
+FLUSH_EVERY_ROWS = 100_000
+
+
+def _shard_ranges(copies: int, workers: int) -> list[tuple[int, int, int]]:
+    """(shard_index, start, count) covering [0, copies) contiguously."""
+    workers = max(1, min(workers, copies))
+    base, extra = divmod(copies, workers)
+    ranges = []
+    start = 0
+    for shard in range(workers):
+        count = base + (1 if shard < extra else 0)
+        ranges.append((shard, start, count))
+        start += count
+    return ranges
+
+
+def _shard_file(part: TablePart, shard: int) -> str:
+    return f"{part.name}__s{shard:03d}.parquet"
+
+
+class _PartWriter:
+    """Buffered Parquet writer for one table part (all columns as strings)."""
+
+    def __init__(self, path: Path, columns: list[str]):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        self._pa = pa
+        self.columns = columns
+        self.schema = pa.schema([(c, pa.string()) for c in columns])
+        self.writer = pq.ParquetWriter(path, self.schema)
+        self.buffer: list[list[Optional[str]]] = [[] for _ in columns]
+        self.rows = 0
+        # Longest value per column: OPENROWSET's default inference caps
+        # strings at VARCHAR(8000), so wide columns (EDX XML payloads) need
+        # an explicit NVARCHAR(MAX) in the load statement's WITH schema.
+        self.max_len = [0] * len(columns)
+
+    def append(self, fields: list[Optional[str]]) -> None:
+        for i, (column, value) in enumerate(zip(self.buffer, fields)):
+            column.append(value)
+            if value is not None and len(value) > self.max_len[i]:
+                self.max_len[i] = len(value)
+        self.rows += 1
+        if len(self.buffer[0]) >= FLUSH_EVERY_ROWS:
+            self.flush()
+
+    def flush(self) -> None:
+        if self.buffer and self.buffer[0]:
+            arrays = [self._pa.array(col, type=self._pa.string()) for col in self.buffer]
+            self.writer.write_table(self._pa.Table.from_arrays(arrays, schema=self.schema))
+            self.buffer = [[] for _ in self.columns]
+
+    def close(self) -> None:
+        self.flush()
+        self.writer.close()
+
+
+def write_shard(
+    suite: SuiteData,
+    out_dir: Path,
+    shard: int,
+    start: int,
+    count: int,
+    base_shift: int = 0,
+    identity_base: int = 500_000_000,
+    on_progress: Optional[Callable[[int], None]] = None,
+) -> dict[str, list[int]]:
+    """Render global copies [start, start+count) into this shard's files.
+
+    Returns per-part max value length per column (for the load schemas).
+    """
+    part_map, all_parts = build_ordered_parts(suite)
+    compiled_by_test = _compile_rows(suite, part_map)
+
+    writers = {
+        part.name: _PartWriter(out_dir / _shard_file(part, shard), part.columns)
+        for part in all_parts
+    }
+    try:
+        for copy_index in range(start, start + count):
+            offset = suite.plan.offset_for(copy_index, base_shift)
+            id_base = {
+                key: identity_base + copy_index * table.identity_count
+                for key, table in suite.tables.items()
+                if table.identity_count
+            }
+            for test in suite.plan.tests:
+                for row in compiled_by_test[test.name]:
+                    writers[row.part.name].append([
+                        None if f is None else _render_field(f, offset, id_base)
+                        for f in row.fields
+                    ])
+            if on_progress:
+                on_progress(copy_index - start + 1)
+    finally:
+        for writer in writers.values():
+            writer.close()
+    return {name: w.max_len for name, w in writers.items()}
+
+
+def _shard_worker(args) -> tuple[int, dict[str, list[int]]]:
+    suite, out_dir, shard, start, count, base_shift, identity_base = args
+    max_lens = write_shard(
+        suite, Path(out_dir), shard, start, count,
+        base_shift=base_shift, identity_base=identity_base,
+    )
+    return shard, max_lens
+
+
+# ---------------------------------------------------------------------------
+# Load scripts
+
+
+_INDEX_FILTER = "i.type_desc = 'NONCLUSTERED' AND i.is_unique = 0 AND i.is_primary_key = 0"
+
+
+def _index_batch(tables: list[str], action: str) -> list[str]:
+    table_list = ", ".join(f"'{t}'" for t in tables)
+    return [
+        "DECLARE @sql nvarchar(max) = N'';",
+        f"SELECT @sql += N'ALTER INDEX ' + QUOTENAME(i.name) + N' ON dbo.'",
+        f"    + QUOTENAME(t.name) + N' {action};' + CHAR(10)",
+        "FROM sys.indexes i JOIN sys.tables t ON t.object_id = i.object_id",
+        f"WHERE t.name IN ({table_list}) AND {_INDEX_FILTER};",
+        "EXEC sp_executesql @sql;",
+    ]
+
+
+def _sql_type(max_len: int) -> str:
+    # OPENROWSET's inferred VARCHAR(8000) truncates wide values (EDX XML
+    # payloads), so every load states an explicit schema sized from the
+    # actual data; MAX only where needed (LOB handling costs on small cols).
+    return "NVARCHAR(MAX)" if max_len > 4000 else "NVARCHAR(4000)"
+
+
+def _part_batch(part: TablePart, shard: int, max_lens: list[int]) -> list[str]:
+    """One GO-terminated batch loading one part, with deadlock retry.
+
+    Parallel shards inserting into the same tables deadlock under lock
+    escalation; error 1205 is retryable by definition, so retry it a few
+    times and re-raise anything else.
+    """
+    table = part.table.name
+    columns = ", ".join(f"[{c}]" for c in part.columns)
+    with_schema = ", ".join(
+        f"[{c}] {_sql_type(m)}" for c, m in zip(part.columns, max_lens)
+    )
+    insert = (
+        f"INSERT INTO [dbo].[{table}] ({columns}) "
+        f"SELECT {columns} "
+        f"FROM OPENROWSET(BULK N'$(DataDir)/{_shard_file(part, shard)}', "
+        f"FORMAT = 'PARQUET') WITH ({with_schema}) AS r;"
+    )
+    # Explicit values for an identity column need IDENTITY_INSERT (the
+    # OPENROWSET path has no KEEPIDENTITY option). Guarded so a target where
+    # the column is not actually IDENTITY still loads.
+    guard = f"OBJECTPROPERTY(OBJECT_ID(N'dbo.{table}'), 'TableHasIdentity') = 1"
+    identity_on = f"        IF {guard} SET IDENTITY_INSERT [dbo].[{table}] ON;"
+    identity_off = f"        IF {guard} SET IDENTITY_INSERT [dbo].[{table}] OFF;"
+
+    lines = ["DECLARE @attempt int = 0;", "WHILE 1 = 1", "BEGIN", "    BEGIN TRY"]
+    if part.keep_identity:
+        lines.append(identity_on)
+    lines.append("        " + insert)
+    if part.keep_identity:
+        lines.append(identity_off)
+    lines += ["        BREAK;", "    END TRY", "    BEGIN CATCH"]
+    if part.keep_identity:
+        lines.append(identity_off)
+    lines += [
+        "        IF ERROR_NUMBER() <> 1205 OR @attempt >= 5 THROW;",
+        "        SET @attempt += 1;",
+        "        WAITFOR DELAY '00:00:02';",
+        "    END CATCH",
+        "END",
+        "GO",
+    ]
+    return lines
+
+
+def _shard_sql_lines(
+    parts: list[TablePart],
+    shard: int,
+    total_shards: int,
+    database: str,
+    col_max: dict[str, list[int]],
+) -> list[str]:
+    # Rotate each shard's starting point so concurrent shards work on
+    # different tables instead of all hammering the same one. Order within a
+    # load doesn't matter for integrity: FK checking is disabled by pre.sql
+    # (as bcp's bulk path always implicitly did).
+    rotation = (shard * len(parts)) // max(1, total_shards)
+    ordered = parts[rotation:] + parts[:rotation]
+    lines = [f"USE [{database}];", "GO"]
+    for part in ordered:
+        lines.extend(_part_batch(part, shard, col_max[part.name]))
+    return lines
+
+
+def write_load_scripts(
+    suite: SuiteData,
+    out_dir: Path,
+    copies: int,
+    shards: list[tuple[int, int, int]],
+    base_shift: int,
+    identity_base: int,
+    database: str,
+    manage_indexes: bool,
+    col_max: dict[str, list[int]],
+) -> list[Path]:
+    _, all_parts = build_ordered_parts(suite)
+    tables = []
+    for part in all_parts:
+        if part.table.name not in tables:
+            tables.append(part.table.name)
+    written: list[Path] = []
+
+    pre = [f"USE [{database}];"]
+    pre.append("-- Skip FK/CHECK validation during the load, as bcp's bulk path")
+    pre.append("-- implicitly does (rows reference IDs within their own copy, and")
+    pre.append("-- shards load tables in rotated order for less lock contention).")
+    for table in tables:
+        pre.append(f"ALTER TABLE [dbo].[{table}] NOCHECK CONSTRAINT ALL;")
+    if manage_indexes:
+        pre.append("-- Drop per-row index maintenance during the load.")
+        pre.extend(_index_batch(tables, "DISABLE"))
+    (out_dir / "pre.sql").write_text("\n".join(pre) + "\n")
+    written.append(out_dir / "pre.sql")
+
+    shard_paths = []
+    for shard, _start, _count in shards:
+        path = out_dir / f"shard_{shard:03d}.sql"
+        path.write_text(
+            "\n".join(
+                _shard_sql_lines(all_parts, shard, len(shards), database, col_max)
+            ) + "\n"
+        )
+        shard_paths.append(path)
+        written.append(path)
+
+    post = [f"USE [{database}];"]
+    post.append("-- Re-enable constraints without validating existing rows (they")
+    post.append("-- stay untrusted — the same end-state a bcp/BULK INSERT load has).")
+    for table in tables:
+        post.append(f"ALTER TABLE [dbo].[{table}] WITH NOCHECK CHECK CONSTRAINT ALL;")
+    if manage_indexes:
+        post.extend(_index_batch(tables, "REBUILD"))
+    reseed = _reseed_tables(all_parts)
+    if reseed:
+        post.append("-- Re-align identity seeds after explicit-identity load.")
+        for name in reseed:
+            post.append(f"DBCC CHECKIDENT ('[dbo].[{name}]');")
+    (out_dir / "post.sql").write_text("\n".join(post) + "\n")
+    written.append(out_dir / "post.sql")
+
+    has_fixup = bool(suite.deferred_rows)
+    if has_fixup:
+        written.append(_write_fixup_sql(
+            out_dir, suite, copies, base_shift, identity_base, database
+        ))
+
+    # Sequential all-in-one variant for plain `sqlcmd -i load.sql`.
+    combined = ["-- Sequential load; load.sh runs the shards in parallel instead.",
+                ":setvar DataDir ."]
+    for path in [out_dir / "pre.sql", *shard_paths, out_dir / "post.sql"]:
+        combined.append(f"-- --- {path.name} ---")
+        combined.extend(path.read_text().splitlines())
+    if has_fixup:
+        combined.append("-- Then run fixup.sql (seed-data-dependent INSERTs).")
+    (out_dir / "load.sql").write_text("\n".join(combined) + "\n")
+    written.append(out_dir / "load.sql")
+
+    load_sh = [
+        "#!/bin/sh",
+        "# Parallel OPENROWSET load (SQL Server 2022+). The server must see the",
+        "# .parquet files at DATA_DIR (e.g. a bind mount into the container).",
+        "# Usage: SERVER=host,port DBUSER=sa DBPASSWORD=... DATA_DIR=/staging/bulkdata sh load.sh",
+        "#   LOAD_WORKERS=6 controls parallel shard loaders;",
+        "#   mssql-tools18 users: SQLCMD_OPTS=-C to trust a self-signed certificate.",
+        "set -e",
+        'cd "$(dirname "$0")"',
+        ': "${SERVER:?set SERVER=host,port}" "${DBUSER:?set DBUSER}" "${DBPASSWORD:?set DBPASSWORD}"',
+        ': "${DATA_DIR:?set DATA_DIR=server-visible path to the .parquet files}"',
+        'SQLCMD="${SQLCMD:-sqlcmd}"',
+        'LOAD_WORKERS="${LOAD_WORKERS:-6}"',
+        'run_sqlcmd() { "$SQLCMD" -S "$SERVER" -U "$DBUSER" -P "$DBPASSWORD" $SQLCMD_OPTS '
+        '-b -v DataDir="$DATA_DIR" -i "$1"; }',
+        "run_sqlcmd pre.sql",
+        'ls shard_*.sql | xargs -P "$LOAD_WORKERS" -I{} sh -c \''
+        '"$0" -S "$1" -U "$2" -P "$3" $4 -b -v DataDir="$5" -i "{}"\' '
+        '"$SQLCMD" "$SERVER" "$DBUSER" "$DBPASSWORD" "$SQLCMD_OPTS" "$DATA_DIR"',
+        "run_sqlcmd post.sql",
+    ]
+    if has_fixup:
+        load_sh.append("run_sqlcmd fixup.sql")
+    load_sh.append('echo "bulk load complete"')
+    (out_dir / "load.sh").write_text("\n".join(load_sh) + "\n")
+    written.append(out_dir / "load.sh")
+    return written
+
+
+def write_bulk_parquet(
+    suite: SuiteData,
+    out_dir: Path,
+    copies: int,
+    base_shift: int = 0,
+    identity_base: int = 500_000_000,
+    database: str = "NBS_ODSE",
+    workers: int = 1,
+    manage_indexes: bool = False,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list[Path]:
+    """Write sharded Parquet plus the load scripts; returns written paths.
+
+    ``on_progress`` receives (shards_done, total_shards).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shards = _shard_ranges(copies, workers)
+    col_max: dict[str, list[int]] = {}
+
+    def merge(shard_max: dict[str, list[int]]) -> None:
+        for name, lens in shard_max.items():
+            current = col_max.setdefault(name, [0] * len(lens))
+            col_max[name] = [max(a, b) for a, b in zip(current, lens)]
+
+    if len(shards) == 1:
+        merge(write_shard(suite, out_dir, 0, 0, copies,
+                          base_shift=base_shift, identity_base=identity_base))
+        if on_progress:
+            on_progress(1, 1)
+    else:
+        specs = [
+            (suite, str(out_dir), shard, start, count, base_shift, identity_base)
+            for shard, start, count in shards
+        ]
+        done = 0
+        with mp.Pool(len(shards)) as pool:
+            for _shard, shard_max in pool.imap_unordered(_shard_worker, specs):
+                merge(shard_max)
+                done += 1
+                if on_progress:
+                    on_progress(done, len(shards))
+
+    _, all_parts = build_ordered_parts(suite)
+    written = [
+        out_dir / _shard_file(part, shard)
+        for part in all_parts
+        for shard, _s, _c in shards
+    ]
+    written.extend(write_load_scripts(
+        suite, out_dir, copies, shards, base_shift, identity_base,
+        database, manage_indexes, col_max,
+    ))
+    return written

--- a/testing-tools/functional-test/src/functional_test/runner.py
+++ b/testing-tools/functional-test/src/functional_test/runner.py
@@ -225,6 +225,7 @@ def run_step(
     remapper: Optional[IdRemapper] = None,
     on_query: Optional[Callable[["QueryResult"], None]] = None,
     on_poll: Optional[Callable[[int, str, Any, int, Any, bool], None]] = None,
+    skip_query: bool = False,
 ) -> StepResult:
     result = StepResult(name=step_dir.name)
 
@@ -232,27 +233,35 @@ def run_step(
     query_path = step_dir / QUERY_FILE
     expected_path = step_dir / EXPECTED_FILE
 
-    for path in (setup_path, query_path, expected_path):
+    # With skip_query only the setup matters: the step just seeds data, so the
+    # query/expected files are neither required nor read.
+    required = (setup_path,) if skip_query else (setup_path, query_path, expected_path)
+    for path in required:
         if not path.is_file():
             result.setup_error = f"Missing required file: {path.name}"
             return result
 
     setup_sql = setup_path.read_text()
-    query_text = query_path.read_text()
-    expected_text = expected_path.read_text()
     if remapper is not None:
         setup_sql = remapper.apply(setup_sql)
-        query_text = remapper.apply(query_text)
-        expected_text = remapper.apply(expected_text)
-
-    queries = split_statements(query_text)
-    expected_map = json.loads(expected_text)
 
     try:
         db.execute_setup(setup_sql)
     except Exception as exc:  # noqa: BLE001 - surface any DB error to the report
         result.setup_error = f"{type(exc).__name__}: {exc}"
         return result
+
+    if skip_query:
+        return result
+
+    query_text = query_path.read_text()
+    expected_text = expected_path.read_text()
+    if remapper is not None:
+        query_text = remapper.apply(query_text)
+        expected_text = remapper.apply(expected_text)
+
+    queries = split_statements(query_text)
+    expected_map = json.loads(expected_text)
 
     for i, query in enumerate(queries):
         if on_event:
@@ -322,6 +331,7 @@ def run_test(
     on_query: Optional[Callable[["QueryResult"], None]] = None,
     on_poll: Optional[Callable[[int, str, Any, int, Any, bool], None]] = None,
     on_step_complete: Optional[Callable[["StepResult"], None]] = None,
+    skip_query: bool = False,
 ) -> TestResult:
     result = TestResult(name=test_dir.name)
     try:
@@ -354,7 +364,8 @@ def run_test(
         if on_event:
             on_event(f"    step {step_dir.name}")
         step_result = run_step(
-            db, step_dir, max_retry, retry_delay, on_event, remapper, on_query, on_poll
+            db, step_dir, max_retry, retry_delay, on_event, remapper, on_query, on_poll,
+            skip_query=skip_query,
         )
         result.steps.append(step_result)
         # Give callers a chance to pause/inspect after each step (e.g. --pause).

--- a/testing-tools/functional-test/tests/test_bulkgen.py
+++ b/testing-tools/functional-test/tests/test_bulkgen.py
@@ -1,0 +1,236 @@
+"""Tests for bulk-load file generation (--bulk): planning, evaluation, output."""
+
+import pytest
+
+from functional_test.bulk import build_bulk_plan
+from functional_test.bulkgen import (
+    BulkGenError,
+    build_ordered_parts,
+    evaluate_suite,
+    split_sql,
+)
+
+ALPHA_SETUP = """USE [NBS_ODSE];
+DECLARE @patient_uid bigint = 1000001000;
+DECLARE @local_id nvarchar(40) = N'PSN' + CONVERT(nvarchar(20), ABS(CONVERT(bigint, @patient_uid))) + N'GA01';
+DECLARE @answer_out TABLE ([value] bigint);
+INSERT INTO [dbo].[Person] ([person_uid], [local_id], [version_ctrl_nbr], [status_cd], [add_time])
+VALUES (@patient_uid, @local_id, 1, N'A', N'2026-05-06T22:11:00.673');
+INSERT INTO [dbo].[Answer] ([act_uid], [txt]) OUTPUT INSERTED.[answer_uid] INTO @answer_out
+VALUES (@patient_uid, N'semi;colon ''quoted''');
+DECLARE @answer_uid bigint;
+SELECT TOP 1 @answer_uid = [value] FROM @answer_out;
+INSERT INTO [dbo].[AnswerHist] ([answer_uid], [note]) VALUES (@answer_uid, N'h');
+UPDATE [dbo].[Person] SET [version_ctrl_nbr] = ISNULL([version_ctrl_nbr], 0) + 1,
+    [status_cd] = N'I' WHERE [person_uid] = @patient_uid;
+INSERT INTO [dbo].[Tmp] ([a], [b]) VALUES (1, N'x'), (2, N'y');
+DELETE FROM [dbo].[Tmp] WHERE [a] = 1;
+INSERT INTO [dbo].[Link] ([person_uid], [grp]) VALUES (@patient_uid,
+    (SELECT TOP(1) [g] FROM [dbo].[SeedTable] WHERE [name]='|' ORDER BY [v] DESC));
+UPDATE [dbo].[Person] SET [note] = N'z' WHERE [person_uid] =
+    (SELECT TOP 1 [person_uid] FROM [dbo].[Person] WHERE [status_cd] = N'NOPE');
+"""
+
+BETA_SETUP = """USE [NBS_ODSE];
+DECLARE @a bigint = 1000002000;
+DECLARE @b bigint = 1000002049;
+INSERT INTO [dbo].[Person] ([person_uid], [local_id], [version_ctrl_nbr], [status_cd], [add_time])
+VALUES (@a, N'PSN1000002000GA01', 1, N'A', N'2026-05-06T22:11:00.673');
+INSERT INTO [dbo].[Act] ([act_uid]) VALUES (@b);
+"""
+
+
+def _make_suite(tmp_path):
+    for name, sql in [("alpha", ALPHA_SETUP), ("beta", BETA_SETUP)]:
+        step = tmp_path / name / "010-step"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(sql)
+    return [tmp_path / "alpha", tmp_path / "beta"]
+
+
+class TestSplitSql:
+    def test_semicolon_inside_string_not_split(self):
+        assert split_sql("INSERT INTO t VALUES (N'a;b'); SELECT 1") == [
+            "INSERT INTO t VALUES (N'a;b')",
+            "SELECT 1",
+        ]
+
+    def test_comments_stripped_outside_strings_only(self):
+        statements = split_sql("-- top comment\nSELECT 1; INSERT (N'x--y')")
+        assert statements == ["SELECT 1", "INSERT (N'x--y')"]
+
+    def test_escaped_quote(self):
+        assert split_sql("SELECT N'it''s;fine'; SELECT 2") == [
+            "SELECT N'it''s;fine'",
+            "SELECT 2",
+        ]
+
+
+class TestBulkPlan:
+    def test_stride_slots_span(self, tmp_path):
+        plan = build_bulk_plan(_make_suite(tmp_path))
+        assert plan.stride == 50  # beta spans ids ..000-..049
+        assert plan.slots == 20
+        assert plan.span == 2000  # blocks 1000001000 and 1000002000
+
+    def test_offset_pattern_tiles_then_jumps(self, tmp_path):
+        plan = build_bulk_plan(_make_suite(tmp_path))
+        offsets = [plan.offset_for(i) for i in (0, 1, 19, 20, 21)]
+        assert offsets == [0, 50, 950, 2000, 2050]
+        assert plan.offset_for(0, base=100000) == 100000
+
+    def test_copies_never_overlap(self, tmp_path):
+        plan = build_bulk_plan(_make_suite(tmp_path))
+        used = set()
+        for i in range(60):
+            offset = plan.offset_for(i)
+            for test in plan.tests:
+                span = range(
+                    test.block_start + offset,
+                    test.block_start + offset + test.block_width,
+                )
+                assert not used.intersection(span), f"copy {i} collides"
+                used.update(span)
+
+    def test_shared_block_rejected(self, tmp_path):
+        dirs = _make_suite(tmp_path)
+        clone = tmp_path / "alpha2" / "010-step"
+        clone.mkdir(parents=True)
+        (clone / "setup.sql").write_text("DECLARE @x bigint = 1000001005;\n")
+        with pytest.raises(ValueError, match="overlapping UID blocks"):
+            build_bulk_plan(dirs + [tmp_path / "alpha2"])
+
+
+class TestEvaluate:
+    def test_final_state(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+
+        person = suite.tables["person"]
+        alpha_person = person.rows[0]
+        # local_id computed from the concat expression.
+        assert "".join(alpha_person["local_id"]) == "PSN1000001000GA01"
+        # UPDATE applied: version bumped against the pre-update row, status set.
+        assert "".join(alpha_person["version_ctrl_nbr"]) == "2"
+        assert "".join(alpha_person["status_cd"]) == "I"
+        # The subquery-miss UPDATE was skipped: no 'note' column materialized.
+        assert "note" not in alpha_person
+
+        # Identity capture: Answer's uid synthesized, reused by AnswerHist.
+        answer = suite.tables["answer"]
+        assert answer.identity_col == "answer_uid"
+        assert answer.identity_count == 1
+        hist = suite.tables["answerhist"]
+        assert hist.rows[0]["answer_uid"] == answer.rows[0]["answer_uid"]
+
+        # Multi-row insert + delete leaves only the a=2 row.
+        tmp = suite.tables["tmp"]
+        assert ["".join(r["a"]) for r in tmp.rows] == ["2"]
+
+        # Seed-data subquery insert deferred, subquery-miss update warned.
+        assert len(suite.deferred_rows) == 1
+        assert any("deferred to fixup.sql" in w for w in suite.warnings)
+        assert any("UPDATE Person skipped" in w for w in suite.warnings)
+
+    def test_column_names_case_insensitive(self, tmp_path):
+        # Different tests spell the same column differently; SQL Server is
+        # case-insensitive, so the union must hold one canonical spelling.
+        step = tmp_path / "mixed" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\n"
+            "DECLARE @b bigint = 1000001001;\n"
+            "INSERT INTO [dbo].[Fact] ([case_uid], [ELP_class_cd]) VALUES (@a, N'x');\n"
+            "INSERT INTO [dbo].[Fact] ([case_uid], [elp_class_cd]) VALUES (@b, N'y');\n"
+            "UPDATE [dbo].[Fact] SET [Elp_Class_Cd] = N'z' WHERE [CASE_UID] = @b;\n"
+        )
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "mixed"]))
+        fact = suite.tables["fact"]
+        assert fact.columns == ["case_uid", "ELP_class_cd"]  # first-seen spelling
+        assert ["".join(r["ELP_class_cd"]) for r in fact.rows] == ["x", "z"]
+        assert not suite.warnings
+
+    def test_unsupported_statement_raises(self, tmp_path):
+        step = tmp_path / "bad" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\nMERGE INTO t USING x ON 1=1;"
+        )
+        with pytest.raises(BulkGenError, match="bad/010"):
+            evaluate_suite(build_bulk_plan([tmp_path / "bad"]))
+
+
+class TestParts:
+    def test_tables_split_per_column_set(self, tmp_path):
+        # Inserts with different column subsets get separate parts: absent
+        # columns would otherwise load as NULL where a real INSERT applies
+        # the column default.
+        step = tmp_path / "split" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\n"
+            "DECLARE @b bigint = 1000001001;\n"
+            "INSERT INTO [dbo].[Fact] ([case_uid], [class_cd]) VALUES (@a, N'x');\n"
+            "INSERT INTO [dbo].[Fact] ([case_uid]) VALUES (@b);\n"
+        )
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "split"]))
+        _, all_parts = build_ordered_parts(suite)
+        assert [p.name for p in all_parts] == ["Fact__1", "Fact__2"]
+        assert all_parts[0].columns == ["case_uid", "class_cd"]
+        assert all_parts[1].columns == ["case_uid"]
+
+    def test_single_column_set_keeps_plain_name(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        _, all_parts = build_ordered_parts(suite)
+        names = [p.name for p in all_parts]
+        assert "Person" in names  # alpha and beta share one column set
+        # FK-safe order: first-insert order across tables.
+        assert names.index("Person") < names.index("Answer")
+        assert names.index("Answer") < names.index("AnswerHist")
+
+    def test_parts_ordered_numerically_not_lexically(self, tmp_path):
+        step = tmp_path / "many" / "010"
+        step.mkdir(parents=True)
+        statements = ["DECLARE @a bigint = 1000001000;"]
+        for i in range(12):
+            statements.append(
+                f"INSERT INTO [dbo].[Fact] ([case_uid], [col{i}]) VALUES (@a, {i});"
+            )
+        (step / "setup.sql").write_text("\n".join(statements) + "\n")
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "many"]))
+        _, all_parts = build_ordered_parts(suite)
+        names = [p.name for p in all_parts]
+        assert names.index("Fact__2") < names.index("Fact__10")
+        assert names.index("Fact__9") < names.index("Fact__10")
+
+    def test_uncaptured_rows_of_identity_table_get_synthesized_ids(self, tmp_path):
+        # A row inserted without OUTPUT capture into an identity table must
+        # still carry a synthesized value: IDENTITY_INSERT advances the seed,
+        # so a server-assigned row would collide with another copy's range.
+        step = tmp_path / "mixid" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\n"
+            "DECLARE @out TABLE ([value] bigint);\n"
+            "INSERT INTO [dbo].[Ans] ([act_uid], [txt]) OUTPUT INSERTED.[ans_uid] "
+            "INTO @out VALUES (@a, N'captured');\n"
+            "INSERT INTO [dbo].[Ans] ([act_uid], [txt]) VALUES (@a, N'plain');\n"
+        )
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "mixid"]))
+        ans = suite.tables["ans"]
+        assert ans.identity_count == 2
+        assert all("ans_uid" in row for row in ans.rows)
+        uids = {row["ans_uid"][0].seq for row in ans.rows}
+        assert uids == {0, 1}
+        # Both rows now share one column set -> a single part, all explicit.
+        _, all_parts = build_ordered_parts(suite)
+        assert [p.name for p in all_parts if p.table.name == "Ans"] == ["Ans"]
+        assert all_parts[0].keep_identity or any(
+            p.keep_identity for p in all_parts
+        )
+
+    def test_identity_part_flag(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        _, all_parts = build_ordered_parts(suite)
+        by_name = {p.name: p for p in all_parts}
+        assert by_name["Answer"].keep_identity is True
+        assert by_name["Person"].keep_identity is False

--- a/testing-tools/functional-test/tests/test_cli.py
+++ b/testing-tools/functional-test/tests/test_cli.py
@@ -149,6 +149,25 @@ class TestParser:
         args = parser.parse_args(["-d", "/data", "--debug"])
         assert args.debug is True
 
+    def test_bulk_flags(self):
+        parser = cli.build_parser()
+        args = parser.parse_args(["-d", "/data"])
+        assert args.bulk is None and args.bulk_out is None
+        assert args.identity_base == 500_000_000
+        args = parser.parse_args(
+            ["-d", "/data", "--bulk", "100", "--bulk-out", "/out", "--identity-base", "7"]
+        )
+        assert args.bulk == 100
+        assert str(args.bulk_out) == "/out"
+        assert args.identity_base == 7
+
+    def test_skip_query_defaults_false(self):
+        parser = cli.build_parser()
+        args = parser.parse_args(["-d", "/data"])
+        assert args.skip_query is False
+        args = parser.parse_args(["-d", "/data", "--skip-query"])
+        assert args.skip_query is True
+
     def test_missing_required_args_exits(self):
         parser = cli.build_parser()
         with pytest.raises(SystemExit):
@@ -241,6 +260,21 @@ class TestMainRun:
         assert database == "NBS_ODSE"
 
 
+class TestSkipQueryFlag:
+    def test_skip_query_passes_despite_mismatched_expected(self, tmp_path, monkeypatch, capsys):
+        # Expected would never match FakeDatabase's result, but with --skip-query
+        # the query is never run, so the test passes on setup alone.
+        _make_test_tree(tmp_path, [{"a": 999}])
+        monkeypatch.setattr(cli, "Database", FakeDatabase)
+        rc = cli.main(
+            ["-S", "h", "-U", "u", "-P", "p", "-d", str(tmp_path),
+             "--retry-delay", "0", "--max-retry", "1", "--skip-query"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "queries skipped" in out
+
+
 class TestDebugFlag:
     def test_failure_without_debug_hides_expected_actual(self, tmp_path, monkeypatch, capsys):
         _make_test_tree(tmp_path, [{"a": 999}])  # expects 999, FakeDatabase returns 1 -> fail
@@ -321,6 +355,84 @@ class TestMainIdFlag:
         assert rc != 2  # not a usage error
         assert {name for name, _ in seen} == {"mytest", "other"}
         assert all(shift == 10000 for _, shift in seen)
+
+
+class TestBulkMode:
+    def _make_bulk_tree(self, root):
+        step = root / "mytest" / "010-step"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "USE [NBS_ODSE];\n"
+            "DECLARE @uid bigint = 1000001000;\n"
+            "INSERT INTO [dbo].[Person] ([person_uid], [nm]) VALUES (@uid, N'x');\n"
+        )
+        (step / "query.sql").write_text("SELECT 1")
+        (step / "expected.json").write_text("{}")
+        return root
+
+    def test_bulk_requires_bulk_out(self, tmp_path, monkeypatch):
+        self._make_bulk_tree(tmp_path)
+        monkeypatch.setattr(cli, "Database", _boom)
+        rc = cli.main(["-d", str(tmp_path), "--bulk", "3"])
+        assert rc == 2
+        rc = cli.main(["-d", str(tmp_path), "--bulk-out", str(tmp_path / "o")])
+        assert rc == 2
+
+    def test_bulk_rejects_start_id(self, tmp_path, monkeypatch):
+        self._make_bulk_tree(tmp_path)
+        monkeypatch.setattr(cli, "Database", _boom)
+        rc = cli.main(["-d", str(tmp_path), "-t", "mytest", "-i", "1000002000",
+                       "--bulk", "3", "--bulk-out", str(tmp_path / "o")])
+        assert rc == 2
+
+    def test_bulk_generates_parquet_by_default(self, tmp_path, monkeypatch, capsys):
+        self._make_bulk_tree(tmp_path)
+        monkeypatch.setattr(cli, "Database", _boom)  # must never connect
+        out = tmp_path / "out"
+        rc = cli.main(["-d", str(tmp_path), "--bulk", "2", "--bulk-out", str(out),
+                       "--bulk-workers", "1"])
+        assert rc == 0
+        assert (out / "Person__s000.parquet").exists()
+        for script in ("pre.sql", "shard_000.sql", "post.sql", "load.sql", "load.sh"):
+            assert (out / script).exists()
+        import pyarrow.parquet as pq
+        uids = pq.read_table(out / "Person__s000.parquet").to_pydict()["person_uid"]
+        assert uids == ["1000001000", "1000001001"]  # copy 2 shifted by width 1
+        assert "2 rows" in capsys.readouterr().out
+
+    def test_bulk_manage_indexes_flag(self, tmp_path, monkeypatch):
+        self._make_bulk_tree(tmp_path)
+        monkeypatch.setattr(cli, "Database", _boom)
+        out = tmp_path / "out"
+        rc = cli.main(["-d", str(tmp_path), "--bulk", "1", "--bulk-out", str(out),
+                       "--bulk-workers", "1", "--manage-indexes"])
+        assert rc == 0
+        assert "DISABLE" in (out / "pre.sql").read_text()
+        assert "REBUILD" in (out / "post.sql").read_text()
+
+    def test_bulk_duplicate_warnings_collapsed(self, tmp_path, monkeypatch, capsys):
+        step = tmp_path / "mytest" / "010-step"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @uid bigint = 1000001000;\n"
+            "INSERT INTO [dbo].[Person] ([person_uid]) VALUES (@uid);\n"
+            # Two identical no-match updates (seed rows) -> one collapsed line.
+            "UPDATE [dbo].[Person] SET [nm] = N'x' WHERE [person_uid] = 1;\n"
+            "UPDATE [dbo].[Person] SET [nm] = N'x' WHERE [person_uid] = 1;\n"
+        )
+        monkeypatch.setattr(cli, "Database", _boom)
+        rc = cli.main(["-d", str(tmp_path), "--bulk", "1", "--bulk-out", str(tmp_path / "o")])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "2x mytest: UPDATE Person matched no rows" in out
+        assert out.count("UPDATE Person matched no rows") == 1
+
+    def test_bulk_eval_error_returns_2(self, tmp_path, monkeypatch, capsys):
+        # No DECLARE'd block ids -> planning fails cleanly.
+        _make_test_tree(tmp_path, [{"a": 1}])
+        monkeypatch.setattr(cli, "Database", _boom)
+        rc = cli.main(["-d", str(tmp_path), "--bulk", "2", "--bulk-out", str(tmp_path / "o")])
+        assert rc == 2
 
 
 def _boom(*args, **kwargs):

--- a/testing-tools/functional-test/tests/test_parquet_out.py
+++ b/testing-tools/functional-test/tests/test_parquet_out.py
@@ -1,0 +1,164 @@
+"""Tests for the Parquet + OPENROWSET bulk output (--bulk-format parquet)."""
+
+import pyarrow.parquet as pq
+
+from functional_test.bulk import build_bulk_plan
+from functional_test.bulkgen import evaluate_suite
+from functional_test.parquet_out import (
+    _shard_ranges,
+    write_bulk_parquet,
+)
+
+from test_bulkgen import _make_suite
+
+
+def _read(out, name):
+    return pq.read_table(out / name).to_pydict()
+
+
+class TestShardRanges:
+    def test_even_split(self):
+        assert _shard_ranges(6, 3) == [(0, 0, 2), (1, 2, 2), (2, 4, 2)]
+
+    def test_remainder_spread_over_first_shards(self):
+        assert _shard_ranges(7, 3) == [(0, 0, 3), (1, 3, 2), (2, 5, 2)]
+
+    def test_more_workers_than_copies(self):
+        assert _shard_ranges(2, 8) == [(0, 0, 1), (1, 1, 1)]
+
+
+class TestParquetValues:
+    def test_values_shifted_and_raw(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        out = tmp_path / "out"
+        write_bulk_parquet(suite, out, copies=3, identity_base=900)
+
+        person = _read(out, "Person__s000.parquet")
+        # alpha + beta per copy, 3 copies; block IDs shifted per copy.
+        assert person["person_uid"] == [
+            "1000001000", "1000002000",
+            "1000001050", "1000002050",
+            "1000001100", "1000002100",
+        ]
+        # No .dat workarounds: the ISO 'T' timestamp survives as-is.
+        assert person["add_time"][0] == "2026-05-06T22:11:00.673"
+        # Embedded ID in the computed local_id shifted.
+        assert person["local_id"][2] == "PSN1000001050GA01"
+
+        answer = _read(out, "Answer__s000.parquet")
+        assert answer["answer_uid"] == ["900", "901", "902"]
+        hist = _read(out, "AnswerHist__s000.parquet")
+        assert hist["answer_uid"] == ["900", "901", "902"]
+
+    def test_empty_string_and_null_distinct(self, tmp_path):
+        step = tmp_path / "vals" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\n"
+            "INSERT INTO [dbo].[Fact] ([case_uid], [empty_col], [null_col]) "
+            "VALUES (@a, N'', NULL);\n"
+        )
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "vals"]))
+        out = tmp_path / "out"
+        write_bulk_parquet(suite, out, copies=1)
+        fact = _read(out, "Fact__s000.parquet")
+        assert fact["empty_col"] == [""]  # real empty string, no CHAR(1) sentinel
+        assert fact["null_col"] == [None]  # real NULL
+
+    def test_sharded_output_matches_single_shard(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        single = tmp_path / "single"
+        sharded = tmp_path / "sharded"
+        write_bulk_parquet(suite, single, copies=5, workers=1)
+        write_bulk_parquet(suite, sharded, copies=5, workers=2)
+
+        one = _read(single, "Person__s000.parquet")
+        merged = _read(sharded, "Person__s000.parquet")
+        second = _read(sharded, "Person__s001.parquet")
+        for col in one:
+            merged_col = merged[col] + second[col]
+            assert merged_col == one[col], f"column {col} differs"
+
+
+class TestLoadScripts:
+    def test_scripts(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        out = tmp_path / "out"
+        write_bulk_parquet(suite, out, copies=4, workers=2, manage_indexes=True)
+
+        shard0 = (out / "shard_000.sql").read_text()
+        assert ("FROM OPENROWSET(BULK N'$(DataDir)/Person__s000.parquet', "
+                "FORMAT = 'PARQUET')") in shard0
+        assert "INSERT INTO [dbo].[Person] (" in shard0
+        # Identity table wrapped in guarded IDENTITY_INSERT; Person is not.
+        assert "SET IDENTITY_INSERT [dbo].[Answer] ON;" in shard0
+        assert "TableHasIdentity" in shard0
+        assert "SET IDENTITY_INSERT [dbo].[Person] ON;" not in shard0
+        # FK-safe order preserved.
+        assert shard0.index("Person__s000") < shard0.index("Answer__s000")
+        assert shard0.index("Answer__s000") < shard0.index("AnswerHist__s000")
+
+        # Deadlock retry wrapper around every insert.
+        assert "IF ERROR_NUMBER() <> 1205 OR @attempt >= 5 THROW;" in shard0
+
+        shard1 = (out / "shard_001.sql").read_text()
+        assert "Person__s001.parquet" in shard1
+        # Rotated start: shard 1 begins on a different table than shard 0.
+        import re
+        first0 = re.search(r"(\w+)__s000\.parquet", shard0).group(1)
+        first1 = re.search(r"(\w+)__s001\.parquet", shard1).group(1)
+        assert first0 != first1
+
+        pre = (out / "pre.sql").read_text()
+        assert "NOCHECK CONSTRAINT ALL" in pre  # FK checks off, like bcp
+        assert "DISABLE" in pre and "NONCLUSTERED" in pre
+        post = (out / "post.sql").read_text()
+        assert "WITH NOCHECK CHECK CONSTRAINT ALL" in post
+        assert "REBUILD" in post
+        assert "DBCC CHECKIDENT ('[dbo].[Answer]');" in post
+
+        load_sh = (out / "load.sh").read_text()
+        assert "xargs -P" in load_sh
+        assert "DATA_DIR" in load_sh
+        assert "run_sqlcmd pre.sql" in load_sh
+        assert "run_sqlcmd fixup.sql" in load_sh  # mini suite has a deferred row
+
+        load_sql = (out / "load.sql").read_text()
+        assert "Person__s000.parquet" in load_sql and "Person__s001.parquet" in load_sql
+
+        # fixup.sql stays set-based: one statement for all copies.
+        fixup = (out / "fixup.sql").read_text()
+        assert fixup.count("INSERT INTO [dbo].[Link]") == 1
+        assert "TOP (4)" in fixup
+        assert "(1000001000 + (n.i / 20) * 2000 + (n.i % 20) * 50)" in fixup
+        assert "SELECT TOP(1) [g] FROM [dbo].[SeedTable]" in fixup
+
+        # No bcp-era artifacts.
+        assert not (out / "views.sql").exists()
+        assert not list(out.glob("*.dat"))
+
+    def test_with_schema_sized_from_data(self, tmp_path):
+        # OPENROWSET's inferred VARCHAR(8000) truncates wide values, so each
+        # statement declares an explicit schema; MAX only for wide columns.
+        payload = "x" * 5000
+        step = tmp_path / "wide" / "010"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(
+            "DECLARE @a bigint = 1000001000;\n"
+            f"INSERT INTO [dbo].[Doc] ([doc_uid], [payload], [cd]) "
+            f"VALUES (@a, N'{payload}', N'11648804');\n"
+        )
+        suite = evaluate_suite(build_bulk_plan([tmp_path / "wide"]))
+        out = tmp_path / "out"
+        write_bulk_parquet(suite, out, copies=2, workers=2)
+        for shard_sql in ("shard_000.sql", "shard_001.sql"):
+            text = (out / shard_sql).read_text()
+            assert "WITH ([doc_uid] NVARCHAR(4000), [payload] NVARCHAR(MAX), " \
+                   "[cd] NVARCHAR(4000)) AS r;" in text
+
+    def test_no_index_sections_by_default(self, tmp_path):
+        suite = evaluate_suite(build_bulk_plan(_make_suite(tmp_path)))
+        out = tmp_path / "out"
+        write_bulk_parquet(suite, out, copies=1)
+        assert "DISABLE" not in (out / "pre.sql").read_text()
+        assert "REBUILD" not in (out / "post.sql").read_text()

--- a/testing-tools/functional-test/tests/test_runner.py
+++ b/testing-tools/functional-test/tests/test_runner.py
@@ -235,6 +235,37 @@ class TestRunStep:
         assert len(result.queries) == 1  # query 1 was never attempted
         assert db.select_calls == ["SELECT a"]
 
+    def test_skip_query_runs_setup_only(self, tmp_path):
+        step = _make_step(
+            tmp_path / "010-step",
+            setup="INSERT 1",
+            query="SELECT a",
+            expected={"0": [{"a": 1}]},
+        )
+        db = FakeDB()  # select() would return no rows -> query would fail
+        result = run_step(db, step, max_retry=1, retry_delay=0, skip_query=True)
+        assert result.passed is True
+        assert db.setup_calls == ["INSERT 1"]
+        assert db.select_calls == []
+        assert result.queries == []
+
+    def test_skip_query_does_not_require_query_files(self, tmp_path):
+        step = tmp_path / "010-step"
+        step.mkdir()
+        (step / "setup.sql").write_text("INSERT 1")
+        # no query.sql / expected.json
+        db = FakeDB()
+        result = run_step(db, step, max_retry=1, retry_delay=0, skip_query=True)
+        assert result.passed is True
+        assert db.setup_calls == ["INSERT 1"]
+
+    def test_skip_query_still_reports_setup_error(self, tmp_path):
+        step = _make_step(tmp_path / "010-step", expected={"0": [{"a": 1}]})
+        db = FakeDB(setup_error=RuntimeError("duplicate key"))
+        result = run_step(db, step, max_retry=1, retry_delay=0, skip_query=True)
+        assert result.passed is False
+        assert "duplicate key" in result.setup_error
+
     def test_select_exception_recorded(self, tmp_path):
         step = _make_step(tmp_path / "010-step", query="SELECT a", expected={"0": [{"a": 1}]})
 
@@ -414,6 +445,30 @@ class TestRunTest:
         result = run_test(db, test_dir, max_retry=1, retry_delay=0)
         assert result.passed is False
         assert [s.name for s in result.steps] == ["010-a"]  # 020-b never ran
+
+    def test_skip_query_runs_all_steps_without_selects(self, tmp_path):
+        test_dir = tmp_path / "mytest"
+        _make_step(test_dir / "010-a", query="SELECT a", expected={"0": [{"a": 1}]})
+        _make_step(test_dir / "020-b", query="SELECT b", expected={"0": [{"b": 2}]})
+        db = FakeDB()  # no query results needed
+        result = run_test(db, test_dir, max_retry=1, retry_delay=0, skip_query=True)
+        assert result.passed is True
+        assert [s.name for s in result.steps] == ["010-a", "020-b"]
+        assert len(db.setup_calls) == 2
+        assert db.select_calls == []
+
+    def test_skip_query_still_applies_remapper_to_setup(self, tmp_path):
+        test_dir = tmp_path / "interview"
+        step = test_dir / "010-step"
+        step.mkdir(parents=True)
+        (step / "setup.sql").write_text(SETUP_WITH_IDS)
+        db = FakeDB()
+        result = run_test(
+            db, test_dir, max_retry=1, retry_delay=0, new_start_id=1000014000, skip_query=True
+        )
+        assert result.passed is True
+        assert "1000014000" in db.setup_calls[0]
+        assert "1000004000" not in db.setup_calls[0]
 
     def test_no_steps_is_error(self, tmp_path):
         test_dir = tmp_path / "empty"

--- a/testing-tools/functional-test/uv.lock
+++ b/testing-tools/functional-test/uv.lock
@@ -28,6 +28,7 @@ name = "functional-test"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pyarrow" },
     { name = "pymssql" },
 ]
 
@@ -37,7 +38,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymssql", specifier = ">=2.3.0" }]
+requires-dist = [
+    { name = "pyarrow", specifier = ">=17.0.0" },
+    { name = "pymssql", specifier = ">=2.3.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.1.1" }]
@@ -67,6 +71,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/2a/eaa70e6d6ed430c2e90c0599e2831a41a50251879e44788ccdbc73115af1/pyarrow-25.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ce0ca222802087b9a8cb031a6468442cb6b67c290a45a601cac64753d34954d3", size = 35945551, upload-time = "2026-07-10T08:25:23.153Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e0/917086af6b246143012cdc8a7c886b018b53204f3d69fc5f9be5857a8b80/pyarrow-25.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:7d6da02ffc7a3a9bda3b7ded4cc2a27ff73969ab37153f3afd46bbbc1ba4f0f7", size = 37636698, upload-time = "2026-07-10T08:25:28.031Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6a/c87829f92503f84993721791c942f3d9aa81044de51a8cfb1da5810e5345/pyarrow-25.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dbf9fa5d4bde73b1cc16377dcaaa010f971e6fa7f5083f5d44f34b50bc1d74af", size = 46858364, upload-time = "2026-07-10T08:25:34.527Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ba/2030d454c2747e26cce23e4a0338067ee0830a155b7894da04caa96783a5/pyarrow-25.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b72d943ff4e10fec8d48aedb23322d8f6ea8bc2d698b81db37e73730f69e4862", size = 50056398, upload-time = "2026-07-10T08:25:40.785Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ce/ba7a5ce7bf0cfc372ec48203a34ece42f73aa2f3231706f61c55e105ecd0/pyarrow-25.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5fb2d837960f1df7f679ff9f1a55065e306347d379e0768cebf14781254d6194", size = 49958146, upload-time = "2026-07-10T08:25:46.98Z" },
+    { url = "https://files.pythonhosted.org/packages/75/eb/c34a29fb7a70dca2f903c7d85a928928ef55af20cd56e99de6b4c0d897bc/pyarrow-25.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:add690feafa0953c443cdba9e9e87f5eaa198f1ea2e43a3b146ea83f202262d0", size = 53096264, upload-time = "2026-07-10T08:25:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f9/35b1f83a0727d84951588e4034aca2feb76dfb45b0725918c0037b0a48f7/pyarrow-25.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:d293e9959b29a24c82d936d04ab2b7fd8b8d334030de2e56a99aba94f008ad7a", size = 27840572, upload-time = "2026-07-10T08:25:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/98/ae2b5acf9876dbeffa6f320776242c52caab062df55c8ac5501ed2679e74/pyarrow-25.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2e3b6544e26e393fe2cd530f523e36c1c8d3c345bbbb60cca3fd866be8322517", size = 35939080, upload-time = "2026-07-10T08:26:04.53Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/3de2a968edbd496c86cb8b932cdbee2d4b08c4a28e9884a15e5c705a646b/pyarrow-25.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:b724d127783b4c19f088fcdfc844cbc318809246a30307bcabd5ed02045e890e", size = 37633420, upload-time = "2026-07-10T08:26:10.354Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/8399243a4ce080426ec37db18d5e29148b7ec960a8a8c7f9059a7bf6ef0a/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:244f98a595f70fa4fd35faa7508c4ae67e14a173397a4b3b49d2b3c360fb0062", size = 46861050, upload-time = "2026-07-10T08:26:16.397Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/72d704b02bc5fc6d06954d76a0208c1e79cad3ab370f6d6a91ffe5078870/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0222f0071d13313962a88d21bf28b80d355ac39d81bfa6ff3fe00eeaf748e4be", size = 50056458, upload-time = "2026-07-10T08:26:23.271Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/3c31a60b6403d63cad2e0f829096f5fc5763a129ead4207a5d4690b96448/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b58726f118c079f9d4ed7e904975d4f15fd69d0741ba511a4e2dcaa4ef16354f", size = 49957793, upload-time = "2026-07-10T08:26:30.232Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/8f8a019061f9863a831915329264372a87ed25eaf9109ce56eb0e84012c5/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38a2c887cb3883e241b70201688db34133b6dfadd04f03c8f9213df53770c18e", size = 53100544, upload-time = "2026-07-10T08:26:36.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e2/738071e95c5ddad7b3dfc12f569ffa992db89d7d7b4a95258fd184191249/pyarrow-25.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:161649d60a7a46c613a19fd795763ea8a88c36ba997dd99d9bc66e6794ee36e8", size = 27848311, upload-time = "2026-07-10T08:26:41.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
This adds two features to the python functional test runner:

1
Option `--skip-query` adds the data in the setup.sql files for the tests without running the functional test RDB_MODERN queries. This is useful for adding some realistic data into the ODSE for testing.
Example:
```
uv run functional-test -d ../../reporting-pipeline-service/src/test/resources/testData/functional -s 1000000 -S '0.0.0.0,3433' -U 'sa' -P 'PASSWORDHERE' --skip-query
```

Or add 10 copies of the functional test data:
```
for k in $(seq 0 9)
do
uv run functional-test -d ../../reporting-pipeline-service/src/test/resources/testData/functional -s $((k * 1000000)) -S '0.0.0.0,3433' -U 'sa' -P 'PASSWORDHERE' --skip-query
done
```

2
Bulk load many many copies of the functional test data (experimental). When you need gigabytes!

Example:
Generate data for 10000 copies of all the functional tests:
```
uv run functional-test \
    -d ../../reporting-pipeline-service/src/test/resources/testData/functional \
    --bulk 10000 --bulk-out out/bulkdata --manage-indexes
```
Add the data to the database:
```
cd out/bulkdata
SERVER=localhost,3433 DBUSER=sa DBPASSWORD='PASSWORDHERE' SQLCMD_OPTS=-C DATA_DIR=/staging/bulkdata sh load.sh
```

## Related Issue
[Jira Ticket](url)

## Additional Notes
Additional notes and context if necessary

## Checklist
- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
 
