### PR TITLE
retry topic routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ When a user or process changes data in the NBS ODSE database, Debezium captures 
       RDBProcs->>RDBTables: MORBIDITY_REPORT_DATAMART
 ```
 
+### Kafka Retry Topic Routing
+
+Spring Kafka republishes failed records to generated retry topics and invokes the original
+listener again. RTR routes those records through the same business path as their main-topic
+records by using the preserved `KafkaHeaders.ORIGINAL_TOPIC` header. The physical received topic
+is retained for diagnostics, while the configured logical main topic is used for entity routing
+and post-processing cache keys.
+
+Main-topic deliveries normally have no original-topic header and route directly by their physical
+topic. Retry deliveries must contain an allowed original topic; unknown or malformed routing is
+rejected rather than acknowledged without processing. Spring preserves the first original topic
+across subsequent retry levels, so repeated retries continue to resolve to the main topic. This
+behavior requires no additional `application.yaml` configuration.
+
 ## Documentation and Related Repositories
 
 - Please refer to the full setup documentation in the [System Admin Guide](https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/7_feature_preview/0_rtr.html)

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -136,6 +136,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:3.3.16'
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'org.testcontainers:testcontainers:2.0.5'
     testImplementation 'org.testcontainers:testcontainers-kafka:2.0.5'

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -68,6 +68,23 @@ tasks.register("test-unit", Test) {
     finalizedBy jacocoTestReport
 }
 
+// Add a listener to capture test summary counts after the suite finishes
+tasks.withType(Test).configureEach {
+    addTestListener(new TestListener() {
+        @Override
+        void afterSuite(TestDescriptor suite, TestResult result) {
+            if (suite.parent == null) {
+                println(
+                        "Tests: ${result.testCount}, " +
+                        "passed: ${result.successfulTestCount}, " +
+                        "failed: ${result.failedTestCount}, " +
+                        "skipped: ${result.skippedTestCount}"
+                )
+            }
+        }
+    })
+}
+
 jacoco {
     toolVersion = "0.8.11"
     reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
@@ -11,11 +11,15 @@ import gov.cdc.nbs.report.pipeline.investigation.util.ProcessInvestigationDataUt
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
 import gov.cdc.nbs.report.pipeline.util.json.CustomJsonGeneratorImpl;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
+import gov.cdc.nbs.report.pipeline.util.kafka.TopicResolution;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.Counter;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -96,6 +100,7 @@ public class InvestigationService {
   private final KafkaTemplate<String, String> kafkaTemplate;
 
   private final ProcessInvestigationDataUtil processDataUtil;
+  private final RetryTopicResolver retryTopicResolver;
   private final ModelMapper modelMapper = new ModelMapper();
   private final CustomJsonGeneratorImpl jsonGenerator = new CustomJsonGeneratorImpl();
 
@@ -114,10 +119,20 @@ public class InvestigationService {
   private Counter msgSuccess;
   private Counter msgFailure;
   private Counter ntfFailure;
+  private Set<String> inputTopics;
 
   @PostConstruct
   void initMetrics() {
     String[] tags = {SERVICE_TAG, SERVICE_NAME};
+    inputTopics =
+        Set.of(
+            investigationTopic,
+            notificationTopic,
+            interviewTopic,
+            contactTopic,
+            vaccinationTopic,
+            treatmentTopic,
+            actRelationshipTopic);
 
     msgProcessed = metrics.counter("inv_msg_processed", tags);
     msgSuccess = metrics.counter("inv_msg_success", tags);
@@ -158,28 +173,41 @@ public class InvestigationService {
       },
       containerFactory = "investigationKafkaListenerContainerFactory")
   public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> rec) {
-    final String topic = rec.topic();
+    TopicResolution topicResolution;
+    try {
+      topicResolution = retryTopicResolver.resolve(rec, inputTopics);
+    } catch (NoSuchElementException exception) {
+      return CompletableFuture.failedFuture(
+          new DataProcessingException(exception.getMessage(), exception));
+    }
+
+    final String physicalTopic = topicResolution.physicalTopic();
+    final String logicalTopic = topicResolution.logicalTopic();
     final String message = rec.value();
     final long batchId = toBatchId.applyAsLong(rec);
 
-    logger.debug(topicDebugLog, "message", message, topic);
-
     return CompletableFuture.runAsync(
         () -> {
-          if (topic.equals(investigationTopic)) {
+          if (logicalTopic.equals(investigationTopic)) {
             processInvestigation(message, batchId);
-          } else if (topic.equals(notificationTopic)) {
+          } else if (logicalTopic.equals(notificationTopic)) {
             processNotification(message);
-          } else if (topic.equals(interviewTopic)) {
+          } else if (logicalTopic.equals(interviewTopic)) {
             processInterview(message, batchId);
-          } else if (topic.equals(contactTopic)) {
+          } else if (logicalTopic.equals(contactTopic)) {
             processContact(message);
-          } else if (topic.equals(vaccinationTopic)) {
+          } else if (logicalTopic.equals(vaccinationTopic)) {
             processVaccination(message, true, "");
-          } else if (topic.equals(treatmentTopic)) {
+          } else if (logicalTopic.equals(treatmentTopic)) {
             processTreatment(message, true, "");
-          } else if (topic.equals(actRelationshipTopic) && message != null) {
-            processActRelationship(message);
+          } else if (logicalTopic.equals(actRelationshipTopic)) {
+            if (message != null) {
+              processActRelationship(message);
+            }
+          } else {
+            throw new DataProcessingException(
+                "Received data from an unknown topic: " + physicalTopic,
+                new NoSuchElementException());
           }
         },
         invExecutor);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
@@ -11,12 +11,15 @@ import gov.cdc.nbs.report.pipeline.observation.transformer.ProcessObservationDat
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
 import gov.cdc.nbs.report.pipeline.util.json.CustomJsonGeneratorImpl;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
+import gov.cdc.nbs.report.pipeline.util.kafka.TopicResolution;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.Counter;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -81,6 +84,7 @@ public class ObservationService {
   private final KafkaTemplate<String, String> kafkaTemplate;
 
   private final ProcessObservationDataUtil processObservationDataUtil;
+  private final RetryTopicResolver retryTopicResolver;
   private final ModelMapper modelMapper = new ModelMapper();
   private final CustomJsonGeneratorImpl jsonGenerator = new CustomJsonGeneratorImpl();
 
@@ -97,10 +101,12 @@ public class ObservationService {
   private Counter msgProcessed;
   private Counter msgSuccess;
   private Counter msgFailure;
+  private Set<String> inputTopics;
 
   @PostConstruct
   void initMetrics() {
     String[] tags = {"service", SERVICE_NAME};
+    inputTopics = Set.of(observationTopic, actRelationshipTopic);
 
     msgProcessed = metrics.counter("obs_msg_processed", tags);
     msgSuccess = metrics.counter("obs_msg_success", tags);
@@ -134,22 +140,32 @@ public class ObservationService {
       },
       containerFactory = "observationKafkaListenerContainerFactory")
   public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> rec) {
+    TopicResolution topicResolution;
+    try {
+      topicResolution = retryTopicResolver.resolve(rec, inputTopics);
+    } catch (NoSuchElementException exception) {
+      return CompletableFuture.failedFuture(
+          new DataProcessingException(exception.getMessage(), exception));
+    }
 
     long batchId = toBatchId.applyAsLong(rec);
-    String topic = rec.topic();
+    String physicalTopic = topicResolution.physicalTopic();
+    String logicalTopic = topicResolution.logicalTopic();
     String message = rec.value();
-    logger.debug(topicDebugLog, message, topic);
+    logger.debug(
+        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
 
-    if (topic.equals(observationTopic)) {
+    if (logicalTopic.equals(observationTopic)) {
       return CompletableFuture.runAsync(
           () -> processObservation(message, batchId, true, ""), obsExecutor);
-    } else if (topic.equals(actRelationshipTopic) && message != null) {
+    } else if (logicalTopic.equals(actRelationshipTopic) && message != null) {
       return CompletableFuture.runAsync(
           () -> processActRelationship(message, batchId), obsExecutor);
     } else {
       return CompletableFuture.failedFuture(
           new DataProcessingException(
-              "Received data from an unknown topic: " + topic, new NoSuchElementException()));
+              "Received data from an unknown topic: " + physicalTopic,
+              new NoSuchElementException()));
     }
   }
 

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
@@ -152,8 +152,6 @@ public class ObservationService {
     String physicalTopic = topicResolution.physicalTopic();
     String logicalTopic = topicResolution.logicalTopic();
     String message = rec.value();
-    logger.debug(
-        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
 
     if (logicalTopic.equals(observationTopic)) {
       return CompletableFuture.runAsync(

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
@@ -12,6 +12,8 @@ import gov.cdc.nbs.report.pipeline.organization.transformer.DataTransformers;
 import gov.cdc.nbs.report.pipeline.organization.transformer.OrganizationType;
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
+import gov.cdc.nbs.report.pipeline.util.kafka.TopicResolution;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.Counter;
 import jakarta.annotation.PostConstruct;
@@ -26,6 +28,7 @@ import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,9 +37,7 @@ import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
-import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Service;
@@ -70,6 +71,8 @@ public class OrganizationService {
 
   @Qualifier("organizationKafkaTemplate")
   private final KafkaTemplate<String, String> kafkaTemplate;
+
+  private final RetryTopicResolver retryTopicResolver;
 
   @Value("${spring.kafka.topics.nbs.organization}")
   private String orgTopic;
@@ -111,10 +114,12 @@ public class OrganizationService {
   private Counter msgProcessed;
   private Counter msgSuccess;
   private Counter msgFailure;
+  private Set<String> inputTopics;
 
   @PostConstruct
   void initMetrics() {
     String[] tags = {"service", SERVICE_NAME};
+    inputTopics = Set.of(orgTopic, placeTopic);
 
     msgProcessed = metrics.counter("org_msg_processed", tags);
     msgSuccess = metrics.counter("org_msg_success", tags);
@@ -146,16 +151,31 @@ public class OrganizationService {
   @KafkaListener(
       topics = {"${spring.kafka.topics.nbs.organization}", "${spring.kafka.topics.nbs.place}"},
       containerFactory = "organizationKafkaListenerContainerFactory")
-  public CompletableFuture<Void> processMessage(
-      String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-    if (topic.equals(orgTopic)) {
-      return CompletableFuture.runAsync(() -> processOrganization(message, topic), orgExecutor);
-    } else if (topic.equals(placeTopic)) {
-      return CompletableFuture.runAsync(() -> processPlace(message, topic), orgExecutor);
+  public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> record) {
+    TopicResolution topicResolution;
+    try {
+      topicResolution = retryTopicResolver.resolve(record, inputTopics);
+    } catch (NoSuchElementException exception) {
+      return CompletableFuture.failedFuture(
+          new DataProcessingException(exception.getMessage(), exception));
+    }
+
+    String physicalTopic = topicResolution.physicalTopic();
+    String logicalTopic = topicResolution.logicalTopic();
+    String message = record.value();
+    log.debug(
+        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
+
+    if (logicalTopic.equals(orgTopic)) {
+      return CompletableFuture.runAsync(
+          () -> processOrganization(message, physicalTopic), orgExecutor);
+    } else if (logicalTopic.equals(placeTopic)) {
+      return CompletableFuture.runAsync(() -> processPlace(message, physicalTopic), orgExecutor);
     } else {
       return CompletableFuture.failedFuture(
           new DataProcessingException(
-              "Received data from an unknown topic: " + topic, new NoSuchElementException()));
+              "Received data from an unknown topic: " + physicalTopic,
+              new NoSuchElementException()));
     }
   }
 

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
@@ -163,8 +163,6 @@ public class OrganizationService {
     String physicalTopic = topicResolution.physicalTopic();
     String logicalTopic = topicResolution.logicalTopic();
     String message = record.value();
-    log.debug(
-        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
 
     if (logicalTopic.equals(orgTopic)) {
       return CompletableFuture.runAsync(

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
@@ -173,8 +173,6 @@ public class PersonService {
     String physicalTopic = topicResolution.physicalTopic();
     String logicalTopic = topicResolution.logicalTopic();
     String message = record.value();
-    log.debug(
-        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
 
     if (logicalTopic.equals(personTopic)) {
       return CompletableFuture.runAsync(() -> processPerson(message, physicalTopic), prsExecutor);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
@@ -16,6 +16,8 @@ import gov.cdc.nbs.report.pipeline.person.transformer.PersonTransformers;
 import gov.cdc.nbs.report.pipeline.person.transformer.PersonType;
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
+import gov.cdc.nbs.report.pipeline.util.kafka.TopicResolution;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.Counter;
 import jakarta.annotation.PostConstruct;
@@ -24,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,6 +34,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,9 +43,7 @@ import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
-import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Service;
@@ -75,6 +77,8 @@ public class PersonService {
 
   @Qualifier("personKafkaTemplate")
   private final KafkaTemplate<String, String> kafkaTemplate;
+
+  private final RetryTopicResolver retryTopicResolver;
 
   @Value("${spring.kafka.topics.nbs.person}")
   private String personTopic;
@@ -120,10 +124,12 @@ public class PersonService {
   private Counter msgProcessed;
   private Counter msgSuccess;
   private Counter msgFailure;
+  private Set<String> inputTopics;
 
   @PostConstruct
   void initMetrics() {
     String[] tags = {"service", SERVICE_NAME};
+    inputTopics = Set.of(personTopic, userTopic);
 
     msgProcessed = metrics.counter("person_msg_processed", tags);
     msgSuccess = metrics.counter("person_msg_success", tags);
@@ -155,16 +161,30 @@ public class PersonService {
   @KafkaListener(
       topics = {"${spring.kafka.topics.nbs.person}", "${spring.kafka.topics.nbs.auth-user}"},
       containerFactory = "personKafkaListenerContainerFactory")
-  public CompletableFuture<Void> processMessage(
-      String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-    if (topic.equals(personTopic)) {
-      return CompletableFuture.runAsync(() -> processPerson(message, topic), prsExecutor);
-    } else if (topic.equals(userTopic)) {
-      return CompletableFuture.runAsync(() -> processUser(message, topic), prsExecutor);
+  public CompletableFuture<Void> processMessage(ConsumerRecord<String, String> record) {
+    TopicResolution topicResolution;
+    try {
+      topicResolution = retryTopicResolver.resolve(record, inputTopics);
+    } catch (NoSuchElementException exception) {
+      return CompletableFuture.failedFuture(
+          new DataProcessingException(exception.getMessage(), exception));
+    }
+
+    String physicalTopic = topicResolution.physicalTopic();
+    String logicalTopic = topicResolution.logicalTopic();
+    String message = record.value();
+    log.debug(
+        "Resolved Kafka topic: physicalTopic={} logicalTopic={}", physicalTopic, logicalTopic);
+
+    if (logicalTopic.equals(personTopic)) {
+      return CompletableFuture.runAsync(() -> processPerson(message, physicalTopic), prsExecutor);
+    } else if (logicalTopic.equals(userTopic)) {
+      return CompletableFuture.runAsync(() -> processUser(message, physicalTopic), prsExecutor);
     } else {
       return CompletableFuture.failedFuture(
           new DataProcessingException(
-              "Received data from an unknown topic: " + topic, new NoSuchElementException()));
+              "Received data from an unknown topic: " + physicalTopic,
+              new NoSuchElementException()));
     }
   }
 

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingService.java
@@ -48,6 +48,8 @@ import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.BackfillData;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.DatamartData;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.dto.Datamart;
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
+import gov.cdc.nbs.report.pipeline.util.kafka.TopicResolution;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -79,6 +81,7 @@ import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -159,6 +162,7 @@ public class PostProcessingService {
   private final InvestigationRepository investigationRepository;
 
   private final ProcessDatamartData dmProcessor;
+  private final RetryTopicResolver retryTopicResolver;
 
   static final String PAYLOAD = "payload";
   static final String SP_EXECUTION_COMPLETED = "Stored proc execution completed: {}";
@@ -181,6 +185,54 @@ public class PostProcessingService {
   @Value("${spring.kafka.topics.nrt.investigation}")
   private String investigationTopic;
 
+  @Value("${spring.kafka.topics.nrt.organization}")
+  private String organizationTopic;
+
+  @Value("${spring.kafka.topics.nrt.patient}")
+  private String patientTopic;
+
+  @Value("${spring.kafka.topics.nrt.provider}")
+  private String providerTopic;
+
+  @Value("${spring.kafka.topics.nrt.investigation-notification}")
+  private String notificationTopic;
+
+  @Value("${spring.kafka.topics.nrt.investigation-case-management}")
+  private String caseManagementTopic;
+
+  @Value("${spring.kafka.topics.nrt.interview}")
+  private String interviewTopic;
+
+  @Value("${spring.kafka.topics.nrt.ldf-data}")
+  private String ldfDataTopic;
+
+  @Value("${spring.kafka.topics.nrt.observation}")
+  private String observationTopic;
+
+  @Value("${spring.kafka.topics.nrt.place}")
+  private String placeTopic;
+
+  @Value("${spring.kafka.topics.nrt.auth-user}")
+  private String authUserTopic;
+
+  @Value("${spring.kafka.topics.nrt.contact}")
+  private String contactTopic;
+
+  @Value("${spring.kafka.topics.nrt.treatment}")
+  private String treatmentTopic;
+
+  @Value("${spring.kafka.topics.nrt.vaccination}")
+  private String vaccinationTopic;
+
+  @Value("${spring.kafka.topics.nrt.odse-state-defined-field-metadata}")
+  private String stateDefinedFieldMetadataTopic;
+
+  @Value("${spring.kafka.topics.nrt.odse-nbs-page}")
+  private String nbsPageTopic;
+
+  @Value("${spring.kafka.topics.nrt.srte-condition-code}")
+  private String conditionCodeTopic;
+
   @Value("${featureFlag.post-processing-enable}")
   private boolean serviceEnable;
 
@@ -190,6 +242,7 @@ public class PostProcessingService {
   private Counter ppDmProcessed;
   private Counter ppMsgSuccess;
   private Counter ppMsgFailure;
+  private Map<String, Entity> nrtTopicEntities;
 
   Timer processTimer;
   private final AtomicInteger msgCacheSizeGauge = new AtomicInteger();
@@ -198,6 +251,25 @@ public class PostProcessingService {
   @PostConstruct
   void initMetrics() {
     String[] tags = {"service", SERVICE_NAME};
+    nrtTopicEntities =
+        Map.ofEntries(
+            Map.entry(investigationTopic, Entity.INVESTIGATION),
+            Map.entry(organizationTopic, Entity.ORGANIZATION),
+            Map.entry(patientTopic, Entity.PATIENT),
+            Map.entry(providerTopic, Entity.PROVIDER),
+            Map.entry(notificationTopic, Entity.NOTIFICATION),
+            Map.entry(caseManagementTopic, Entity.CASE_MANAGEMENT),
+            Map.entry(interviewTopic, Entity.INTERVIEW),
+            Map.entry(ldfDataTopic, Entity.LDF_DATA),
+            Map.entry(observationTopic, Entity.OBSERVATION),
+            Map.entry(placeTopic, Entity.D_PLACE),
+            Map.entry(authUserTopic, Entity.AUTH_USER),
+            Map.entry(contactTopic, Entity.CONTACT),
+            Map.entry(treatmentTopic, Entity.TREATMENT),
+            Map.entry(vaccinationTopic, Entity.VACCINATION),
+            Map.entry(stateDefinedFieldMetadataTopic, Entity.STATE_DEFINED_FIELD_METADATA),
+            Map.entry(nbsPageTopic, Entity.PAGE),
+            Map.entry(conditionCodeTopic, Entity.CONDITION));
 
     ppMsgProcessed = metrics.counter("post_msg_processed", tags);
     ppDmProcessed = metrics.counter("post_dm_processed", tags);
@@ -228,9 +300,7 @@ public class PostProcessingService {
    *   3. Cache the extracted IDs for further processing in idCache and data in idVals.
    * </ul>
    *
-   * @param topic The name of the Kafka topic from which the message was received.
-   * @param key The key of the Kafka message, typically used for partitioning.
-   * @param payload The value of the Kafka message, which contains the payload to be processed.
+   * @param record the consumed Kafka record containing the topic, key, payload, and native headers
    */
   @RetryableTopic(
       attempts = "${spring.kafka.consumer.max-retry}",
@@ -269,35 +339,38 @@ public class PostProcessingService {
         "${spring.kafka.topics.nrt.srte-condition-code}"
       },
       containerFactory = "kafkaListenerContainerFactoryDefault")
-  public void processNrtMessage(
-      @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-      @Header(KafkaHeaders.RECEIVED_KEY) String key,
-      @Payload String payload) {
-
+  public void processNrtMessage(ConsumerRecord<String, String> record) {
     ppMsgProcessed.increment();
     if (!serviceEnable) {
       return; // skip processing when not enabled
     }
-    extractIdFromMessage(topic, key, payload);
+
+    TopicResolution topicResolution = retryTopicResolver.resolve(record, nrtTopicEntities.keySet());
+    String logicalTopic = topicResolution.logicalTopic();
+    Entity entity = nrtTopicEntities.get(logicalTopic);
+    extractIdFromMessage(logicalTopic, record.key(), record.value(), entity);
+  }
+
+  void processNrtMessage(String topic, String key, String payload) {
+    processNrtMessage(new ConsumerRecord<>(topic, 0, 0L, key, payload));
   }
 
   /**
    * Extracts entity UID from the Kafka message and caches it for further processing. If the
    * identifier is numeric, it is also enriched with values from the message payload.
    *
-   * @param topic the Kafka topic from which the message was received (used to determine entity
-   *     type)
+   * @param topic the normalized logical topic used to determine the entity and cache key
    * @param messageKey the Kafka message key in JSON format, containing the entity UID
    * @param payload the Kafka message payload in JSON format, used for enrichment when UID is
    *     numeric
+   * @param entity the entity explicitly mapped from the configured logical topic
    * @throws DataProcessingException if the UID field is missing or cannot be processed
    */
-  private void extractIdFromMessage(String topic, String messageKey, String payload) {
+  private void extractIdFromMessage(
+      String topic, String messageKey, String payload, Entity entity) {
     try {
       logger.info("Got this key payload: {} from the topic: {}", messageKey, topic);
       JsonNode keyNode = objectMapper.readTree(messageKey);
-
-      Entity entity = getEntityByTopic(topic);
       if (Objects.isNull(keyNode.get(PAYLOAD).get(entity.getUidName()))) {
         throw new NoSuchElementException(
             "The '"
@@ -314,7 +387,7 @@ public class PostProcessingService {
       } else {
         Long id = idNode.asLong();
         idCache.computeIfAbsent(topic, k -> new ConcurrentLinkedQueue<>()).add(id);
-        extractValFromMessage(id, topic, payload);
+        extractValFromMessage(id, topic, payload, entity);
       }
 
     } catch (Exception e) {
@@ -327,7 +400,7 @@ public class PostProcessingService {
    * Extracts and categorizes additional values from a Kafka message payload based on the entity
    * type.
    *
-   * <p>Depending on the topic suffix, this method will:
+   * <p>Depending on the explicitly mapped entity, this method will:
    *
    * <ul>
    *   <li><b>Investigation</b>: add the UID to summary/aggregate caches and map it to Page Builder
@@ -341,11 +414,12 @@ public class PostProcessingService {
    * @param uid the numeric identifier extracted from the Kafka message key
    * @param topic the Kafka topic name, used to determine which entity-specific rules to apply
    * @param payload the Kafka message payload in JSON format, used to extract additional values
+   * @param entity the entity explicitly mapped from the configured logical topic
    */
-  private void extractValFromMessage(Long uid, String topic, String payload) {
+  private void extractValFromMessage(Long uid, String topic, String payload, Entity entity) {
     try {
       JsonNode payloadNode = objectMapper.readTree(payload).get(PAYLOAD);
-      if (topic.endsWith(INVESTIGATION.getEntityName())) {
+      if (entity == INVESTIGATION) {
         extractSummaryCase(uid, payloadNode.path("case_type_cd").asText());
 
         JsonNode tblNode = payloadNode.path("rdb_table_name_list");
@@ -355,11 +429,11 @@ public class PostProcessingService {
               .forEach(
                   tbl -> pbCache.computeIfAbsent(tbl, k -> new ConcurrentLinkedQueue<>()).add(uid));
         }
-      } else if (topic.endsWith(NOTIFICATION.getEntityName())) {
+      } else if (entity == NOTIFICATION) {
         String actTypeCd = payloadNode.path("act_type_cd").asText();
         Long phcUid = payloadNode.get(INVESTIGATION.getUidName()).asLong();
         extractSummaryCase(phcUid, actTypeCd);
-      } else if (topic.endsWith(OBSERVATION.getEntityName())) {
+      } else if (entity == OBSERVATION) {
         String domainCd = payloadNode.path("obs_domain_cd_st_1").asText();
         String ctrlCd =
             Optional.ofNullable(payloadNode.get("ctrl_cd_display_form"))
@@ -1407,23 +1481,14 @@ public class PostProcessingService {
   }
 
   /**
-   * Retrieves the entity type (e.g., INVESTIGATION, NOTIFICATION, ORGANIZATION) based on the Kafka
-   * topic name. This mapping is used to determine how to process the message and which stored
-   * procedure to execute.
+   * Retrieves the entity explicitly mapped to a configured logical NRT topic.
    *
-   * @param topic The name of the Kafka topic (e.g., "dummy_investigation", "dummy_notification").
-   * @return The corresponding entity type as an `Entity` enum value.
-   *     <p>Example: If the topic is "dummy_investigation", the method will return
-   *     `Entity.INVESTIGATION`.
-   * @throws IllegalArgumentException If the topic does not map to a known entity type.
+   * @param topic the normalized logical topic used as the cache key
+   * @return the mapped entity, or {@link Entity#UNKNOWN} when the topic is not configured
    */
   @NonNull
   private Entity getEntityByTopic(String topic) {
-    return Arrays.stream(Entity.values())
-        .filter(entity -> entity.getPriority() > 0)
-        .filter(entity -> topic.endsWith(entity.getEntityName()))
-        .findFirst()
-        .orElse(UNKNOWN);
+    return nrtTopicEntities.getOrDefault(topic, UNKNOWN);
   }
 
   private void processTopic(

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
@@ -1,0 +1,78 @@
+package gov.cdc.nbs.report.pipeline.util.kafka;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.stereotype.Component;
+
+/** Resolves a Kafka delivery to one of a listener's configured logical main topics. */
+@Component
+public final class RetryTopicResolver {
+
+  /**
+   * Resolves a consumed record to a configured logical main topic.
+   *
+   * <p>An exact physical-topic match takes precedence. Otherwise, the resolver uses Spring Kafka's
+   * {@link KafkaHeaders#ORIGINAL_TOPIC} header, which is added when a record is forwarded to a
+   * retry topic. The resolved topic must be present in {@code allowedMainTopics}.
+   *
+   * @param record the consumed Kafka record containing the physical topic and native headers
+   * @param allowedMainTopics the configured main topics accepted by the calling listener
+   * @return the physical delivery topic and resolved logical main topic
+   * @throws IllegalArgumentException if the record or allowed-topic set is invalid
+   * @throws NoSuchElementException if neither the physical nor original topic is allowed
+   */
+  public TopicResolution resolve(ConsumerRecord<?, ?> record, Set<String> allowedMainTopics) {
+    if (record == null) {
+      throw new IllegalArgumentException("Consumer record must not be null");
+    }
+    validateMainTopics(allowedMainTopics);
+
+    String physicalTopic = record.topic();
+    if (allowedMainTopics.contains(physicalTopic)) {
+      return new TopicResolution(physicalTopic, physicalTopic);
+    }
+
+    String originalTopic = extractOriginalTopic(record);
+    if (originalTopic != null && allowedMainTopics.contains(originalTopic)) {
+      return new TopicResolution(physicalTopic, originalTopic);
+    }
+
+    throw new NoSuchElementException("Received data from an unknown topic: " + physicalTopic);
+  }
+
+  private static String extractOriginalTopic(ConsumerRecord<?, ?> record) {
+    Header originalTopicHeader = record.headers().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+    if (originalTopicHeader == null || originalTopicHeader.value() == null) {
+      return null;
+    }
+
+    try {
+      String originalTopic =
+          StandardCharsets.UTF_8
+              .newDecoder()
+              .onMalformedInput(CodingErrorAction.REPORT)
+              .onUnmappableCharacter(CodingErrorAction.REPORT)
+              .decode(ByteBuffer.wrap(originalTopicHeader.value()))
+              .toString();
+      return originalTopic.isBlank() ? null : originalTopic;
+    } catch (CharacterCodingException exception) {
+      return null;
+    }
+  }
+
+  private static void validateMainTopics(Set<String> allowedMainTopics) {
+    if (allowedMainTopics == null || allowedMainTopics.isEmpty()) {
+      throw new IllegalArgumentException("Allowed main topics must not be empty");
+    }
+    if (allowedMainTopics.stream().anyMatch(topic -> topic == null || topic.isBlank())) {
+      throw new IllegalArgumentException("Allowed main topic must not be blank");
+    }
+  }
+}

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
@@ -1,8 +1,5 @@
 package gov.cdc.nbs.report.pipeline.util.kafka;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -53,18 +50,9 @@ public final class RetryTopicResolver {
       return null;
     }
 
-    try {
-      String originalTopic =
-          StandardCharsets.UTF_8
-              .newDecoder()
-              .onMalformedInput(CodingErrorAction.REPORT)
-              .onUnmappableCharacter(CodingErrorAction.REPORT)
-              .decode(ByteBuffer.wrap(originalTopicHeader.value()))
-              .toString();
-      return originalTopic.isBlank() ? null : originalTopic;
-    } catch (CharacterCodingException exception) {
-      return null;
-    }
+    // convert bytes[] to string using UTF-8 encoding
+    String originalTopic = new String(originalTopicHeader.value(), StandardCharsets.UTF_8);
+    return originalTopic.isBlank() ? null : originalTopic;
   }
 
   private static void validateMainTopics(Set<String> allowedMainTopics) {

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolver.java
@@ -5,12 +5,15 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.stereotype.Component;
 
 /** Resolves a Kafka delivery to one of a listener's configured logical main topics. */
 @Component
 public final class RetryTopicResolver {
+  private static final Logger logger = LoggerFactory.getLogger(RetryTopicResolver.class);
 
   /**
    * Resolves a consumed record to a configured logical main topic.
@@ -32,16 +35,21 @@ public final class RetryTopicResolver {
     validateMainTopics(allowedMainTopics);
 
     String physicalTopic = record.topic();
-    if (allowedMainTopics.contains(physicalTopic)) {
-      return new TopicResolution(physicalTopic, physicalTopic);
+    String originalTopic = null;
+    if (!allowedMainTopics.contains(physicalTopic)) {
+      originalTopic = extractOriginalTopic(record);
+      if (originalTopic == null || !allowedMainTopics.contains(originalTopic)) {
+        throw new NoSuchElementException("Received data from an unknown topic: " + physicalTopic);
+      }
     }
 
-    String originalTopic = extractOriginalTopic(record);
-    if (originalTopic != null && allowedMainTopics.contains(originalTopic)) {
-      return new TopicResolution(physicalTopic, originalTopic);
-    }
-
-    throw new NoSuchElementException("Received data from an unknown topic: " + physicalTopic);
+    TopicResolution resolution =
+        new TopicResolution(physicalTopic, originalTopic != null ? originalTopic : physicalTopic);
+    logger.debug(
+        "Resolved Kafka topic: physicalTopic={} logicalTopic={}",
+        resolution.physicalTopic(),
+        resolution.logicalTopic());
+    return resolution;
   }
 
   private static String extractOriginalTopic(ConsumerRecord<?, ?> record) {

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/TopicResolution.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/util/kafka/TopicResolution.java
@@ -1,0 +1,28 @@
+package gov.cdc.nbs.report.pipeline.util.kafka;
+
+import java.util.Objects;
+
+/** The physical Kafka delivery topic and its configured logical business topic. */
+public record TopicResolution(String physicalTopic, String logicalTopic) {
+
+  /**
+   * Creates a validated topic resolution.
+   *
+   * @param physicalTopic the Kafka topic from which the record was consumed
+   * @param logicalTopic the configured main topic used for business routing
+   * @throws NullPointerException if either topic is {@code null}
+   */
+  public TopicResolution {
+    Objects.requireNonNull(physicalTopic, "Physical topic must not be null");
+    Objects.requireNonNull(logicalTopic, "Logical topic must not be null");
+  }
+
+  /**
+   * Indicates whether Kafka delivered the record from a retry topic.
+   *
+   * @return {@code true} when the physical delivery topic differs from the logical main topic
+   */
+  public boolean retryDelivery() {
+    return !physicalTopic.equals(logicalTopic);
+  }
+}

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
@@ -17,9 +17,12 @@ import gov.cdc.nbs.report.pipeline.investigation.repository.model.reporting.*;
 import gov.cdc.nbs.report.pipeline.investigation.util.ProcessInvestigationDataUtil;
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.*;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -32,6 +35,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SendResult;
 
 class InvestigationServiceTest {
@@ -95,6 +99,7 @@ class InvestigationServiceTest {
             treatmentRepository,
             kafkaTemplate,
             transformer,
+            new RetryTopicResolver(),
             new CustomMetrics(new SimpleMeterRegistry()));
 
     investigationService.setInvestigationTopic(investigationTopic);
@@ -190,6 +195,138 @@ class InvestigationServiceTest {
   void testProcessMessageException(String topic) {
     String invalidPayload = "{\"payload\": {\"after\": }}";
     checkException(topic, invalidPayload, DataProcessingException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Investigation_retry-0", "Investigation_retry-1"})
+  void testProcessInvestigationRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"public_health_case_uid\": \"1\"}}}";
+    when(investigationRepository.computeInvestigations("1")).thenReturn(Optional.empty());
+    investigationService.setPhcDatamartEnable(false);
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, investigationTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(investigationRepository).computeInvestigations("1");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Notification_retry-0", "Notification_retry-1"})
+  void testProcessNotificationRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"notification_uid\": \"2\"}}}";
+    when(notificationRepository.computeNotifications("2")).thenReturn(Optional.empty());
+    investigationService.setPhcDatamartEnable(false);
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, notificationTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(notificationRepository).computeNotifications("2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Interview_retry-0", "Interview_retry-1"})
+  void testProcessInterviewRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"interview_uid\": \"3\"}}}";
+    when(interviewRepository.computeInterviews("3")).thenReturn(Optional.empty());
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, interviewTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(interviewRepository).computeInterviews("3");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Contact_retry-0", "Contact_retry-1"})
+  void testProcessContactRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"ct_contact_uid\": \"4\"}}}";
+    when(contactRepository.computeContact("4")).thenReturn(Optional.empty());
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, contactTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(contactRepository).computeContact("4");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Vaccination_retry-0", "Vaccination_retry-1"})
+  void testProcessVaccinationRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"intervention_uid\": \"5\"}, \"op\": \"u\"}}";
+    when(vaccinationRepository.computeVaccination("5")).thenReturn(Optional.empty());
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, vaccinationTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(vaccinationRepository).computeVaccination("5");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Treatment_retry-0", "Treatment_retry-1"})
+  void testProcessTreatmentRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"treatment_uid\": \"6\"}, \"op\": \"u\"}}";
+    when(treatmentRepository.computeTreatment("6")).thenReturn(Optional.empty());
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, treatmentTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(treatmentRepository).computeTreatment("6");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Act_relationship_retry-0", "Act_relationship_retry-1"})
+  void testProcessActRelationshipRetryMessage(String retryTopic) {
+    String payload =
+        "{\"payload\": {\"after\": {\"source_act_uid\": \"7\", \"type_cd\": \"1180\"},"
+            + " \"op\": \"c\"}}";
+    when(vaccinationRepository.computeVaccination("7")).thenReturn(Optional.empty());
+
+    CompletableFuture<Void> future =
+        investigationService.processMessage(retryRecord(retryTopic, actRelationshipTopic, payload));
+
+    assertThrows(CompletionException.class, future::join);
+    verify(vaccinationRepository).computeVaccination("7");
+  }
+
+  @Test
+  void testProcessMessageRejectsUnknownTopic() {
+    ConsumerRecord<String, String> record = getRecord("unknownTopic", null);
+
+    CompletableFuture<Void> future = investigationService.processMessage(record);
+
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(
+        investigationRepository,
+        notificationRepository,
+        interviewRepository,
+        contactRepository,
+        vaccinationRepository,
+        treatmentRepository,
+        kafkaTemplate);
+  }
+
+  @Test
+  void testProcessMessageRejectsUnknownOriginalTopic() {
+    ConsumerRecord<String, String> record =
+        retryRecord("Investigation_retry-0", "unknownTopic", null);
+
+    CompletableFuture<Void> future = investigationService.processMessage(record);
+
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(
+        investigationRepository,
+        notificationRepository,
+        interviewRepository,
+        contactRepository,
+        vaccinationRepository,
+        treatmentRepository,
+        kafkaTemplate);
   }
 
   @Test
@@ -776,6 +913,15 @@ class InvestigationServiceTest {
 
   private ConsumerRecord<String, String> getRecord(String topic, String payload) {
     return new ConsumerRecord<>(topic, 0, 11L, null, payload);
+  }
+
+  private ConsumerRecord<String, String> retryRecord(
+      String retryTopic, String originalTopic, String payload) {
+    ConsumerRecord<String, String> record = getRecord(retryTopic, payload);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
   }
 
   private void checkException(

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
@@ -16,8 +16,10 @@ import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.Observation
 import gov.cdc.nbs.report.pipeline.observation.repository.ObservationRepository;
 import gov.cdc.nbs.report.pipeline.observation.transformer.ProcessObservationDataUtil;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,8 +32,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
 
 class ObservationServiceTest {
 
@@ -65,6 +69,7 @@ class ObservationServiceTest {
             observationRepository,
             kafkaTemplate,
             transformer,
+            new RetryTopicResolver(),
             new CustomMetrics(new SimpleMeterRegistry()));
     observationService.setObservationTopic(inputTopicNameObservation);
     observationService.setActRelationshipTopic(inputTopicNameActRelationship);
@@ -98,7 +103,26 @@ class ObservationServiceTest {
     when(kafkaTemplate.send(anyString(), anyString(), isNull()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
-    validateData(payload, observation, inputTopicNameObservation);
+    validateData(getRecord(payload, inputTopicNameObservation), observation);
+
+    verify(observationRepository).computeObservations(String.valueOf(observationUid));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Observation_retry-0", "Observation_retry-1"})
+  void testProcessObservationRetryMessage(String retryTopic) throws JsonProcessingException {
+    Long observationUid = 123456789L;
+    String payload =
+        "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
+    Observation observation = constructObservation(observationUid, "Order");
+    when(observationRepository.computeObservations(String.valueOf(observationUid)))
+        .thenReturn(Optional.of(observation));
+    when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(kafkaTemplate.send(anyString(), anyString(), isNull()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    validateData(getRetryRecord(payload, retryTopic, inputTopicNameObservation), observation);
 
     verify(observationRepository).computeObservations(String.valueOf(observationUid));
   }
@@ -116,18 +140,7 @@ class ObservationServiceTest {
       throws JsonProcessingException {
     Long sourceActUid = 123456789L;
     String obsDomainCdSt = "Order";
-    String payload =
-        "{\"payload\": {\"before\": {\"source_act_uid\": \""
-            + sourceActUid
-            + "\", \"type_cd\": \""
-            + typeCd
-            + "\", \"target_class_cd\": \""
-            + targetClassCd
-            + "\"},"
-            + "\"after\": {\"source_act_uid\": \"123\"},"
-            + "\"op\": \""
-            + op
-            + "\"}}";
+    String payload = actRelationshipPayload(sourceActUid, op, typeCd, targetClassCd);
 
     if (typeCd.equals("OTHER") || !op.equals("d") || targetClassCd.equals("OTHER")) {
       ConsumerRecord<String, String> rec = getRecord(payload, inputTopicNameActRelationship);
@@ -143,10 +156,28 @@ class ObservationServiceTest {
       when(kafkaTemplate.send(anyString(), anyString(), isNull()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
-      validateData(payload, observation, inputTopicNameActRelationship);
+      validateData(getRecord(payload, inputTopicNameActRelationship), observation);
 
       verify(observationRepository).computeObservations(String.valueOf(sourceActUid));
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Act_relationship_retry-0", "Act_relationship_retry-1"})
+  void testProcessActRelationshipRetryMessage(String retryTopic) throws JsonProcessingException {
+    Long sourceActUid = 123456789L;
+    String payload = actRelationshipPayload(sourceActUid, "d", "LabReport", "OBS");
+    Observation observation = constructObservation(sourceActUid, "Order");
+    when(observationRepository.computeObservations(String.valueOf(sourceActUid)))
+        .thenReturn(Optional.of(observation));
+    when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(kafkaTemplate.send(anyString(), anyString(), isNull()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    validateData(getRetryRecord(payload, retryTopic, inputTopicNameActRelationship), observation);
+
+    verify(observationRepository).computeObservations(String.valueOf(sourceActUid));
   }
 
   @Test
@@ -200,9 +231,24 @@ class ObservationServiceTest {
   void testProcessMessageUnknownTopic() {
     ConsumerRecord<String, String> rec = getRecord(null, "dummyTopicName");
 
-    observationService.processMessage(rec);
+    CompletableFuture<Void> future = observationService.processMessage(rec);
 
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(observationRepository);
     verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void testProcessMessageRejectsUnknownOriginalTopic() {
+    ConsumerRecord<String, String> rec =
+        getRetryRecord(null, "Observation_retry-0", "unknownTopic");
+
+    CompletableFuture<Void> future = observationService.processMessage(rec);
+
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(observationRepository);
   }
 
   @ParameterizedTest
@@ -234,9 +280,8 @@ class ObservationServiceTest {
     assertEquals(NoDataException.class, ex.getCause().getClass());
   }
 
-  private void validateData(String payload, Observation observation, String inputTopic)
+  private void validateData(ConsumerRecord<String, String> rec, Observation observation)
       throws JsonProcessingException {
-    ConsumerRecord<String, String> rec = getRecord(payload, inputTopic);
     observationService.processMessage(rec);
 
     ObservationKey observationKey = new ObservationKey();
@@ -343,7 +388,31 @@ class ObservationServiceTest {
     return observation;
   }
 
+  private String actRelationshipPayload(
+      Long sourceActUid, String operation, String typeCd, String targetClassCd) {
+    return "{\"payload\": {\"before\": {\"source_act_uid\": \""
+        + sourceActUid
+        + "\", \"type_cd\": \""
+        + typeCd
+        + "\", \"target_class_cd\": \""
+        + targetClassCd
+        + "\"},"
+        + "\"after\": {\"source_act_uid\": \"123\"},"
+        + "\"op\": \""
+        + operation
+        + "\"}}";
+  }
+
   private ConsumerRecord<String, String> getRecord(String payload, String inputTopic) {
     return new ConsumerRecord<>(inputTopic, 0, 11L, null, payload);
+  }
+
+  private ConsumerRecord<String, String> getRetryRecord(
+      String payload, String retryTopic, String originalTopic) {
+    ConsumerRecord<String, String> record = getRecord(payload, retryTopic);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
   }
 }

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
@@ -18,12 +18,15 @@ import gov.cdc.nbs.report.pipeline.organization.repository.OrgRepository;
 import gov.cdc.nbs.report.pipeline.organization.repository.PlaceRepository;
 import gov.cdc.nbs.report.pipeline.organization.transformer.DataTransformers;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,10 +34,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
 
 @ExtendWith(MockitoExtension.class)
 class OrganizationServiceTest {
@@ -75,6 +80,7 @@ class OrganizationServiceTest {
             placeRepository,
             transformer,
             kafkaTemplate,
+            new RetryTopicResolver(),
             new CustomMetrics(new SimpleMeterRegistry()));
     organizationService.setOrgTopic(orgTopic);
     organizationService.setPlaceTopic(placeTopic);
@@ -119,7 +125,7 @@ class OrganizationServiceTest {
     String changeData = readFileData("rawDataFiles/organization/OrgChangeData.json");
 
     organizationService.setElasticSearchEnable(false);
-    organizationService.processMessage(changeData, orgTopic);
+    organizationService.processMessage(record(changeData, orgTopic));
 
     // verify that only one message was sent
     Awaitility.await()
@@ -151,7 +157,7 @@ class OrganizationServiceTest {
     place.setPlaceTele(null);
     when(placeRepository.computeAllPlaces(anyString())).thenReturn(Optional.of(List.of(place)));
 
-    organizationService.processMessage(payload, placeTopic);
+    organizationService.processMessage(record(payload, placeTopic));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -162,6 +168,55 @@ class OrganizationServiceTest {
 
     ILoggingEvent le = listAppender.list.get(1);
     assertEquals("PlaceTele array is null.", le.getFormattedMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"OrgUpdate_retry-0", "OrgUpdate_retry-1"})
+  void testProcessOrganizationRetryMessage(String retryTopic) {
+    OrganizationSp organization = new OrganizationSp();
+    organization.setOrganizationUid(10036000L);
+    when(orgRepository.computeAllOrganizations("10036000")).thenReturn(Set.of(organization));
+    organizationService.setElasticSearchEnable(false);
+    organizationService.setPhcDatamartEnable(false);
+
+    CompletableFuture<Void> future =
+        organizationService.processMessage(
+            retryRecord(
+                readFileData("rawDataFiles/organization/OrgChangeData.json"),
+                retryTopic,
+                orgTopic));
+    future.join();
+
+    verify(orgRepository).computeAllOrganizations("10036000");
+    verifyNoInteractions(placeRepository);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"PlaceUpdate_retry-0", "PlaceUpdate_retry-1"})
+  void testProcessPlaceRetryMessage(String retryTopic) throws JsonProcessingException {
+    String payload = "{\"payload\": {\"after\": {\"place_uid\": \"10045001\"}}}";
+    Place place =
+        objectMapper.readValue(readFileData("rawDataFiles/organization/Place.json"), Place.class);
+    when(placeRepository.computeAllPlaces("10045001")).thenReturn(Optional.of(List.of(place)));
+
+    CompletableFuture<Void> future =
+        organizationService.processMessage(retryRecord(payload, retryTopic, placeTopic));
+    future.join();
+
+    verify(placeRepository).computeAllPlaces("10045001");
+    verifyNoInteractions(orgRepository);
+  }
+
+  @Test
+  void testProcessMessageRejectsUnknownOriginalTopic() {
+    ConsumerRecord<String, String> retryRecord =
+        retryRecord(null, "OrgUpdate_retry-0", "unknownTopic");
+
+    CompletableFuture<Void> future = organizationService.processMessage(retryRecord);
+
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(orgRepository, placeRepository);
   }
 
   @ParameterizedTest
@@ -181,7 +236,7 @@ class OrganizationServiceTest {
       expectedExceptionClass = NullPointerException.class;
     }
 
-    CompletableFuture<Void> future = organizationService.processMessage(payload, topic);
+    CompletableFuture<Void> future = organizationService.processMessage(record(payload, topic));
     CompletionException ex = assertThrows(CompletionException.class, future::join);
     assertEquals(expectedExceptionClass, ex.getCause().getCause().getClass());
   }
@@ -201,7 +256,8 @@ class OrganizationServiceTest {
       when(placeRepository.computeAllPlaces(String.valueOf(placeUid)))
           .thenReturn(Optional.of(Collections.emptyList()));
     }
-    CompletableFuture<Void> future = organizationService.processMessage(payload, inputTopic);
+    CompletableFuture<Void> future =
+        organizationService.processMessage(record(payload, inputTopic));
 
     CompletionException ex = assertThrows(CompletionException.class, future::join);
     assertEquals(NoDataException.class, ex.getCause().getClass());
@@ -226,7 +282,7 @@ class OrganizationServiceTest {
 
     String changeData = "{\"payload\": {\"after\": {\"organization_uid\": \"123456789\"}}}";
     organizationService.setPhcDatamartEnable(false);
-    organizationService.processMessage(changeData, orgTopic);
+    organizationService.processMessage(record(changeData, orgTopic));
 
     verify(orgRepository, never()).updatePhcFact(anyString(), anyString());
   }
@@ -235,7 +291,7 @@ class OrganizationServiceTest {
     String changeData = readFileData("rawDataFiles/organization/OrgChangeData.json");
     String expectedKey = readFileData("rawDataFiles/organization/OrgKey.json");
 
-    organizationService.processMessage(changeData, orgTopic);
+    organizationService.processMessage(record(changeData, orgTopic));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -276,7 +332,7 @@ class OrganizationServiceTest {
             PlaceTele.class);
     PlaceTeleKey expectedTeleKey = PlaceTeleKey.builder().placeTeleLocatorUid(10040080L).build();
 
-    organizationService.processMessage(payload, placeTopic);
+    organizationService.processMessage(record(payload, placeTopic));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -314,5 +370,18 @@ class OrganizationServiceTest {
     assertEquals(expectedTele, actualTele);
 
     assertNull(valueCaptor.getAllValues().getFirst()); // tombstone message
+  }
+
+  private ConsumerRecord<String, String> record(String payload, String topic) {
+    return new ConsumerRecord<>(topic, 0, 11L, null, payload);
+  }
+
+  private ConsumerRecord<String, String> retryRecord(
+      String payload, String retryTopic, String originalTopic) {
+    ConsumerRecord<String, String> record = record(payload, retryTopic);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
   }
 }

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
@@ -22,12 +22,15 @@ import gov.cdc.nbs.report.pipeline.person.repository.UserRepository;
 import gov.cdc.nbs.report.pipeline.person.transformer.PersonTransformers;
 import gov.cdc.nbs.report.pipeline.util.DataProcessingException;
 import gov.cdc.nbs.report.pipeline.util.NoDataException;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,10 +38,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
 
 @ExtendWith(MockitoExtension.class)
 class PersonServiceTest {
@@ -83,6 +88,7 @@ class PersonServiceTest {
             userRepository,
             transformer,
             kafkaTemplate,
+            new RetryTopicResolver(),
             new CustomMetrics(new SimpleMeterRegistry()));
     personService.setPersonTopic(inputTopicPerson);
     personService.setUserTopic(inputTopicUser);
@@ -129,7 +135,7 @@ class PersonServiceTest {
         "rawDataFiles/patient/PatientKey.json");
     verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
 
-    personService.processMessage(incomingChangeData, inputTopicPerson);
+    personService.processMessage(record(incomingChangeData, inputTopicPerson));
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
@@ -167,7 +173,7 @@ class PersonServiceTest {
 
     verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
 
-    personService.processMessage(incomingChangeData, inputTopicPerson);
+    personService.processMessage(record(incomingChangeData, inputTopicPerson));
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
@@ -184,7 +190,7 @@ class PersonServiceTest {
     String patientData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
 
     personService.setElasticSearchEnable(false);
-    personService.processMessage(patientData, inputTopicPerson);
+    personService.processMessage(record(patientData, inputTopicPerson));
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
@@ -204,7 +210,7 @@ class PersonServiceTest {
     String providerData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PRV\"}}}";
 
     personService.setElasticSearchEnable(false);
-    personService.processMessage(providerData, inputTopicPerson);
+    personService.processMessage(record(providerData, inputTopicPerson));
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
@@ -221,7 +227,7 @@ class PersonServiceTest {
     String patientData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
 
     personService.setPhcDatamartEnable(false);
-    personService.processMessage(patientData, inputTopicPerson);
+    personService.processMessage(record(patientData, inputTopicPerson));
     verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
   }
 
@@ -230,7 +236,7 @@ class PersonServiceTest {
     String providerData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PRV\"}}}";
 
     personService.setPhcDatamartEnable(false);
-    personService.processMessage(providerData, inputTopicPerson);
+    personService.processMessage(record(providerData, inputTopicPerson));
     verify(patientRepository, never()).updatePhcFact(anyString(), anyString());
   }
 
@@ -243,7 +249,7 @@ class PersonServiceTest {
     Mockito.when(userRepository.computeAuthUsers(anyString()))
         .thenReturn(Optional.of(List.of(user)));
 
-    personService.processMessage(payload, inputTopicUser);
+    personService.processMessage(record(payload, inputTopicUser));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -269,6 +275,49 @@ class PersonServiceTest {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = {"Person_retry-0", "Person_retry-1"})
+  void testProcessPersonRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
+    PatientSp patient = PatientSp.builder().personUid(10000001L).build();
+    when(patientRepository.computePatients("10000001")).thenReturn(List.of(patient));
+    personService.setPhcDatamartEnable(false);
+
+    CompletableFuture<Void> future =
+        personService.processMessage(retryRecord(payload, retryTopic, inputTopicPerson));
+    future.join();
+
+    verify(patientRepository).computePatients("10000001");
+    verifyNoInteractions(providerRepository, userRepository);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"User_retry-0", "User_retry-1"})
+  void testProcessAuthUserRetryMessage(String retryTopic) {
+    String payload = "{\"payload\": {\"after\": {\"auth_user_uid\": \"11\"}}}";
+    when(userRepository.computeAuthUsers("11"))
+        .thenReturn(Optional.of(List.of(constructAuthUser())));
+
+    CompletableFuture<Void> future =
+        personService.processMessage(retryRecord(payload, retryTopic, inputTopicUser));
+    future.join();
+
+    verify(userRepository).computeAuthUsers("11");
+    verifyNoInteractions(patientRepository, providerRepository);
+  }
+
+  @Test
+  void testProcessMessageRejectsUnknownOriginalTopic() {
+    ConsumerRecord<String, String> retryRecord =
+        retryRecord(null, "Person_retry-0", "unknownTopic");
+
+    CompletableFuture<Void> future = personService.processMessage(retryRecord);
+
+    CompletionException exception = assertThrows(CompletionException.class, future::join);
+    assertEquals(NoSuchElementException.class, exception.getCause().getCause().getClass());
+    verifyNoInteractions(patientRepository, providerRepository, userRepository);
+  }
+
+  @ParameterizedTest
   @CsvSource({
     "{\"payload\": {}},Nobody",
     "{\"payload\": {}},Person",
@@ -277,7 +326,7 @@ class PersonServiceTest {
     "{\"payload\": {\"after\": {}}},User"
   })
   void testProcessMessageException(String payload, String inputTopic) {
-    CompletableFuture<Void> future = personService.processMessage(payload, inputTopic);
+    CompletableFuture<Void> future = personService.processMessage(record(payload, inputTopic));
     CompletionException ex = assertThrows(CompletionException.class, future::join);
     assertEquals(NoSuchElementException.class, ex.getCause().getCause().getClass());
   }
@@ -299,7 +348,7 @@ class PersonServiceTest {
       when(userRepository.computeAuthUsers(String.valueOf(authUserUid)))
           .thenReturn(Optional.of(Collections.emptyList()));
     }
-    CompletableFuture<Void> future = personService.processMessage(payload, inputTopic);
+    CompletableFuture<Void> future = personService.processMessage(record(payload, inputTopic));
     CompletionException ex = assertThrows(CompletionException.class, future::join);
     assertEquals(NoDataException.class, ex.getCause().getClass());
   }
@@ -319,7 +368,8 @@ class PersonServiceTest {
   @Test
   void testProcessUnknownCode() {
     String payload = "{\"payload\": {\"after\": {\"person_uid\": \"123456789\", \"cd\": \"UNK\"}}}";
-    CompletableFuture<Void> future = personService.processMessage(payload, inputTopicPerson);
+    CompletableFuture<Void> future =
+        personService.processMessage(record(payload, inputTopicPerson));
     CompletionException ex = assertThrows(CompletionException.class, future::join);
     assertEquals(DataProcessingException.class, ex.getCause().getClass());
     assertTrue(ex.getCause().getMessage().endsWith("No data to process for this entity type: UNK"));
@@ -338,7 +388,7 @@ class PersonServiceTest {
     String expectedReportingValue = readFileData(expectedReportingValueFilePath);
     String expectedElasticValue = readFileData(expectedElasticValueFilePath);
 
-    personService.processMessage(incomingChangeData, inputTopicPerson);
+    personService.processMessage(record(incomingChangeData, inputTopicPerson));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -393,6 +443,19 @@ class PersonServiceTest {
         .entityDataNested(readFileData(filePathPrefix + "PersonEntityData.json"))
         .emailNested(readFileData(filePathPrefix + "PersonEmail.json"))
         .build();
+  }
+
+  private ConsumerRecord<String, String> record(String payload, String topic) {
+    return new ConsumerRecord<>(topic, 0, 11L, null, payload);
+  }
+
+  private ConsumerRecord<String, String> retryRecord(
+      String payload, String retryTopic, String originalTopic) {
+    ConsumerRecord<String, String> record = record(payload, retryTopic);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
   }
 
   private AuthUser constructAuthUser() {

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/EventMetricCleanupTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/EventMetricCleanupTest.java
@@ -13,6 +13,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.InvestigationRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.PostProcRepository;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Method;
@@ -50,10 +51,11 @@ class EventMetricCleanupTest {
                 postProcRepository,
                 investigationRepository,
                 datamartProcessor,
+                new RetryTopicResolver(),
                 new CustomMetrics(new SimpleMeterRegistry())));
+    PostProcessingTestUtils.configureNrtTopics(service);
     service.initMetrics();
     datamartProcessor.initMetrics();
-    service.setInvestigationTopic("dummy_investigation");
     service.setServiceEnable(true);
 
     Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceDmTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceDmTest.java
@@ -11,6 +11,7 @@ import ch.qos.logback.core.read.ListAppender;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.InvestigationRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.PostProcRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.DatamartData;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
@@ -58,7 +59,9 @@ class PostProcessingServiceDmTest {
                 postProcRepositoryMock,
                 investigationRepositoryMock,
                 datamartProcessor,
+                new RetryTopicResolver(),
                 new CustomMetrics(new SimpleMeterRegistry())));
+    PostProcessingTestUtils.configureNrtTopics(postProcessingServiceMock);
     postProcessingServiceMock.initMetrics();
     datamartProcessor.initMetrics();
     postProcessingServiceMock.setServiceEnable(true);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceEntityTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceEntityTest.java
@@ -14,16 +14,21 @@ import ch.qos.logback.core.read.ListAppender;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.InvestigationRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.PostProcRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.DatamartData;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -55,11 +60,12 @@ class PostProcessingServiceEntityTest {
                 postProcRepositoryMock,
                 investigationRepositoryMock,
                 datamartProcessor,
+                new RetryTopicResolver(),
                 new CustomMetrics(new SimpleMeterRegistry())));
+    PostProcessingTestUtils.configureNrtTopics(postProcessingServiceMock);
     postProcessingServiceMock.initMetrics();
     datamartProcessor.initMetrics();
 
-    postProcessingServiceMock.setInvestigationTopic("dummy_investigation");
     postProcessingServiceMock.setServiceEnable(true);
 
     Logger logger = (Logger) LoggerFactory.getLogger(PostProcessingService.class);
@@ -102,6 +108,41 @@ class PostProcessingServiceEntityTest {
     postProcessingServiceMock.processNrtMessage(topic, key, key);
 
     assertTrue(postProcessingServiceMock.idCache.isEmpty());
+  }
+
+  @ParameterizedTest(name = "{0} retry-{3}")
+  @MethodSource("retryTopicMappings")
+  void testRetryTopicUsesLogicalCacheKey(
+      String logicalTopic, String uidField, boolean textualUid, int retryIndex) {
+    String uid = textualUid ? "TEST_CD" : "123";
+    String key =
+        "{\"payload\":{\"" + uidField + "\":" + (textualUid ? "\"" + uid + "\"" : uid) + "}}";
+    String physicalTopic = logicalTopic + "_retry-" + retryIndex;
+    ConsumerRecord<String, String> record =
+        PostProcessingTestUtils.retryRecord(physicalTopic, logicalTopic, key, key);
+
+    postProcessingServiceMock.processNrtMessage(record);
+
+    assertFalse(postProcessingServiceMock.idCache.containsKey(physicalTopic));
+    assertFalse(postProcessingServiceMock.cdCache.containsKey(physicalTopic));
+    if (textualUid) {
+      assertEquals(uid, postProcessingServiceMock.cdCache.get(logicalTopic).element());
+    } else {
+      assertEquals(
+          Long.valueOf(uid), postProcessingServiceMock.idCache.get(logicalTopic).element());
+    }
+  }
+
+  @Test
+  void testRetryTopicRejectsUnknownOriginalTopic() {
+    String key = "{\"payload\":{\"patient_uid\":123}}";
+    ConsumerRecord<String, String> record =
+        PostProcessingTestUtils.retryRecord("dummy_patient_retry-0", "unknown_topic", key, key);
+
+    assertThrows(
+        NoSuchElementException.class, () -> postProcessingServiceMock.processNrtMessage(record));
+    assertTrue(postProcessingServiceMock.idCache.isEmpty());
+    assertTrue(postProcessingServiceMock.cdCache.isEmpty());
   }
 
   @Test
@@ -883,7 +924,7 @@ class PostProcessingServiceEntityTest {
   @Test
   void testPostProcessNoUserProfileUidException() {
     String userProfileKey = "{\"payload\":{}}";
-    String topic = "dummy_user_profile";
+    String topic = "dummy_auth_user";
 
     RuntimeException ex =
         assertThrows(
@@ -1024,15 +1065,46 @@ class PostProcessingServiceEntityTest {
   void testPostProcessUnknownTopic(String key) {
     String topic = "dummy_topic";
 
-    postProcessingServiceMock.processNrtMessage(topic, key, key);
-    postProcessingServiceMock.processCachedIds();
+    NoSuchElementException exception =
+        assertThrows(
+            NoSuchElementException.class,
+            () -> postProcessingServiceMock.processNrtMessage(topic, key, key));
 
-    List<ILoggingEvent> logs = listAppender.list;
-    assertTrue(
-        logs.get(2)
-            .getFormattedMessage()
-            .contains("Unknown topic: " + topic + " cannot be processed"));
+    assertEquals("Received data from an unknown topic: " + topic, exception.getMessage());
+    assertTrue(postProcessingServiceMock.idCache.isEmpty());
+    assertTrue(postProcessingServiceMock.cdCache.isEmpty());
   }
+
+  private static Stream<Arguments> retryTopicMappings() {
+    return Stream.of(
+            new TopicMapping(
+                PostProcessingTestUtils.INVESTIGATION_TOPIC, "public_health_case_uid", false),
+            new TopicMapping(PostProcessingTestUtils.ORGANIZATION_TOPIC, "organization_uid", false),
+            new TopicMapping(PostProcessingTestUtils.PATIENT_TOPIC, "patient_uid", false),
+            new TopicMapping(PostProcessingTestUtils.PROVIDER_TOPIC, "provider_uid", false),
+            new TopicMapping(PostProcessingTestUtils.NOTIFICATION_TOPIC, "notification_uid", false),
+            new TopicMapping(
+                PostProcessingTestUtils.CASE_MANAGEMENT_TOPIC, "public_health_case_uid", false),
+            new TopicMapping(PostProcessingTestUtils.INTERVIEW_TOPIC, "interview_uid", false),
+            new TopicMapping(PostProcessingTestUtils.LDF_DATA_TOPIC, "ldf_uid", false),
+            new TopicMapping(PostProcessingTestUtils.OBSERVATION_TOPIC, "observation_uid", false),
+            new TopicMapping(PostProcessingTestUtils.PLACE_TOPIC, "place_uid", false),
+            new TopicMapping(PostProcessingTestUtils.AUTH_USER_TOPIC, "auth_user_uid", false),
+            new TopicMapping(PostProcessingTestUtils.CONTACT_TOPIC, "contact_uid", false),
+            new TopicMapping(PostProcessingTestUtils.TREATMENT_TOPIC, "treatment_uid", false),
+            new TopicMapping(PostProcessingTestUtils.VACCINATION_TOPIC, "vaccination_uid", false),
+            new TopicMapping(
+                PostProcessingTestUtils.STATE_DEFINED_FIELD_METADATA_TOPIC, "ldf_uid", false),
+            new TopicMapping(PostProcessingTestUtils.NBS_PAGE_TOPIC, "nbs_page_uid", false),
+            new TopicMapping(PostProcessingTestUtils.CONDITION_CODE_TOPIC, "condition_cd", true))
+        .flatMap(
+            topic ->
+                Stream.of(
+                    Arguments.of(topic.logicalTopic(), topic.uidField(), topic.textualUid(), 0),
+                    Arguments.of(topic.logicalTopic(), topic.uidField(), topic.textualUid(), 1)));
+  }
+
+  private record TopicMapping(String logicalTopic, String uidField, boolean textualUid) {}
 
   @Test
   void testShutdown() {

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingServiceRetryTest.java
@@ -13,6 +13,7 @@ import gov.cdc.nbs.report.pipeline.postprocessing.repository.InvestigationReposi
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.PostProcRepository;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.BackfillData;
 import gov.cdc.nbs.report.pipeline.postprocessing.repository.model.DatamartData;
+import gov.cdc.nbs.report.pipeline.util.kafka.RetryTopicResolver;
 import gov.cdc.nbs.report.pipeline.util.metrics.CustomMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
@@ -59,8 +60,10 @@ class PostProcessingServiceRetryTest {
                 postProcRepositoryMock,
                 investigationRepositoryMock,
                 datamartProcessor,
+                new RetryTopicResolver(),
                 new CustomMetrics(new SimpleMeterRegistry())));
     postProcessingServiceMock.setMaxRetries(2);
+    PostProcessingTestUtils.configureNrtTopics(postProcessingServiceMock);
     postProcessingServiceMock.initMetrics();
     datamartProcessor.initMetrics();
     datamartProcessor.setMaxRetries(2);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingTestUtils.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/postprocessing/service/PostProcessingTestUtils.java
@@ -1,0 +1,57 @@
+package gov.cdc.nbs.report.pipeline.postprocessing.service;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.support.KafkaHeaders;
+
+final class PostProcessingTestUtils {
+
+  static final String INVESTIGATION_TOPIC = "dummy_investigation";
+  static final String ORGANIZATION_TOPIC = "dummy_organization";
+  static final String PATIENT_TOPIC = "dummy_patient";
+  static final String PROVIDER_TOPIC = "dummy_provider";
+  static final String NOTIFICATION_TOPIC = "dummy_notification";
+  static final String CASE_MANAGEMENT_TOPIC = "dummy_case_management";
+  static final String INTERVIEW_TOPIC = "dummy_interview";
+  static final String LDF_DATA_TOPIC = "dummy_ldf_data";
+  static final String OBSERVATION_TOPIC = "dummy_observation";
+  static final String PLACE_TOPIC = "dummy_place";
+  static final String AUTH_USER_TOPIC = "dummy_auth_user";
+  static final String CONTACT_TOPIC = "dummy_contact";
+  static final String TREATMENT_TOPIC = "dummy_treatment";
+  static final String VACCINATION_TOPIC = "dummy_vaccination";
+  static final String STATE_DEFINED_FIELD_METADATA_TOPIC = "dummy_state_defined_field_metadata";
+  static final String NBS_PAGE_TOPIC = "dummy_NBS_page";
+  static final String CONDITION_CODE_TOPIC = "dummy_Condition_code";
+
+  private PostProcessingTestUtils() {}
+
+  static void configureNrtTopics(PostProcessingService service) {
+    service.setInvestigationTopic(INVESTIGATION_TOPIC);
+    service.setOrganizationTopic(ORGANIZATION_TOPIC);
+    service.setPatientTopic(PATIENT_TOPIC);
+    service.setProviderTopic(PROVIDER_TOPIC);
+    service.setNotificationTopic(NOTIFICATION_TOPIC);
+    service.setCaseManagementTopic(CASE_MANAGEMENT_TOPIC);
+    service.setInterviewTopic(INTERVIEW_TOPIC);
+    service.setLdfDataTopic(LDF_DATA_TOPIC);
+    service.setObservationTopic(OBSERVATION_TOPIC);
+    service.setPlaceTopic(PLACE_TOPIC);
+    service.setAuthUserTopic(AUTH_USER_TOPIC);
+    service.setContactTopic(CONTACT_TOPIC);
+    service.setTreatmentTopic(TREATMENT_TOPIC);
+    service.setVaccinationTopic(VACCINATION_TOPIC);
+    service.setStateDefinedFieldMetadataTopic(STATE_DEFINED_FIELD_METADATA_TOPIC);
+    service.setNbsPageTopic(NBS_PAGE_TOPIC);
+    service.setConditionCodeTopic(CONDITION_CODE_TOPIC);
+  }
+
+  static ConsumerRecord<String, String> retryRecord(
+      String retryTopic, String originalTopic, String key, String payload) {
+    ConsumerRecord<String, String> record = new ConsumerRecord<>(retryTopic, 0, 11L, key, payload);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+}

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicOriginalHeaderIntegrationTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicOriginalHeaderIntegrationTest.java
@@ -1,0 +1,189 @@
+package gov.cdc.nbs.report.pipeline.util.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = RetryTopicOriginalHeaderIntegrationTest.TestConfiguration.class)
+@DirtiesContext
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {
+      RetryTopicOriginalHeaderIntegrationTest.MAIN_TOPIC,
+      RetryTopicOriginalHeaderIntegrationTest.RETRY_TOPIC_ZERO,
+      RetryTopicOriginalHeaderIntegrationTest.RETRY_TOPIC_ONE,
+      RetryTopicOriginalHeaderIntegrationTest.DLT_TOPIC
+    })
+class RetryTopicOriginalHeaderIntegrationTest {
+
+  static final String MAIN_TOPIC = "retry-header-test";
+  static final String RETRY_TOPIC_ZERO = MAIN_TOPIC + "_retry-0";
+  static final String RETRY_TOPIC_ONE = MAIN_TOPIC + "_retry-1";
+  static final String DLT_TOPIC = MAIN_TOPIC + "_dlt";
+  private static final String GROUP_ID = "retry-header-test-group";
+
+  @Autowired private KafkaTemplate<String, String> kafkaTemplate;
+  @Autowired private RetryingListener listener;
+
+  @Test
+  void preservesOriginalTopicThroughTwoRetryLevels() throws Exception {
+    kafkaTemplate.send(MAIN_TOPIC, "test-key", "test-value").get();
+
+    assertTrue(listener.await(Duration.ofSeconds(20)), "Timed out waiting for retry deliveries");
+    List<Delivery> deliveries = listener.deliveries();
+
+    assertAll(
+        () -> assertEquals(3, deliveries.size()),
+        () -> assertEquals(MAIN_TOPIC, deliveries.get(0).physicalTopic()),
+        () -> assertNull(deliveries.get(0).originalTopic()),
+        () -> assertEquals(RETRY_TOPIC_ZERO, deliveries.get(1).physicalTopic()),
+        () -> assertEquals(MAIN_TOPIC, deliveries.get(1).originalTopic()),
+        () -> assertEquals(RETRY_TOPIC_ONE, deliveries.get(2).physicalTopic()),
+        () -> assertEquals(MAIN_TOPIC, deliveries.get(2).originalTopic()),
+        () ->
+            assertEquals(
+                List.of(MAIN_TOPIC, MAIN_TOPIC, MAIN_TOPIC),
+                deliveries.stream().map(Delivery::logicalTopic).toList()));
+  }
+
+  record Delivery(String physicalTopic, String logicalTopic, String originalTopic) {}
+
+  static final class RetryingListener {
+    private final RetryTopicResolver resolver;
+    private final List<Delivery> deliveries = new CopyOnWriteArrayList<>();
+    private final CountDownLatch deliveryLatch = new CountDownLatch(3);
+    private final AtomicInteger attempts = new AtomicInteger();
+
+    RetryingListener(RetryTopicResolver resolver) {
+      this.resolver = resolver;
+    }
+
+    @RetryableTopic(
+        attempts = "3",
+        autoCreateTopics = "false",
+        retryTopicSuffix = "_retry",
+        dltTopicSuffix = "_dlt",
+        topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+        backoff = @Backoff(delay = 10, multiplier = 2.0),
+        kafkaTemplate = "kafkaTemplate")
+    @KafkaListener(topics = MAIN_TOPIC, groupId = GROUP_ID)
+    void listen(ConsumerRecord<String, String> record) {
+      TopicResolution resolution = resolver.resolve(record, Set.of(MAIN_TOPIC));
+      deliveries.add(
+          new Delivery(
+              resolution.physicalTopic(), resolution.logicalTopic(), originalTopic(record)));
+      deliveryLatch.countDown();
+
+      if (attempts.incrementAndGet() < 3) {
+        throw new IllegalStateException("Force retry");
+      }
+    }
+
+    boolean await(Duration timeout) throws InterruptedException {
+      return deliveryLatch.await(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    List<Delivery> deliveries() {
+      return new ArrayList<>(deliveries);
+    }
+
+    private String originalTopic(ConsumerRecord<String, String> record) {
+      Header header = record.headers().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+      return header == null ? null : new String(header.value(), StandardCharsets.UTF_8);
+    }
+  }
+
+  @Configuration
+  @EnableKafkaRetryTopic
+  static class TestConfiguration {
+
+    @Bean
+    RetryTopicResolver retryTopicResolver() {
+      return new RetryTopicResolver();
+    }
+
+    @Bean
+    RetryingListener retryingListener(RetryTopicResolver resolver) {
+      return new RetryingListener(resolver);
+    }
+
+    @Bean
+    TaskScheduler taskScheduler() {
+      ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+      scheduler.setPoolSize(1);
+      scheduler.setThreadNamePrefix("retry-header-test-");
+      return scheduler;
+    }
+
+    @Bean
+    ProducerFactory<String, String> producerFactory(EmbeddedKafkaBroker broker) {
+      Map<String, Object> properties = KafkaTestUtils.producerProps(broker);
+      properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+      properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+      return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    KafkaTemplate<String, String> kafkaTemplate(ProducerFactory<String, String> producerFactory) {
+      return new KafkaTemplate<>(producerFactory);
+    }
+
+    @Bean
+    ConsumerFactory<String, String> consumerFactory(EmbeddedKafkaBroker broker) {
+      Map<String, Object> properties = KafkaTestUtils.consumerProps(GROUP_ID, "false", broker);
+      properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+      properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+      properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+      return new DefaultKafkaConsumerFactory<>(properties);
+    }
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        ConsumerFactory<String, String> consumerFactory) {
+      ConcurrentKafkaListenerContainerFactory<String, String> factory =
+          new ConcurrentKafkaListenerContainerFactory<>();
+      factory.setConsumerFactory(consumerFactory);
+      return factory;
+    }
+  }
+}

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolverTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/util/kafka/RetryTopicResolverTest.java
@@ -1,0 +1,167 @@
+package gov.cdc.nbs.report.pipeline.util.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.kafka.support.KafkaHeaders;
+
+class RetryTopicResolverTest {
+
+  private static final String MAIN_TOPIC = "nbs_Person";
+  private static final Set<String> ALLOWED_TOPICS = Set.of(MAIN_TOPIC, "nbs_Auth_user");
+  private final RetryTopicResolver resolver = new RetryTopicResolver();
+
+  @Test
+  void resolvesExactMainTopicWithoutOriginalTopicHeader() {
+    ConsumerRecord<String, String> record = record(MAIN_TOPIC);
+
+    TopicResolution resolution = resolver.resolve(record, ALLOWED_TOPICS);
+
+    assertAll(
+        () -> assertEquals(MAIN_TOPIC, resolution.physicalTopic()),
+        () -> assertEquals(MAIN_TOPIC, resolution.logicalTopic()),
+        () -> assertFalse(resolution.retryDelivery()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"nbs_Person_retry-0", "nbs_Person_retry-1"})
+  void resolvesRetryTopicFromOriginalTopicHeader(String physicalTopic) {
+    ConsumerRecord<String, String> record = record(physicalTopic, MAIN_TOPIC);
+
+    TopicResolution resolution = resolver.resolve(record, ALLOWED_TOPICS);
+
+    assertAll(
+        () -> assertEquals(physicalTopic, resolution.physicalTopic()),
+        () -> assertEquals(MAIN_TOPIC, resolution.logicalTopic()),
+        () -> assertTrue(resolution.retryDelivery()));
+  }
+
+  @Test
+  void exactMainTopicTakesPrecedenceOverConflictingOriginalTopicHeader() {
+    ConsumerRecord<String, String> record = record(MAIN_TOPIC, "nbs_Auth_user");
+
+    TopicResolution resolution = resolver.resolve(record, ALLOWED_TOPICS);
+
+    assertAll(
+        () -> assertEquals(MAIN_TOPIC, resolution.logicalTopic()),
+        () -> assertFalse(resolution.retryDelivery()));
+  }
+
+  @Test
+  void rejectsUnknownPhysicalTopicWithoutOriginalTopicHeader() {
+    assertUnknownTopic(record("nbs_Person_retry-0"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "nbs_Organization"})
+  void rejectsInvalidOrUnconfiguredOriginalTopic(String originalTopic) {
+    assertUnknownTopic(record("nbs_Person_retry-0", originalTopic));
+  }
+
+  @Test
+  void rejectsOriginalTopicHeaderWithNullValue() {
+    ConsumerRecord<String, String> record = record("nbs_Person_retry-0");
+    record.headers().add(KafkaHeaders.ORIGINAL_TOPIC, null);
+
+    assertUnknownTopic(record);
+  }
+
+  @Test
+  void rejectsMalformedUtf8OriginalTopicHeader() {
+    ConsumerRecord<String, String> record = record("nbs_Person_retry-0");
+    record.headers().add(KafkaHeaders.ORIGINAL_TOPIC, new byte[] {(byte) 0xC3, (byte) 0x28});
+
+    assertUnknownTopic(record);
+  }
+
+  @Test
+  void doesNotModifyTheConsumerRecord() {
+    ConsumerRecord<String, String> record = record("nbs_Person_retry-1", MAIN_TOPIC);
+    int headerCount = record.headers().toArray().length;
+
+    resolver.resolve(record, ALLOWED_TOPICS);
+
+    assertAll(
+        () -> assertEquals("record-key", record.key()),
+        () -> assertEquals("record-value", record.value()),
+        () -> assertEquals(2, record.partition()),
+        () -> assertEquals(42L, record.offset()),
+        () -> assertEquals(headerCount, record.headers().toArray().length),
+        () ->
+            assertEquals(
+                MAIN_TOPIC,
+                new String(
+                    record.headers().lastHeader(KafkaHeaders.ORIGINAL_TOPIC).value(),
+                    StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void rejectsNullRecord() {
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolve(null, ALLOWED_TOPICS));
+  }
+
+  @Test
+  void topicResolutionRejectsNullTopics() {
+    assertAll(
+        () -> assertThrows(NullPointerException.class, () -> new TopicResolution(null, MAIN_TOPIC)),
+        () ->
+            assertThrows(NullPointerException.class, () -> new TopicResolution(MAIN_TOPIC, null)));
+  }
+
+  @Test
+  void rejectsMissingAllowedTopics() {
+    ConsumerRecord<String, String> record = record(MAIN_TOPIC);
+
+    assertAll(
+        () -> assertThrows(IllegalArgumentException.class, () -> resolver.resolve(record, null)),
+        () ->
+            assertThrows(IllegalArgumentException.class, () -> resolver.resolve(record, Set.of())));
+  }
+
+  @Test
+  void rejectsInvalidAllowedTopic() {
+    ConsumerRecord<String, String> record = record(MAIN_TOPIC);
+    Set<String> topicsWithNull = new HashSet<>();
+    topicsWithNull.add(MAIN_TOPIC);
+    topicsWithNull.add(null);
+
+    assertAll(
+        () ->
+            assertThrows(
+                IllegalArgumentException.class, () -> resolver.resolve(record, topicsWithNull)),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> resolver.resolve(record, Set.of(MAIN_TOPIC, " "))));
+  }
+
+  private void assertUnknownTopic(ConsumerRecord<String, String> record) {
+    NoSuchElementException exception =
+        assertThrows(NoSuchElementException.class, () -> resolver.resolve(record, ALLOWED_TOPICS));
+
+    assertEquals("Received data from an unknown topic: " + record.topic(), exception.getMessage());
+  }
+
+  private ConsumerRecord<String, String> record(String physicalTopic) {
+    return new ConsumerRecord<>(physicalTopic, 2, 42L, "record-key", "record-value");
+  }
+
+  private ConsumerRecord<String, String> record(String physicalTopic, String originalTopic) {
+    ConsumerRecord<String, String> record = record(physicalTopic);
+    record
+        .headers()
+        .add(KafkaHeaders.ORIGINAL_TOPIC, originalTopic.getBytes(StandardCharsets.UTF_8));
+    return record;
+  }
+}


### PR DESCRIPTION
## Description
This PR fixes APP-920 by ensuring Spring Kafka retry-topic deliveries follow the same business-processing path as records consumed from their configured main topics. It introduces shared logical-topic resolution using the preserved `KafkaHeaders.ORIGINAL_TOPIC` header while retaining the physical delivery topic for diagnostics. Observation, person, organization, investigation, and post-processing listeners now reject unknown topics instead of silently acknowledging unprocessed records.

## Related Issue
[APP-920](https://cdc-nbs.atlassian.net/browse/APP-920)

## Additional Notes
Retry routing is centralized and validated against each listener’s configured main-topic allowlist. Post-processing now uses explicit topic-to-entity mappings and logical main topics for cache keys.

- Added `RetryTopicResolver` and `TopicResolution`.
- Added retry support across all multiplexed RTR listeners.
- Added explicit mappings for all 17 configured NRT post-processing topics.
- Added unit coverage for first- and second-level retries and unknown-topic rejection.
- Added an embedded Kafka integration test proving `ORIGINAL_TOPIC` is preserved through two retry levels.
- Added `spring-kafka-test:3.3.16` as a test dependency.
- Added successful test-count summaries to Gradle test output.
- Documented retry-topic routing behavior; no `application.yaml` changes are required.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
 
