### PR TITLE
[APP-904] reduce job_flow_log volume with configurable event-procedure logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ Specific `functional` and `unit` tests can be executed using the `tests` argumen
 ### Adding MasterEtl-level Validation for Functional Tests
 Review [FuncationTestValidation.md](./documentation/FunctionalTestValidation.md) for more details.
 
+### Event-procedure execution logging
+
+Event-procedure routine logging is controlled by
+`EVENT_PROCEDURE_DEBUG_LOGGING` and defaults to `false`:
+
+| Value | Routine `job_flow_log` rows | `ERROR` rows |
+|---|---|---|
+| `false` (default) | Suppressed | Always retained |
+| `true` | Written | Always retained |
+
+Enable it temporarily when investigating stored-procedure execution:
+
+```sh
+EVENT_PROCEDURE_DEBUG_LOGGING=true ./gradlew :reporting-pipeline-service:bootRun
+```
+
+This setting does not enable diagnostic `@debug` result sets. See
+[`documentation/EventProcedureJobFlowLogging.md`](documentation/EventProcedureJobFlowLogging.md)
+for operational guidance and stored-procedure coverage behavior.
+
 ### Windows Note (Testcontainers EOF Error)
 
 If you see `unexpected EOF` while running containerized tests on Windows, this is usually caused by Testcontainers trying to copy the entire project directory into a container and hitting a locked file.

--- a/reporting-pipeline-service/build.gradle
+++ b/reporting-pipeline-service/build.gradle
@@ -46,6 +46,8 @@ test {
 tasks.register("test-functional", Test) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
+    // Functional tests capture stored-procedure coverage from job_flow_log.
+    systemProperty "EVENT_PROCEDURE_DEBUG_LOGGING", "true"
     if (System.getProperty("tests") != null) {
         systemProperty "tests", System.getProperty("tests")
     }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ReportingPipelineServiceApplication.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ReportingPipelineServiceApplication.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.report.pipeline;
 
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.connector.ConnectorProperties;
 import gov.cdc.nbs.report.pipeline.lag.LagProperties;
 import org.springframework.boot.SpringApplication;
@@ -11,7 +12,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * various reporting microservices into a single application to simplify the ETL data pipeline.
  */
 @SpringBootApplication
-@EnableConfigurationProperties({ConnectorProperties.class, LagProperties.class})
+@EnableConfigurationProperties({
+  ConnectorProperties.class,
+  LagProperties.class,
+  EventProcedureLoggingProperties.class
+})
 public class ReportingPipelineServiceApplication {
 
   /**

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/config/EventProcedureLoggingProperties.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/config/EventProcedureLoggingProperties.java
@@ -1,0 +1,6 @@
+package gov.cdc.nbs.report.pipeline.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "feature-flag")
+public record EventProcedureLoggingProperties(boolean eventProcedureDebugLogging) {}

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/ContactRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/ContactRepository.java
@@ -8,6 +8,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface ContactRepository extends JpaRepository<Contact, String> {
 
-  @Query(nativeQuery = true, value = "exec sp_contact_record_event :ct_contact_uid")
-  Optional<Contact> computeContact(@Param("ct_contact_uid") String contactUid);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_contact_record_event @cc_uids = :ct_contact_uid, @debug = 0, "
+              + "@debug_logging = :debugLogging")
+  Optional<Contact> computeContact(
+      @Param("ct_contact_uid") String contactUid, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/InterviewRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/InterviewRepository.java
@@ -10,6 +10,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface InterviewRepository extends JpaRepository<Interview, String> {
 
-  @Query(nativeQuery = true, value = "exec sp_interview_event :interview_uids")
-  Optional<Interview> computeInterviews(@Param("interview_uids") String interviewUids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_interview_event @ix_uids = :interview_uids, @debug = 0, "
+              + "@debug_logging = :debugLogging")
+  Optional<Interview> computeInterviews(
+      @Param("interview_uids") String interviewUids, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/InvestigationRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/InvestigationRepository.java
@@ -11,12 +11,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface InvestigationRepository extends JpaRepository<Investigation, String> {
 
-  @Query(nativeQuery = true, value = "execute sp_investigation_event :investigation_uids")
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_investigation_event @phc_id_list = :investigation_uids, "
+              + "@debug_logging = :debugLogging")
   Optional<Investigation> computeInvestigations(
-      @Param("investigation_uids") String investigationUids);
+      @Param("investigation_uids") String investigationUids,
+      @Param("debugLogging") boolean debugLogging);
 
-  @Procedure("sp_public_health_case_fact_datamart_event")
-  void populatePhcFact(@Param("investigation_uids") String phcIds);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_public_health_case_fact_datamart_event "
+              + "@phc_id_list = :phcIds, @debug = 0, @debug_logging = :debugLogging")
+  void populatePhcFact(@Param("phcIds") String phcIds, @Param("debugLogging") boolean debugLogging);
 
   @Procedure("sp_public_health_case_fact_datamart_update")
   void updatePhcFact(@Param("objName") String objName, @Param("uidLst") String uidLst);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/NotificationRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/NotificationRepository.java
@@ -8,7 +8,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<NotificationUpdate, String> {
 
-  @Query(nativeQuery = true, value = "execute sp_notification_event :notification_uids")
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_notification_event @notification_list = :notification_uids, "
+              + "@debug_logging = :debugLogging")
   Optional<NotificationUpdate> computeNotifications(
-      @Param("notification_uids") String notificationUids);
+      @Param("notification_uids") String notificationUids,
+      @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/TreatmentRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/TreatmentRepository.java
@@ -8,6 +8,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface TreatmentRepository extends JpaRepository<Treatment, String> {
 
-  @Query(nativeQuery = true, value = "exec sp_treatment_event :treatment_uid")
-  Optional<Treatment> computeTreatment(@Param("treatment_uid") String treatmentUid);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_treatment_event @treatment_uids = :treatment_uid, "
+              + "@debug = 0, @debug_logging = :debugLogging")
+  Optional<Treatment> computeTreatment(
+      @Param("treatment_uid") String treatmentUid, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/VaccinationRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/repository/VaccinationRepository.java
@@ -8,6 +8,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface VaccinationRepository extends JpaRepository<Vaccination, String> {
 
-  @Query(nativeQuery = true, value = "exec sp_vaccination_event :vaccination_uid")
-  Optional<Vaccination> computeVaccination(@Param("vaccination_uid") String vaccinationUid);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_vaccination_event @vac_uids = :vaccination_uid, "
+              + "@debug = 0, @debug_logging = :debugLogging")
+  Optional<Vaccination> computeVaccination(
+      @Param("vaccination_uid") String vaccinationUid, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationService.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.report.pipeline.investigation.service;
 
 import static gov.cdc.nbs.report.pipeline.util.UtilHelper.*;
 
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.investigation.repository.*;
 import gov.cdc.nbs.report.pipeline.investigation.repository.model.dto.*;
 import gov.cdc.nbs.report.pipeline.investigation.repository.model.reporting.InvestigationKey;
@@ -91,6 +92,7 @@ public class InvestigationService {
   private final ContactRepository contactRepository;
   private final VaccinationRepository vaccinationRepository;
   private final TreatmentRepository treatmentRepository;
+  private final EventProcedureLoggingProperties eventProcedureLoggingProperties;
 
   @Qualifier("investigationKafkaTemplate")
   private final KafkaTemplate<String, String> kafkaTemplate;
@@ -196,12 +198,17 @@ public class InvestigationService {
 
             if (phcDatamartEnable) {
               CompletableFuture.runAsync(
-                  () -> processDataUtil.processPhcFactDatamart(phcUid), phcExecutor);
+                  () ->
+                      processDataUtil.processPhcFactDatamart(
+                          phcUid, eventProcedureLoggingProperties.eventProcedureDebugLogging()),
+                  phcExecutor);
             }
 
             logger.info(topicDebugLog, "Investigation", publicHealthCaseUid, investigationTopic);
             Optional<Investigation> investigationData =
-                investigationRepository.computeInvestigations(publicHealthCaseUid);
+                investigationRepository.computeInvestigations(
+                    publicHealthCaseUid,
+                    eventProcedureLoggingProperties.eventProcedureDebugLogging());
             if (investigationData.isPresent()) {
               Investigation investigation = investigationData.get();
               investigationKey.setPublicHealthCaseUid(Long.valueOf(publicHealthCaseUid));
@@ -294,7 +301,8 @@ public class InvestigationService {
             logger.info(topicDebugLog, "Notification", notificationUid, notificationTopic);
 
             Optional<NotificationUpdate> notificationData =
-                notificationRepository.computeNotifications(notificationUid);
+                notificationRepository.computeNotifications(
+                    notificationUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
             if (notificationData.isPresent()) {
               NotificationUpdate notification = notificationData.get();
               processDataUtil.processNotifications(notification.getInvestigationNotifications());
@@ -320,7 +328,9 @@ public class InvestigationService {
       interviewUid = extractUid(value, "interview_uid");
 
       logger.info(topicDebugLog, "Interview", interviewUid, interviewTopic);
-      Optional<Interview> interviewData = interviewRepository.computeInterviews(interviewUid);
+      Optional<Interview> interviewData =
+          interviewRepository.computeInterviews(
+              interviewUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
       if (interviewData.isPresent()) {
         Interview interview = interviewData.get();
         processDataUtil.processInterview(interview, batchId);
@@ -342,7 +352,9 @@ public class InvestigationService {
       contactUid = extractUid(value, "ct_contact_uid");
 
       logger.info(topicDebugLog, "Contact", contactUid, contactTopic);
-      Optional<Contact> contactData = contactRepository.computeContact(contactUid);
+      Optional<Contact> contactData =
+          contactRepository.computeContact(
+              contactUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
       if (contactData.isPresent()) {
         Contact contact = contactData.get();
         processDataUtil.processContact(contact);
@@ -372,7 +384,9 @@ public class InvestigationService {
         vaccinationUid = actRelationshipSourceActUid;
       }
       logger.info(topicDebugLog, "Vaccination", vaccinationUid, topic);
-      Optional<Vaccination> vacData = vaccinationRepository.computeVaccination(vaccinationUid);
+      Optional<Vaccination> vacData =
+          vaccinationRepository.computeVaccination(
+              vaccinationUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
       if (vacData.isPresent()) {
         Vaccination vaccination = vacData.get();
         processDataUtil.processVaccination(vaccination);
@@ -408,7 +422,9 @@ public class InvestigationService {
       }
 
       logger.info(topicDebugLog, "Treatment", treatmentUid, topic);
-      Optional<Treatment> treatmentData = treatmentRepository.computeTreatment(treatmentUid);
+      Optional<Treatment> treatmentData =
+          treatmentRepository.computeTreatment(
+              treatmentUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
       if (treatmentData.isPresent()) {
         Treatment treatment = treatmentData.get();
 

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/util/ProcessInvestigationDataUtil.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/util/ProcessInvestigationDataUtil.java
@@ -448,7 +448,8 @@ public class ProcessInvestigationDataUtil {
       logger.info(ex.getMessage(), "InvestigationConfirmationMethod");
     } catch (Exception e) {
       logger.error(
-          "Error processing investigation confirmation method JSON array from investigation data: {}",
+          "Error processing investigation confirmation method JSON array from investigation data:"
+              + " {}",
           e.getMessage());
     }
   }
@@ -526,16 +527,12 @@ public class ProcessInvestigationDataUtil {
   }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
-  public void processPhcFactDatamart(String publicHealthCaseUid) {
-    processPhcFactDatamart(publicHealthCaseUid, false);
-  }
-
-  @Transactional(isolation = Isolation.REPEATABLE_READ)
   public void processPhcFactDatamart(String publicHealthCaseUid, boolean debugLogging) {
     try {
       // Calling sp_public_health_case_fact_datamart_event
       logger.info(
-          "Executing stored proc: sp_public_health_case_fact_datamart_event '{}' to populate PHС fact datamart",
+          "Executing stored proc: sp_public_health_case_fact_datamart_event '{}' to populate PHС"
+              + " fact datamart",
           publicHealthCaseUid);
       investigationRepository.populatePhcFact(publicHealthCaseUid, debugLogging);
       logger.info(
@@ -551,7 +548,8 @@ public class ProcessInvestigationDataUtil {
     try {
       // Calling sp_public_health_case_fact_datamart_update
       logger.info(
-          "Executing stored proc: sp_public_health_case_fact_datamart_update '{}', '{}' to update PHС fact datamart",
+          "Executing stored proc: sp_public_health_case_fact_datamart_update '{}', '{}' to update"
+              + " PHС fact datamart",
           objName,
           uid);
       investigationRepository.updatePhcFact(objName, uid);
@@ -609,7 +607,8 @@ public class ProcessInvestigationDataUtil {
 
     } catch (Exception e) {
       logger.error(
-          "Error processing Investigation Interview or any of the associated data from interview data: {}",
+          "Error processing Investigation Interview or any of the associated data from interview"
+              + " data: {}",
           e.getMessage());
     }
   }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/util/ProcessInvestigationDataUtil.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/investigation/util/ProcessInvestigationDataUtil.java
@@ -527,12 +527,17 @@ public class ProcessInvestigationDataUtil {
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   public void processPhcFactDatamart(String publicHealthCaseUid) {
+    processPhcFactDatamart(publicHealthCaseUid, false);
+  }
+
+  @Transactional(isolation = Isolation.REPEATABLE_READ)
+  public void processPhcFactDatamart(String publicHealthCaseUid, boolean debugLogging) {
     try {
       // Calling sp_public_health_case_fact_datamart_event
       logger.info(
           "Executing stored proc: sp_public_health_case_fact_datamart_event '{}' to populate PHС fact datamart",
           publicHealthCaseUid);
-      investigationRepository.populatePhcFact(publicHealthCaseUid);
+      investigationRepository.populatePhcFact(publicHealthCaseUid, debugLogging);
       logger.info(
           "Stored proc execution completed: sp_public_health_case_fact_datamart_event '{}",
           publicHealthCaseUid);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/repository/LdfDataRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/repository/LdfDataRepository.java
@@ -12,9 +12,12 @@ public interface LdfDataRepository extends JpaRepository<LdfData, Long> {
 
   @Query(
       nativeQuery = true,
-      value = "execute sp_ldf_data_event :bus_obj_nm, :ldf_uid, :bus_obj_uids")
+      value =
+          "execute sp_ldf_data_event @bus_obj_nm = :bus_obj_nm, @ldf_uid = :ldf_uid, "
+              + "@bus_obj_uid_list = :bus_obj_uids, @debug_logging = :debugLogging")
   Optional<LdfData> computeLdfData(
       @Param("bus_obj_nm") String busObjNm,
       @Param("ldf_uid") String ldfUid,
-      @Param("bus_obj_uids") String busObjUids);
+      @Param("bus_obj_uids") String busObjUids,
+      @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataService.java
@@ -5,6 +5,7 @@ import static gov.cdc.nbs.report.pipeline.util.UtilHelper.extractChangeDataCaptu
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.ldfdata.model.dto.LdfData;
 import gov.cdc.nbs.report.pipeline.ldfdata.model.dto.LdfDataKey;
 import gov.cdc.nbs.report.pipeline.ldfdata.repository.LdfDataRepository;
@@ -57,6 +58,7 @@ public class LdfDataService {
   private int threadPoolSize;
 
   private final LdfDataRepository ldfDataRepository;
+  private final EventProcedureLoggingProperties eventProcedureLoggingProperties;
 
   @Qualifier("ldfdataKafkaTemplate")
   private final KafkaTemplate<String, String> kafkaTemplate;
@@ -191,7 +193,11 @@ public class LdfDataService {
     if (opType.equals("d")) {
       return Optional.of(initializeBean(ldfUid, busObjUid, busObjNm));
     } else {
-      return ldfDataRepository.computeLdfData(busObjNm, ldfUid, busObjUid);
+      return ldfDataRepository.computeLdfData(
+          busObjNm,
+          ldfUid,
+          busObjUid,
+          eventProcedureLoggingProperties.eventProcedureDebugLogging());
     }
   }
 

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/repository/ObservationRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/repository/ObservationRepository.java
@@ -10,6 +10,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ObservationRepository extends JpaRepository<Observation, String> {
 
-  @Query(nativeQuery = true, value = "execute sp_Observation_Event :observation_uids")
-  Optional<Observation> computeObservations(@Param("observation_uids") String observation_uids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_observation_event @obs_id_list = :observation_uids, "
+              + "@debug_logging = :debugLogging")
+  Optional<Observation> computeObservations(
+      @Param("observation_uids") String observationUids,
+      @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationService.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.report.pipeline.observation.service;
 
 import static gov.cdc.nbs.report.pipeline.util.UtilHelper.*;
 
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.Observation;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.ObservationKey;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.ObservationReporting;
@@ -76,6 +77,7 @@ public class ObservationService {
   private int threadPoolSize;
 
   private final ObservationRepository observationRepository;
+  private final EventProcedureLoggingProperties eventProcedureLoggingProperties;
 
   @Qualifier("observationKafkaTemplate")
   private final KafkaTemplate<String, String> kafkaTemplate;
@@ -172,7 +174,8 @@ public class ObservationService {
             observationKey.setObservationUid(Long.valueOf(observationUid));
             logger.info(topicDebugLog, observationUid, observationTopic);
             Optional<Observation> observationData =
-                observationRepository.computeObservations(observationUid);
+                observationRepository.computeObservations(
+                    observationUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
             if (observationData.isPresent()) {
               ObservationReporting reportingModel =
                   modelMapper.map(observationData.get(), ObservationReporting.class);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/repository/OrgRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/repository/OrgRepository.java
@@ -11,8 +11,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrgRepository extends JpaRepository<OrganizationSp, String> {
 
-  @Query(nativeQuery = true, value = "execute sp_organization_event :org_uids")
-  Set<OrganizationSp> computeAllOrganizations(@Param("org_uids") String orgUids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_organization_event @org_id_list = :org_uids, "
+              + "@debug_logging = :debugLogging")
+  Set<OrganizationSp> computeAllOrganizations(
+      @Param("org_uids") String orgUids, @Param("debugLogging") boolean debugLogging);
 
   @Procedure("sp_public_health_case_fact_datamart_update")
   void updatePhcFact(@Param("objName") String objName, @Param("uidLst") String uidLst);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/repository/PlaceRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/repository/PlaceRepository.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, String> {
 
-  @Query(nativeQuery = true, value = "execute sp_place_event :place_uids")
-  Optional<List<Place>> computeAllPlaces(@Param("place_uids") String placeUids);
+  @Query(
+      nativeQuery = true,
+      value = "execute sp_place_event @id_list = :place_uids, " + "@debug_logging = :debugLogging")
+  Optional<List<Place>> computeAllPlaces(
+      @Param("place_uids") String placeUids, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationService.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.report.pipeline.organization.service;
 import static gov.cdc.nbs.report.pipeline.util.UtilHelper.errorMessage;
 import static gov.cdc.nbs.report.pipeline.util.UtilHelper.extractUid;
 
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.organization.model.dto.org.OrganizationSp;
 import gov.cdc.nbs.report.pipeline.organization.model.dto.place.Place;
 import gov.cdc.nbs.report.pipeline.organization.model.dto.place.PlaceTele;
@@ -66,6 +67,7 @@ import org.springframework.util.ObjectUtils;
 public class OrganizationService {
   private final OrgRepository orgRepository;
   private final PlaceRepository placeRepository;
+  private final EventProcedureLoggingProperties eventProcedureLoggingProperties;
   private final DataTransformers transformer;
 
   @Qualifier("organizationKafkaTemplate")
@@ -174,7 +176,8 @@ public class OrganizationService {
             }
 
             Set<OrganizationSp> organizations =
-                orgRepository.computeAllOrganizations(organizationUid);
+                orgRepository.computeAllOrganizations(
+                    organizationUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
             if (organizations.isEmpty()) {
               throw new EntityNotFoundException(
                   "Unable to find Organization with id: " + organizationUid);
@@ -234,7 +237,9 @@ public class OrganizationService {
     try {
       placeUid = extractUid(message, "place_uid");
       log.info(topicDebugLog, "Place", placeUid, topic);
-      Optional<List<Place>> placeData = placeRepository.computeAllPlaces(placeUid);
+      Optional<List<Place>> placeData =
+          placeRepository.computeAllPlaces(
+              placeUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
 
       if (placeData.isPresent() && !placeData.get().isEmpty()) {
         placeData

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/PatientRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/PatientRepository.java
@@ -10,8 +10,13 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PatientRepository extends JpaRepository<PatientSp, String> {
-  @Query(nativeQuery = true, value = "execute sp_Patient_Event :person_uids")
-  List<PatientSp> computePatients(@Param("person_uids") String personUids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_patient_event @user_id_list = :person_uids, "
+              + "@debug_logging = :debugLogging")
+  List<PatientSp> computePatients(
+      @Param("person_uids") String personUids, @Param("debugLogging") boolean debugLogging);
 
   @Procedure("sp_public_health_case_fact_datamart_update")
   void updatePhcFact(@Param("objName") String objName, @Param("uidLst") String uidLst);

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/ProviderRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/ProviderRepository.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProviderRepository extends JpaRepository<ProviderSp, String> {
-  @Query(nativeQuery = true, value = "execute sp_provider_event :person_uids")
-  List<ProviderSp> computeProviders(@Param("person_uids") String personUids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_provider_event @user_id_list = :person_uids, "
+              + "@debug_logging = :debugLogging")
+  List<ProviderSp> computeProviders(
+      @Param("person_uids") String personUids, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/UserRepository.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/repository/UserRepository.java
@@ -8,6 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<AuthUser, String> {
-  @Query(nativeQuery = true, value = "execute sp_auth_user_event :user_uids")
-  Optional<List<AuthUser>> computeAuthUsers(@Param("user_uids") String userUids);
+  @Query(
+      nativeQuery = true,
+      value =
+          "execute sp_auth_user_event @user_id_list = :user_uids, "
+              + "@debug_logging = :debugLogging")
+  Optional<List<AuthUser>> computeAuthUsers(
+      @Param("user_uids") String userUids, @Param("debugLogging") boolean debugLogging);
 }

--- a/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
+++ b/reporting-pipeline-service/src/main/java/gov/cdc/nbs/report/pipeline/person/service/PersonService.java
@@ -6,6 +6,7 @@ import static gov.cdc.nbs.report.pipeline.util.UtilHelper.extractUid;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.person.model.dto.patient.PatientSp;
 import gov.cdc.nbs.report.pipeline.person.model.dto.provider.ProviderSp;
 import gov.cdc.nbs.report.pipeline.person.model.dto.user.AuthUser;
@@ -71,6 +72,7 @@ public class PersonService {
   private final PatientRepository patientRepository;
   private final ProviderRepository providerRepository;
   private final UserRepository userRepository;
+  private final EventProcedureLoggingProperties eventProcedureLoggingProperties;
   private final PersonTransformers transformer;
 
   @Qualifier("personKafkaTemplate")
@@ -187,11 +189,15 @@ public class PersonService {
             String cd = payloadNode.get("cd").asText();
             switch (cd) {
               case "PAT":
-                personDataFromStoredProc = patientRepository.computePatients(personUid);
+                personDataFromStoredProc =
+                    patientRepository.computePatients(
+                        personUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
                 processPatientData(personDataFromStoredProc);
                 break;
               case "PRV":
-                providerDataFromStoredProc = providerRepository.computeProviders(personUid);
+                providerDataFromStoredProc =
+                    providerRepository.computeProviders(
+                        personUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
                 processProviderData(providerDataFromStoredProc);
                 break;
               default:
@@ -294,7 +300,9 @@ public class PersonService {
     try {
       userUid = extractUid(message, "auth_user_uid");
       log.info(topicDebugLog, "User", userUid, topic);
-      Optional<List<AuthUser>> userData = userRepository.computeAuthUsers(userUid);
+      Optional<List<AuthUser>> userData =
+          userRepository.computeAuthUsers(
+              userUid, eventProcedureLoggingProperties.eventProcedureDebugLogging());
 
       if (userData.isPresent() && !userData.get().isEmpty()) {
         userData

--- a/reporting-pipeline-service/src/main/resources/application.yaml
+++ b/reporting-pipeline-service/src/main/resources/application.yaml
@@ -120,6 +120,7 @@ lag:
   admin-timeout-ms: ${LAG_ADMIN_TIMEOUT_MS:10000}
 
 featureFlag:
+  event-procedure-debug-logging: ${EVENT_PROCEDURE_DEBUG_LOGGING:false}
   elastic-search-enable: ${FF_ES_ENABLE:false}
   seeding-enable: ${FF_SEEDING_ENABLE:true}
   thread-pool-size: ${FF_THREAD_POOL_SIZE:1}

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/rdb.changelog-7.13.yaml
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/rdb.changelog-7.13.yaml
@@ -3287,3 +3287,12 @@ databaseChangeLog:
         - sqlFile:
             path: db/changelog/migrations/v7.13/rdb/tables/262-alter_nrt_dead_letter_log.sql
             splitStatements: false
+  - changeSet:
+      id: 962
+      author: liquibase
+      runOnChange: true
+      changes:
+        - sqlFile:
+            path: db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
+            splitStatements: true
+            endDelimiter: GO

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
@@ -6,7 +6,7 @@ IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_organizati
     END
 GO
 
-CREATE PROCEDURE dbo.sp_organization_event @org_id_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_organization_event @org_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -14,27 +14,30 @@ BEGIN
 
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
-        INSERT INTO [dbo].[job_flow_log]
-        (
-          batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1]
-        )
-        VALUES (
-                 @batch_id
-               ,'Organization PRE-Processing Event'
-               ,'sp_organization_event'
-               ,'START'
-               ,0
-               ,LEFT('Pre ID-' + @org_id_list,199)
-               ,0
-               ,LEFT(@org_id_list,199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (
+              batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1]
+            )
+            VALUES (
+                     @batch_id
+                   ,'Organization PRE-Processing Event'
+                   ,'sp_organization_event'
+                   ,'START'
+                   ,0
+                   ,LEFT('Pre ID-' + @org_id_list,199)
+                   ,0
+                   ,LEFT(@org_id_list,199)
+                   );
+        END;
 
         SELECT o.organization_uid,
                LTRIM(RTRIM(SUBSTRING(o.description,1,1000))) as description,
@@ -154,27 +157,30 @@ BEGIN
                  LEFT JOIN nbs_srte.dbo.NAICS_INDUSTRY_CODE naics WITH (NOLOCK) ON (NAICS.CODE = o.STANDARD_INDUSTRY_CLASS_CD)
         WHERE o.organization_uid in (SELECT value FROM STRING_SPLIT(@org_id_list, ','))
 
-        INSERT INTO [dbo].[job_flow_log]
-        (
-          batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1]
-        )
-        VALUES (
-                 @batch_id
-               ,'Organization PRE-Processing Event'
-               ,'sp_organization_event'
-               ,'COMPLETE'
-               ,0
-               ,LEFT('Pre ID-' + @org_id_list,199)
-               ,0
-               ,LEFT(@org_id_list,199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (
+              batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1]
+            )
+            VALUES (
+                     @batch_id
+                   ,'Organization PRE-Processing Event'
+                   ,'sp_organization_event'
+                   ,'COMPLETE'
+                   ,0
+                   ,LEFT('Pre ID-' + @org_id_list,199)
+                   ,0
+                   ,LEFT(@org_id_list,199)
+                   );
+        END;
 
     END TRY
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @org_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@org_id_list, 199);
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         IF @debug_logging = 1
         BEGIN
@@ -22,9 +24,9 @@ BEGIN
                 @package_name = 'sp_organization_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @org_id_list,199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@org_id_list,199);
+                @msg_description1 = @job_flow_message;
         END;
 
         SELECT o.organization_uid,
@@ -153,9 +155,9 @@ BEGIN
                 @package_name = 'sp_organization_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @org_id_list,199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@org_id_list,199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -180,7 +182,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Organization PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@org_id_list,199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/051-sp_organization_event-001.sql
@@ -16,27 +16,15 @@ BEGIN
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (
-              batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1]
-            )
-            VALUES (
-                     @batch_id
-                   ,'Organization PRE-Processing Event'
-                   ,'sp_organization_event'
-                   ,'START'
-                   ,0
-                   ,LEFT('Pre ID-' + @org_id_list,199)
-                   ,0
-                   ,LEFT(@org_id_list,199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Organization PRE-Processing Event',
+                @package_name = 'sp_organization_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @org_id_list,199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@org_id_list,199);
         END;
 
         SELECT o.organization_uid,
@@ -159,27 +147,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (
-              batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1]
-            )
-            VALUES (
-                     @batch_id
-                   ,'Organization PRE-Processing Event'
-                   ,'sp_organization_event'
-                   ,'COMPLETE'
-                   ,0
-                   ,LEFT('Pre ID-' + @org_id_list,199)
-                   ,0
-                   ,LEFT(@org_id_list,199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Organization PRE-Processing Event',
+                @package_name = 'sp_organization_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @org_id_list,199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@org_id_list,199);
         END;
 
     END TRY
@@ -196,28 +172,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                 batch_id
-                                               ,[Dataflow_Name]
-                                               ,[package_Name]
-                                               ,[Status_Type]
-                                               ,[step_number]
-                                               ,[step_name]
-                                               ,[row_count]
-                                               ,[Msg_Description1]
-                                               ,[Error_Description]
-        )
-        VALUES (
-                 @batch_id
-               ,'Organization PRE-Processing Event'
-               ,'sp_organization_event'
-               ,'ERROR'
-               ,0
-               ,'Organization PRE-Processing Event'
-               ,0
-               ,LEFT(@org_id_list,199)
-               ,@FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Organization PRE-Processing Event',
+            @package_name = 'sp_organization_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Organization PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@org_id_list,199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
@@ -17,23 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Provider PRE-Processing Event'
-                   ,'sp_provider_event'
-                   ,'START'
-                   ,0
-                   ,LEFT('Pre ID-' + @user_id_list, 199)
-                   ,0
-                   ,LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Provider PRE-Processing Event',
+                @package_name = 'sp_provider_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
         SELECT p.person_uid,
@@ -177,22 +169,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-                                                          ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Provider PRE-Processing Event'
-                   ,'sp_provider_event'
-                   ,'COMPLETE'
-                   ,0
-                   ,'PRE-Processing'
-                   ,0
-                   ,LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Provider PRE-Processing Event',
+                @package_name = 'sp_provider_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = 'PRE-Processing',
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
     END TRY
@@ -209,24 +194,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1]
-                                                      ,[Error_Description])
-        VALUES (@batch_id
-               ,'Provider PRE-Processing Event'
-               ,'sp_provider_event'
-               ,'ERROR'
-               ,0
-               ,'Provider PRE-Processing Event'
-               ,0
-                ,LEFT(@user_id_list, 199)
-               ,@FullErrorMessage);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Provider PRE-Processing Event',
+            @package_name = 'sp_provider_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Provider PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@user_id_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @user_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@user_id_list, 199);
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_provider_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         SELECT p.person_uid,
@@ -177,7 +179,7 @@ BEGIN
                 @step_number = 0,
                 @step_name = 'PRE-Processing',
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -202,7 +204,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Provider PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@user_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/052-sp_provider_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_provider_event @user_id_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_provider_event @user_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,23 +15,26 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Provider PRE-Processing Event'
-               ,'sp_provider_event'
-               ,'START'
-               ,0
-               ,LEFT('Pre ID-' + @user_id_list, 199)
-               ,0
-               ,LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Provider PRE-Processing Event'
+                   ,'sp_provider_event'
+                   ,'START'
+                   ,0
+                   ,LEFT('Pre ID-' + @user_id_list, 199)
+                   ,0
+                   ,LEFT(@user_id_list, 199));
+        END;
 
         SELECT p.person_uid,
                p.person_parent_uid,
@@ -172,22 +175,25 @@ BEGIN
         WHERE p.person_uid in (SELECT value FROM STRING_SPLIT(@user_id_list, ','))
           AND p.cd = 'PRV';
 
-        INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Provider PRE-Processing Event'
-               ,'sp_provider_event'
-               ,'COMPLETE'
-               ,0
-               ,'PRE-Processing'
-               ,0
-               ,LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+                                                          ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Provider PRE-Processing Event'
+                   ,'sp_provider_event'
+                   ,'COMPLETE'
+                   ,0
+                   ,'PRE-Processing'
+                   ,0
+                   ,LEFT(@user_id_list, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @user_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@user_id_list, 199);
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_patient_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         create table #temp_race_table
@@ -358,9 +360,9 @@ BEGIN
                 @package_name = 'sp_patient_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -385,7 +387,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Patient PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@user_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_patient_event @user_id_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_patient_event @user_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,23 +15,26 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Patient PRE-Processing Event'
-               ,'sp_patient_event'
-               ,'START'
-               ,0
-               ,LEFT('Pre ID-' + @user_id_list, 199)
-               ,0
-               ,LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Patient PRE-Processing Event'
+                   ,'sp_patient_event'
+                   ,'START'
+                   ,0
+                   ,LEFT('Pre ID-' + @user_id_list, 199)
+                   ,0
+                   ,LEFT(@user_id_list, 199));
+        END;
 
         create table #temp_race_table
         (
@@ -355,23 +358,26 @@ BEGIN
           AND p.cd = 'PAT';
 
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Patient PRE-Processing Event'
-               ,'sp_patient_event'
-               ,'COMPLETE'
-               ,0
-               ,LEFT('Pre ID-' + @user_id_list, 199)
-               ,0
-               ,LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Patient PRE-Processing Event'
+                   ,'sp_patient_event'
+                   ,'COMPLETE'
+                   ,0
+                   ,LEFT('Pre ID-' + @user_id_list, 199)
+                   ,0
+                   ,LEFT(@user_id_list, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/054-sp_patient_event-001.sql
@@ -17,23 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Patient PRE-Processing Event'
-                   ,'sp_patient_event'
-                   ,'START'
-                   ,0
-                   ,LEFT('Pre ID-' + @user_id_list, 199)
-                   ,0
-                   ,LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Patient PRE-Processing Event',
+                @package_name = 'sp_patient_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
         create table #temp_race_table
@@ -360,23 +352,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Patient PRE-Processing Event'
-                   ,'sp_patient_event'
-                   ,'COMPLETE'
-                   ,0
-                   ,LEFT('Pre ID-' + @user_id_list, 199)
-                   ,0
-                   ,LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Patient PRE-Processing Event',
+                @package_name = 'sp_patient_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
     END TRY
@@ -393,27 +377,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1]
-        ,[Error_Description]
-        )
-        VALUES (@batch_id
-               ,'Patient PRE-Processing Event'
-               ,'sp_patient_event'
-               ,'ERROR'
-               ,0
-               ,'Patient PRE-Processing Event'
-               ,0
-               ,LEFT(@user_id_list, 199)
-               ,@FullErrorMessage
-        );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Patient PRE-Processing Event',
+            @package_name = 'sp_patient_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Patient PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@user_id_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
@@ -17,26 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-                                                          ,[Msg_Description1]
-            )
-            VALUES (
-                     @batch_id
-                   ,'Observation PRE-Processing Event'
-                   ,'sp_observation_event'
-                   ,'START'
-                   ,0
-                   ,LEFT('Pre ID-' + @obs_id_list,199)
-                   ,0
-                   ,LEFT(@obs_id_list,199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Observation PRE-Processing Event',
+                @package_name = 'sp_observation_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @obs_id_list,199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@obs_id_list,199);
         END;
 
         SELECT
@@ -448,25 +437,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (     batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES (
-                     @batch_id
-                   , 'Observation PRE-Processing Event'
-                   , 'sp_observation_event'
-                   , 'COMPLETE'
-                   , 0
-                   , LEFT ('Pre ID-' + @obs_id_list, 199)
-                   , 0
-                   , LEFT (@obs_id_list, 199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Observation PRE-Processing Event',
+                @package_name = 'sp_observation_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT ('Pre ID-' + @obs_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT (@obs_id_list, 199);
         END;
 
     END TRY
@@ -483,27 +462,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        (      batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description])
-        VALUES (
-                 @batch_id
-               , 'Observation PRE-Processing Event'
-               , 'sp_observation_event'
-               , 'ERROR'
-               , 0
-               , 'Observation PRE-Processing Event'
-               , 0
-               , LEFT (@obs_id_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Observation PRE-Processing Event',
+            @package_name = 'sp_observation_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Observation PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT (@obs_id_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE [dbo].[sp_observation_event] @obs_id_list nvarchar(max)
+CREATE PROCEDURE [dbo].[sp_observation_event] @obs_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,26 +15,29 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) AS bigint);
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1]
-        )
-        VALUES (
-                 @batch_id
-               ,'Observation PRE-Processing Event'
-               ,'sp_observation_event'
-               ,'START'
-               ,0
-               ,LEFT('Pre ID-' + @obs_id_list,199)
-               ,0
-               ,LEFT(@obs_id_list,199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+                                                          ,[Msg_Description1]
+            )
+            VALUES (
+                     @batch_id
+                   ,'Observation PRE-Processing Event'
+                   ,'sp_observation_event'
+                   ,'START'
+                   ,0
+                   ,LEFT('Pre ID-' + @obs_id_list,199)
+                   ,0
+                   ,LEFT(@obs_id_list,199)
+                   );
+        END;
 
         SELECT
             act.act_uid,
@@ -443,25 +446,28 @@ BEGIN
 
         -- select * from dbo.Observation_Dim_Event;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (     batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES (
-                 @batch_id
-               , 'Observation PRE-Processing Event'
-               , 'sp_observation_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT ('Pre ID-' + @obs_id_list, 199)
-               , 0
-               , LEFT (@obs_id_list, 199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (     batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES (
+                     @batch_id
+                   , 'Observation PRE-Processing Event'
+                   , 'sp_observation_event'
+                   , 'COMPLETE'
+                   , 0
+                   , LEFT ('Pre ID-' + @obs_id_list, 199)
+                   , 0
+                   , LEFT (@obs_id_list, 199)
+                   );
+        END;
 
     END TRY
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/055-sp_observation_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @obs_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@obs_id_list, 199);
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) AS bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_observation_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @obs_id_list,199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@obs_id_list,199);
+                @msg_description1 = @job_flow_message;
         END;
 
         SELECT
@@ -443,9 +445,9 @@ BEGIN
                 @package_name = 'sp_observation_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT ('Pre ID-' + @obs_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT (@obs_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -470,7 +472,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Observation PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT (@obs_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
@@ -6,7 +6,7 @@ IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_investigat
     END
 GO
 
-CREATE PROCEDURE [dbo].[sp_investigation_event] @phc_id_list nvarchar(max)
+CREATE PROCEDURE [dbo].[sp_investigation_event] @phc_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,23 +15,26 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Investigation PRE-Processing Event'
-               , 'sp_investigation_event'
-               , 'START'
-               , 0
-               , LEFT('Pre ID-' + @phc_id_list, 199)
-               , 0
-               , LEFT(@phc_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Investigation PRE-Processing Event'
+                   , 'sp_investigation_event'
+                   , 'START'
+                   , 0
+                   , LEFT('Pre ID-' + @phc_id_list, 199)
+                   , 0
+                   , LEFT(@phc_id_list, 199));
+        END;
 
         /*Complete Investigation section*/
          SELECT results.public_health_case_uid,
@@ -1029,23 +1032,26 @@ BEGIN
 
         -- select * from dbo.Investigation_Dim_Event;
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Investigation PRE-Processing Event'
-               , 'sp_investigation_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT('Pre ID-' + @phc_id_list, 199)
-               , 0
-               , LEFT(@phc_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Investigation PRE-Processing Event'
+                   , 'sp_investigation_event'
+                   , 'COMPLETE'
+                   , 0
+                   , LEFT('Pre ID-' + @phc_id_list, 199)
+                   , 0
+                   , LEFT(@phc_id_list, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
@@ -17,23 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Investigation PRE-Processing Event'
-                   , 'sp_investigation_event'
-                   , 'START'
-                   , 0
-                   , LEFT('Pre ID-' + @phc_id_list, 199)
-                   , 0
-                   , LEFT(@phc_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Investigation PRE-Processing Event',
+                @package_name = 'sp_investigation_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @phc_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@phc_id_list, 199);
         END;
 
         /*Complete Investigation section*/
@@ -1034,23 +1026,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Investigation PRE-Processing Event'
-                   , 'sp_investigation_event'
-                   , 'COMPLETE'
-                   , 0
-                   , LEFT('Pre ID-' + @phc_id_list, 199)
-                   , 0
-                   , LEFT(@phc_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Investigation PRE-Processing Event',
+                @package_name = 'sp_investigation_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @phc_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@phc_id_list, 199);
         END;
 
     END TRY
@@ -1067,27 +1051,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , 'Investigation PRE-Processing Event'
-               , 'sp_investigation_event'
-               , 'ERROR'
-               , 0
-               , 'Investigation PRE-Processing Event'
-               , 0
-               , LEFT(@phc_id_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Investigation PRE-Processing Event',
+            @package_name = 'sp_investigation_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Investigation PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@phc_id_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/056-sp_investigation_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @phc_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@phc_id_list, 199);
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_investigation_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @phc_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@phc_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         /*Complete Investigation section*/
@@ -1032,9 +1034,9 @@ BEGIN
                 @package_name = 'sp_investigation_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @phc_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@phc_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -1059,7 +1061,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Investigation PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@phc_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
         /*select * from dbo.v_ldf_provider ldf
@@ -90,23 +82,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
     end try
@@ -123,27 +107,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_provider_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_provider_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_provider PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_provider_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
         /*select * from dbo.v_ldf_provider ldf
          WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -85,23 +88,26 @@ Begin
             and p.cd='PRV'
         Order By business_object_uid, display_order_nbr ;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
     end try
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/057-sp_ldf_provider_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_provider PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_provider_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         /*select * from dbo.v_ldf_provider ldf
@@ -88,9 +90,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     end try
@@ -115,7 +117,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
         /*
         select * from dbo.v_ldf_organization ldf
@@ -91,23 +83,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
     end try
 
@@ -123,27 +107,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_organization_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_organization_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_organization PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_organization_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
         /*
         select * from dbo.v_ldf_organization ldf
          WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -86,23 +89,26 @@ Begin
                   join nbs_odse.dbo.Organization o with (nolock) on d.business_object_uid=o.organization_uid
         Order By business_object_uid, display_order_nbr;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
     end try
 
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/058-sp_ldf_organization_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_organization PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_organization_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
         /*
         select * from dbo.v_ldf_organization ldf
@@ -89,9 +91,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
     end try
 
@@ -115,7 +117,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
         /*select * from dbo.v_ldf_patient ldf
@@ -91,23 +83,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
     end try
 
@@ -123,27 +107,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_patient PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_patient_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         /*select * from dbo.v_ldf_patient ldf
@@ -89,9 +91,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
     end try
 
@@ -115,7 +117,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/059-sp_ldf_patient_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_patient_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_patient_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_patient PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_patient_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
         /*select * from dbo.v_ldf_patient ldf
          WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -86,23 +89,26 @@ Begin
             and p.cd='PAT'
         Order By business_object_uid, display_order_nbr ;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
     end try
 
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_observation PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_observation_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         /* select * from dbo.v_ldf_observation ldf
@@ -90,9 +92,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
     end try
 
@@ -116,7 +118,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_observation_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_observation_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_observation PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_observation_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
         /* select * from dbo.v_ldf_observation ldf
           WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -87,23 +90,26 @@ Begin
 
         Order By business_object_uid, display_order_nbr ;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
     end try
 
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/060-sp_ldf_observation_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
         /* select * from dbo.v_ldf_observation ldf
@@ -92,23 +84,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
     end try
 
@@ -124,27 +108,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_phc PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_phc_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
         /*
         select * from dbo.v_ldf_phc ldf
@@ -91,9 +93,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     end try
@@ -118,7 +120,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_phc_event  @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_phc_event  @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_phc PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_phc_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
         /*
         select * from dbo.v_ldf_phc ldf
          WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -88,23 +91,26 @@ Begin
 
         Order By business_object_uid, display_order_nbr;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
     end try
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/061-sp_ldf_phc_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
         /*
         select * from dbo.v_ldf_phc ldf
@@ -93,23 +85,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
     end try
@@ -126,27 +110,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
@@ -17,23 +17,15 @@ Begin
         
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
         /*select * from dbo.v_ldf_intervention ldf
@@ -91,23 +83,15 @@ Begin
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
         END;
 
     end try
@@ -124,27 +108,16 @@ Begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
@@ -14,6 +14,8 @@ Begin
 
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_intervention PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_intervention_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
         IF @debug_logging = 1
         BEGIN
@@ -23,9 +25,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         /*select * from dbo.v_ldf_intervention ldf
@@ -89,9 +91,9 @@ Begin
                 @package_name = @package_name,
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     end try
@@ -116,7 +118,7 @@ Begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/062-sp_ldf_intervention_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_intervention_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT
+CREATE PROCEDURE dbo.sp_ldf_intervention_event @ldf_uid_list nvarchar(max), @bus_obj_uid_list nvarchar(max), @batch_id BIGINT, @debug_logging bit = 0
 AS
 Begin
 
@@ -15,23 +15,26 @@ Begin
         DECLARE @dataflow_name NVARCHAR(200) = 'ldf_intervention PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_intervention_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
         /*select * from dbo.v_ldf_intervention ldf
          WHERE ldf.ldf_uid in (SELECT value FROM STRING_SPLIT(@ldf_uid_list, ','))
@@ -86,23 +89,26 @@ Begin
 
         Order By business_object_uid, display_order_nbr;
 
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+        END;
 
     end try
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_ldf_data_event @bus_obj_nm varchar(20), @ldf_uid nvarchar(max),  @bus_obj_uid_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_ldf_data_event @bus_obj_nm varchar(20), @ldf_uid nvarchar(max),  @bus_obj_uid_list nvarchar(max), @debug_logging bit = 0
 AS 
 begin
 	 begin try
@@ -16,51 +16,101 @@ begin
 		DECLARE @dataflow_name NVARCHAR(200) = 'ldf_data PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_data_event';
         
-        INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'START'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+		IF @debug_logging = 1
+		BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'START'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+		END;
 
-			if @bus_obj_nm = 'PAT'  exec dbo.sp_ldf_patient_event @ldf_uid, @bus_obj_uid_list, @batch_id
-			else if @bus_obj_nm = 'PRV'  exec dbo.sp_ldf_provider_event @ldf_uid , @bus_obj_uid_list, @batch_id 
-			else if  @bus_obj_nm = 'ORG'  exec dbo.sp_ldf_organization_event @ldf_uid, @bus_obj_uid_list, @batch_id 
-			else if  @bus_obj_nm = 'LAB'  exec dbo.sp_ldf_observation_event @ldf_uid, @bus_obj_uid_list, @batch_id 
-			else if  @bus_obj_nm = 'PHC'  exec dbo.sp_ldf_phc_event @ldf_uid, @bus_obj_uid_list, @batch_id 
-			else if  @bus_obj_nm = 'BMD'  exec dbo.sp_ldf_phc_event @ldf_uid, @bus_obj_uid_list, @batch_id
-			else if  @bus_obj_nm = 'HEP'  exec dbo.sp_ldf_phc_event @ldf_uid, @bus_obj_uid_list, @batch_id
-			else if  @bus_obj_nm = 'NIP'  exec dbo.sp_ldf_phc_event @ldf_uid, @bus_obj_uid_list, @batch_id
-			else if  @bus_obj_nm = 'VAC'  exec dbo.sp_ldf_intervention_event @ldf_uid, @bus_obj_uid_list, @batch_id 
-		
-		INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                , @dataflow_name
-                , @package_name
-                , 'COMPLETE'
-                , 0
-                , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                , 0
-                , LEFT(@bus_obj_uid_list, 199));
+			if @bus_obj_nm = 'PAT'
+				exec dbo.sp_ldf_patient_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'PRV'
+				exec dbo.sp_ldf_provider_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'ORG'
+				exec dbo.sp_ldf_organization_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'LAB'
+				exec dbo.sp_ldf_observation_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'PHC'
+				exec dbo.sp_ldf_phc_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'BMD'
+				exec dbo.sp_ldf_phc_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'HEP'
+				exec dbo.sp_ldf_phc_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'NIP'
+				exec dbo.sp_ldf_phc_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+			else if @bus_obj_nm = 'VAC'
+				exec dbo.sp_ldf_intervention_event
+					@ldf_uid_list = @ldf_uid,
+					@bus_obj_uid_list = @bus_obj_uid_list,
+					@batch_id = @batch_id,
+					@debug_logging = @debug_logging;
+		IF @debug_logging = 1
+		BEGIN
+    		INSERT INTO [dbo].[job_flow_log]
+                ( batch_id
+                , [Dataflow_Name]
+                , [package_Name]
+                , [Status_Type]
+                , [step_number]
+                , [step_name]
+                , [row_count]
+                , [Msg_Description1])
+                VALUES ( @batch_id
+                    , @dataflow_name
+                    , @package_name
+                    , 'COMPLETE'
+                    , 0
+                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
+                    , 0
+                    , LEFT(@bus_obj_uid_list, 199));
+		END;
 
 	end try
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
@@ -18,23 +18,15 @@ begin
         
 		IF @debug_logging = 1
 		BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'START'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @dataflow_name,
+                @package_name = @package_name,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
 		END;
 
 			if @bus_obj_nm = 'PAT'
@@ -93,23 +85,15 @@ begin
 					@debug_logging = @debug_logging;
 		IF @debug_logging = 1
 		BEGIN
-    		INSERT INTO [dbo].[job_flow_log]
-                ( batch_id
-                , [Dataflow_Name]
-                , [package_Name]
-                , [Status_Type]
-                , [step_number]
-                , [step_name]
-                , [row_count]
-                , [Msg_Description1])
-                VALUES ( @batch_id
-                    , @dataflow_name
-                    , @package_name
-                    , 'COMPLETE'
-                    , 0
-                    , LEFT('Pre ID-' + @bus_obj_uid_list, 199)
-                    , 0
-                    , LEFT(@bus_obj_uid_list, 199));
+			EXEC dbo.sp_add_job_flow_log
+			    @batch_id = @batch_id,
+			    @dataflow_name = @dataflow_name,
+			    @package_name = @package_name,
+			    @status_type = 'COMPLETE',
+			    @step_number = 0,
+			    @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+			    @row_count = 0,
+			    @msg_description1 = LEFT(@bus_obj_uid_list, 199);
 		END;
 
 	end try
@@ -125,27 +109,16 @@ begin
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , @dataflow_name
-               , @package_name
-               , 'ERROR'
-               , 0
-               , @dataflow_name
-               , 0
-               , LEFT(@bus_obj_uid_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @dataflow_name,
+            @package_name = @package_name,
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = @dataflow_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/063-sp_ldf_data_event-001.sql
@@ -15,6 +15,8 @@ begin
 		SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 		DECLARE @dataflow_name NVARCHAR(200) = 'ldf_data PRE-Processing Event';
         DECLARE @package_name NVARCHAR(200) = 'sp_ldf_data_event';
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @bus_obj_uid_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@bus_obj_uid_list, 199);
         
 		IF @debug_logging = 1
 		BEGIN
@@ -24,9 +26,9 @@ begin
                 @package_name = @package_name,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+                @msg_description1 = @job_flow_message;
 		END;
 
 			if @bus_obj_nm = 'PAT'
@@ -91,9 +93,9 @@ begin
 			    @package_name = @package_name,
 			    @status_type = 'COMPLETE',
 			    @step_number = 0,
-			    @step_name = LEFT('Pre ID-' + @bus_obj_uid_list, 199),
+			    @step_name = @job_flow_step_name,
 			    @row_count = 0,
-			    @msg_description1 = LEFT(@bus_obj_uid_list, 199);
+			    @msg_description1 = @job_flow_message;
 		END;
 
 	end try
@@ -117,7 +119,7 @@ begin
             @step_number = 0,
             @step_name = @dataflow_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@bus_obj_uid_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         return @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
@@ -13,7 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
-
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @notification_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@notification_list, 199);
 
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         IF @debug_logging = 1
@@ -24,9 +25,9 @@ BEGIN
                 @package_name = 'sp_notification_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT ('Pre ID-' + @notification_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT (@notification_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
 
@@ -217,9 +218,9 @@ BEGIN
                 @package_name = 'sp_notification_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT ('Pre ID-' + @notification_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT (@notification_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -246,7 +247,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Notification PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT (@notification_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
@@ -18,25 +18,15 @@ BEGIN
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES (
-                     @batch_id
-                   , 'Notification PRE-Processing Event'
-                   , 'sp_notification_event'
-                   , 'START'
-                   , 0
-                   , LEFT ('Pre ID-' + @notification_list, 199)
-                   , 0
-                   , LEFT (@notification_list, 199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Notification PRE-Processing Event',
+                @package_name = 'sp_notification_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT ('Pre ID-' + @notification_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT (@notification_list, 199);
         END;
 
 
@@ -221,25 +211,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (      batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES (
-                     @batch_id
-                   , 'Notification PRE-Processing Event'
-                   , 'sp_notification_event'
-                   , 'COMPLETE'
-                   , 0
-                   , LEFT ('Pre ID-' + @notification_list, 199)
-                   , 0
-                   , LEFT (@notification_list, 199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Notification PRE-Processing Event',
+                @package_name = 'sp_notification_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT ('Pre ID-' + @notification_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT (@notification_list, 199);
         END;
 
     END TRY
@@ -258,27 +238,16 @@ BEGIN
             'Error Message: ' + ERROR_MESSAGE();
 
 
-        INSERT INTO [dbo].[job_flow_log]
-        (      batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description])
-        VALUES (
-                 @batch_id
-               , 'Notification PRE-Processing Event'
-               , 'sp_notification_event'
-               , 'ERROR'
-               , 0
-               , 'Notification PRE-Processing Event'
-               , 0
-               , LEFT (@notification_list, 199)
-               , @FullErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Notification PRE-Processing Event',
+            @package_name = 'sp_notification_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Notification PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT (@notification_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/064-sp_notification_event-001.sql
@@ -6,7 +6,7 @@ IF EXISTS (SELECT * FROM sysobjects WHERE  id = object_id(N'[dbo].[sp_notificati
     END
 GO
 
-CREATE PROCEDURE [dbo].[sp_notification_event] @notification_list nvarchar(max)
+CREATE PROCEDURE [dbo].[sp_notification_event] @notification_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -16,25 +16,28 @@ BEGIN
 
 
         SET @batch_id = cast((format(getdate(),'yyMMddHHmmssffff')) as bigint);
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES (
-                 @batch_id
-               , 'Notification PRE-Processing Event'
-               , 'sp_notification_event'
-               , 'START'
-               , 0
-               , LEFT ('Pre ID-' + @notification_list, 199)
-               , 0
-               , LEFT (@notification_list, 199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES (
+                     @batch_id
+                   , 'Notification PRE-Processing Event'
+                   , 'sp_notification_event'
+                   , 'START'
+                   , 0
+                   , LEFT ('Pre ID-' + @notification_list, 199)
+                   , 0
+                   , LEFT (@notification_list, 199)
+                   );
+        END;
 
 
         --Payload structure
@@ -216,25 +219,28 @@ BEGIN
 
 
 
-        INSERT INTO [dbo].[job_flow_log]
-        (      batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES (
-                 @batch_id
-               , 'Notification PRE-Processing Event'
-               , 'sp_notification_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT ('Pre ID-' + @notification_list, 199)
-               , 0
-               , LEFT (@notification_list, 199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (      batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES (
+                     @batch_id
+                   , 'Notification PRE-Processing Event'
+                   , 'sp_notification_event'
+                   , 'COMPLETE'
+                   , 0
+                   , LEFT ('Pre ID-' + @notification_list, 199)
+                   , 0
+                   , LEFT (@notification_list, 199)
+                   );
+        END;
 
     END TRY
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
@@ -23,6 +23,8 @@ BEGIN
         DECLARE @batch_id BIGINT;
 
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @ix_uids, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@ix_uids, 199);
 
         IF @debug_logging = 1
         BEGIN
@@ -32,9 +34,9 @@ BEGIN
                 @package_name = 'sp_interview_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @ix_uids, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@ix_uids, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         BEGIN
@@ -1443,9 +1445,9 @@ BEGIN
                 @package_name = 'sp_interview_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @ix_uids, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@ix_uids, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -1469,7 +1471,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Interview PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@ix_uids, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
@@ -26,23 +26,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Interview PRE-Processing Event'
-                   , 'sp_interview_event'
-                   , 'START'
-                   , 0
-                   , LEFT('Pre ID-' + @ix_uids, 199)
-                   , 0
-                   , LEFT(@ix_uids, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'sp_interview_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @ix_uids, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@ix_uids, 199);
         END;
 
         BEGIN
@@ -108,10 +100,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -189,10 +185,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -236,10 +236,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -282,10 +286,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -349,10 +357,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -392,10 +404,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -441,10 +457,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -491,10 +511,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -540,10 +564,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -594,10 +622,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -638,10 +670,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -676,10 +712,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -728,10 +768,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -785,10 +829,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -848,10 +896,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -891,10 +943,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -935,10 +991,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
         COMMIT TRANSACTION;
@@ -985,10 +1045,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
         COMMIT TRANSACTION;
@@ -1021,10 +1085,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
         COMMIT TRANSACTION;
@@ -1073,10 +1141,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1125,10 +1197,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1162,10 +1238,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1214,10 +1294,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1263,10 +1347,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1333,10 +1421,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                    @RowCount_no);
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'nrt_interview',
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
 
 
@@ -1345,23 +1437,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Interview PRE-Processing Event'
-                   , 'sp_interview_event'
-                   , 'COMPLETE'
-                   , 0
-                   , LEFT('Pre ID-' + @ix_uids, 199)
-                   , 0
-                   , LEFT(@ix_uids, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Interview PRE-Processing Event',
+                @package_name = 'sp_interview_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @ix_uids, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@ix_uids, 199);
         END;
 
     END TRY
@@ -1377,27 +1461,16 @@ BEGIN
         'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
         'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description]
-        )
-        VALUES ( @batch_id
-               , 'Interview PRE-Processing Event'
-               , 'sp_interview_event'
-               , 'ERROR'
-               , 0
-               , 'Interview PRE-Processing Event'
-               , 0
-               , LEFT(@ix_uids, 199)
-               , @FullErrorMessage
-        );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Interview PRE-Processing Event',
+            @package_name = 'sp_interview_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Interview PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@ix_uids, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/065-sp_interview_event-001.sql
@@ -7,7 +7,7 @@ END
 GO 
 
 CREATE PROCEDURE [dbo].[sp_interview_event] @ix_uids nvarchar(max),
-                                                     @debug bit = 'false'
+                                                     @debug bit = 0, @debug_logging bit = 0
 AS
 BEGIN
 
@@ -24,23 +24,26 @@ BEGIN
 
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Interview PRE-Processing Event'
-               , 'sp_interview_event'
-               , 'START'
-               , 0
-               , LEFT('Pre ID-' + @ix_uids, 199)
-               , 0
-               , LEFT(@ix_uids, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Interview PRE-Processing Event'
+                   , 'sp_interview_event'
+                   , 'START'
+                   , 0
+                   , LEFT('Pre ID-' + @ix_uids, 199)
+                   , 0
+                   , LEFT(@ix_uids, 199));
+        END;
 
         BEGIN
             TRANSACTION;
@@ -103,10 +106,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -181,10 +187,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -225,10 +234,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -268,10 +280,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -332,10 +347,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -372,10 +390,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -418,10 +439,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -465,10 +489,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -511,10 +538,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -562,10 +592,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -603,10 +636,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -638,10 +674,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -687,10 +726,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -741,10 +783,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -801,10 +846,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -841,10 +889,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -882,10 +933,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
         COMMIT TRANSACTION;
 
@@ -929,10 +983,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
         COMMIT TRANSACTION;
 
@@ -962,10 +1019,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1011,10 +1071,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -1060,10 +1123,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -1094,10 +1160,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -1143,10 +1212,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -1189,10 +1261,13 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
@@ -1256,32 +1331,38 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (@batch_id, 'Interview PRE-Processing Event', 'nrt_interview', 'START', @Proc_Step_no, @Proc_Step_Name,
+                    @RowCount_no);
+        END;
 
 
         COMMIT TRANSACTION;
 
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Interview PRE-Processing Event'
-               , 'sp_interview_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT('Pre ID-' + @ix_uids, 199)
-               , 0
-               , LEFT(@ix_uids, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Interview PRE-Processing Event'
+                   , 'sp_interview_event'
+                   , 'COMPLETE'
+                   , 0
+                   , LEFT('Pre ID-' + @ix_uids, 199)
+                   , 0
+                   , LEFT(@ix_uids, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
@@ -17,23 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Auth_User PRE-Processing Event'
-                   , 'sp_auth_user_event'
-                   , 'START'
-                   , 0
-                   , LEFT('Pre ID-' + @user_id_list, 199)
-                   , 0
-                   , LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Auth_User PRE-Processing Event',
+                @package_name = 'sp_auth_user_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
         SELECT a.auth_user_uid,
@@ -53,22 +45,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] ( batch_id
-                                                          , [Dataflow_Name]
-                                                          , [package_Name]
-                                                          , [Status_Type]
-                                                          , [step_number]
-                                                          , [step_name]
-                                                          , [row_count]
-                                                          , [Msg_Description1])
-            VALUES ( @batch_id
-                   , 'Auth_User PRE-Processing Event'
-                   , 'sp_auth_user_event'
-                   , 'COMPLETE'
-                   , 0
-                   , LEFT('Pre ID-' + @user_id_list, 199)
-                   , 0
-                   , LEFT(@user_id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Auth_User PRE-Processing Event',
+                @package_name = 'sp_auth_user_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@user_id_list, 199);
         END;
 
     END TRY
@@ -84,27 +69,16 @@ BEGIN
         'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
         'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log] ( batch_id
-                                                      , [Dataflow_Name]
-                                                      , [package_Name]
-                                                      , [Status_Type]
-                                                      , [step_number]
-                                                      , [step_name]
-                                                      , [row_count]
-                                                      , [Msg_Description1]
-                                                        ,[Error_Description]
-                                                        )
-
-        VALUES ( @batch_id
-               , 'Auth_user PRE-Processing Event'
-               , 'sp_auth_user_event'
-               , 'ERROR'
-               , 0
-               , 'Auth_user PRE-Processing Event'
-               , 0
-               , LEFT(@user_id_list, 199)
-                ,@FullErrorMessage
-            );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Auth_user PRE-Processing Event',
+            @package_name = 'sp_auth_user_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Auth_user PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@user_id_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_auth_user_event @user_id_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_auth_user_event @user_id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,23 +15,26 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Auth_User PRE-Processing Event'
-               , 'sp_auth_user_event'
-               , 'START'
-               , 0
-               , LEFT('Pre ID-' + @user_id_list, 199)
-               , 0
-               , LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Auth_User PRE-Processing Event'
+                   , 'sp_auth_user_event'
+                   , 'START'
+                   , 0
+                   , LEFT('Pre ID-' + @user_id_list, 199)
+                   , 0
+                   , LEFT(@user_id_list, 199));
+        END;
 
         SELECT a.auth_user_uid,
                a.user_id,
@@ -48,22 +51,25 @@ BEGIN
         FROM nbs_odse.dbo.Auth_user a WITH (NOLOCK)
         WHERE a.auth_user_uid in (SELECT value FROM STRING_SPLIT(@user_id_list, ','));
 
-        INSERT INTO [dbo].[job_flow_log] ( batch_id
-                                                      , [Dataflow_Name]
-                                                      , [package_Name]
-                                                      , [Status_Type]
-                                                      , [step_number]
-                                                      , [step_name]
-                                                      , [row_count]
-                                                      , [Msg_Description1])
-        VALUES ( @batch_id
-               , 'Auth_User PRE-Processing Event'
-               , 'sp_auth_user_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT('Pre ID-' + @user_id_list, 199)
-               , 0
-               , LEFT(@user_id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] ( batch_id
+                                                          , [Dataflow_Name]
+                                                          , [package_Name]
+                                                          , [Status_Type]
+                                                          , [step_number]
+                                                          , [step_name]
+                                                          , [row_count]
+                                                          , [Msg_Description1])
+            VALUES ( @batch_id
+                   , 'Auth_User PRE-Processing Event'
+                   , 'sp_auth_user_event'
+                   , 'COMPLETE'
+                   , 0
+                   , LEFT('Pre ID-' + @user_id_list, 199)
+                   , 0
+                   , LEFT(@user_id_list, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/067-sp_auth_user_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @user_id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@user_id_list, 199);
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_auth_user_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         SELECT a.auth_user_uid,
@@ -51,9 +53,9 @@ BEGIN
                 @package_name = 'sp_auth_user_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @user_id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@user_id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -77,7 +79,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Auth_user PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@user_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
@@ -17,23 +17,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id
-            ,[Dataflow_Name]
-            ,[package_Name]
-            ,[Status_Type]
-            ,[step_number]
-            ,[step_name]
-            ,[row_count]
-            ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Place PRE-Processing Event'
-                   ,'sp_place_event'
-                   ,'START'
-                   ,0
-                   ,LEFT('Pre ID-' + @id_list, 199)
-                   ,0
-                   ,LEFT(@id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Place PRE-Processing Event',
+                @package_name = 'sp_place_event',
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@id_list, 199);
         END;
 
 
@@ -127,22 +119,15 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-                                                          ,[Msg_Description1])
-            VALUES (@batch_id
-                   ,'Place PRE-Processing Event'
-                   ,'sp_place_event'
-                   ,'COMPLETE'
-                   ,0
-                   ,LEFT('Pre ID-' + @id_list, 199)
-                   ,0
-                   ,LEFT(@id_list, 199));
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'Place PRE-Processing Event',
+                @package_name = 'sp_place_event',
+                @status_type = 'COMPLETE',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @id_list, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@id_list, 199);
         END;
 
     END TRY
@@ -158,25 +143,16 @@ BEGIN
         'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
         'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1]
-                                                    ,[Error_Description])
-        VALUES (@batch_id
-               ,'Place PRE-Processing Event'
-               ,'sp_place_event'
-               ,'ERROR'
-               ,0
-               ,'Place PRE-Processing Event'
-               ,0
-               ,LEFT(@id_list, 199)
-                , @FullErrorMessage
-            );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'Place PRE-Processing Event',
+            @package_name = 'sp_place_event',
+            @status_type = 'ERROR',
+            @step_number = 0,
+            @step_name = 'Place PRE-Processing Event',
+            @row_count = 0,
+            @msg_description1 = LEFT(@id_list, 199),
+            @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_place_event @id_list nvarchar(max)
+CREATE PROCEDURE dbo.sp_place_event @id_list nvarchar(max), @debug_logging bit = 0
 AS
 BEGIN
 
@@ -15,23 +15,26 @@ BEGIN
         DECLARE @batch_id BIGINT;
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id
-        ,[Dataflow_Name]
-        ,[package_Name]
-        ,[Status_Type]
-        ,[step_number]
-        ,[step_name]
-        ,[row_count]
-        ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Place PRE-Processing Event'
-               ,'sp_place_event'
-               ,'START'
-               ,0
-               ,LEFT('Pre ID-' + @id_list, 199)
-               ,0
-               ,LEFT(@id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id
+            ,[Dataflow_Name]
+            ,[package_Name]
+            ,[Status_Type]
+            ,[step_number]
+            ,[step_name]
+            ,[row_count]
+            ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Place PRE-Processing Event'
+                   ,'sp_place_event'
+                   ,'START'
+                   ,0
+                   ,LEFT('Pre ID-' + @id_list, 199)
+                   ,0
+                   ,LEFT(@id_list, 199));
+        END;
 
 
         SELECT
@@ -122,22 +125,25 @@ BEGIN
                                            FOR json path, INCLUDE_NULL_VALUES) AS tele) AS tele) AS nested
         WHERE p.place_uid in (SELECT value FROM STRING_SPLIT(@id_list, ','));
 
-        INSERT INTO [dbo].[job_flow_log] (batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1])
-        VALUES (@batch_id
-               ,'Place PRE-Processing Event'
-               ,'sp_place_event'
-               ,'COMPLETE'
-               ,0
-               ,LEFT('Pre ID-' + @id_list, 199)
-               ,0
-               ,LEFT(@id_list, 199));
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+                                                          ,[Msg_Description1])
+            VALUES (@batch_id
+                   ,'Place PRE-Processing Event'
+                   ,'sp_place_event'
+                   ,'COMPLETE'
+                   ,0
+                   ,LEFT('Pre ID-' + @id_list, 199)
+                   ,0
+                   ,LEFT(@id_list, 199));
+        END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/068-sp_place_event-001.sql
@@ -13,6 +13,8 @@ BEGIN
     BEGIN TRY
 
         DECLARE @batch_id BIGINT;
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @id_list, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@id_list, 199);
         SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
 
         IF @debug_logging = 1
@@ -23,9 +25,9 @@ BEGIN
                 @package_name = 'sp_place_event',
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
 
@@ -125,9 +127,9 @@ BEGIN
                 @package_name = 'sp_place_event',
                 @status_type = 'COMPLETE',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @id_list, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@id_list, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
     END TRY
@@ -151,7 +153,7 @@ BEGIN
             @step_number = 0,
             @step_name = 'Place PRE-Processing Event',
             @row_count = 0,
-            @msg_description1 = LEFT(@id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return @FullErrorMessage;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
@@ -34,23 +34,15 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , @Dataflow_Name
-               , @Package_Name
-               , 'START'
-               , 0
-               , LEFT('Pre ID-' + @cc_uids, 199)
-               , 0
-               , LEFT(@cc_uids, 199));
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = 0,
+            @step_name = LEFT('Pre ID-' + @cc_uids, 199),
+            @row_count = 0,
+            @msg_description1 = LEFT(@cc_uids, 199);
     END;
 
     BEGIN TRANSACTION;
@@ -171,10 +163,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -257,10 +253,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -304,10 +304,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -350,10 +354,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -417,10 +425,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -460,10 +472,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -508,10 +524,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -558,10 +578,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -608,10 +632,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -669,10 +697,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -713,10 +745,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -749,10 +785,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -797,10 +837,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -852,10 +896,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -914,10 +962,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -956,10 +1008,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -999,10 +1055,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -1048,10 +1108,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -1083,10 +1147,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -1138,10 +1206,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1196,10 +1268,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1242,10 +1318,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1352,10 +1432,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1364,23 +1448,15 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , @Dataflow_Name
-               , @Package_Name
-               , 'COMPLETE'
-               , 0
-               , LEFT('Pre ID-' + @cc_uids, 199)
-               , 0
-               , LEFT(@cc_uids, 199));
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'COMPLETE',
+            @step_number = 0,
+            @step_name = LEFT('Pre ID-' + @cc_uids, 199),
+            @row_count = 0,
+            @msg_description1 = LEFT(@cc_uids, 199);
     END;
 
     END TRY
@@ -1396,26 +1472,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1]
-        , [Error_Description])
-        VALUES ( @batch_id
-               , @Dataflow_Name
-               , @Package_Name
-               , 'ERROR'
-               , @Proc_Step_no
-               , @Proc_Step_Name
-               , 0
-               , LEFT(@cc_uids, 199)
-               ,@FullErrorMessage
-        );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'ERROR',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@cc_uids, 199),
+            @error_description = @FullErrorMessage;
         return -1;
 
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
@@ -7,7 +7,7 @@ END
 GO
 
 CREATE PROCEDURE [dbo].[sp_contact_record_event] @cc_uids nvarchar(max),
-                                                     @debug bit = 'false'
+                                                     @debug bit = 0, @debug_logging bit = 0
 AS
 BEGIN
 
@@ -32,23 +32,26 @@ BEGIN
             @debug = 'true'
             select @batch_id as Batch_id;
 
-    INSERT INTO [dbo].[job_flow_log]
-    ( batch_id
-    , [Dataflow_Name]
-    , [package_Name]
-    , [Status_Type]
-    , [step_number]
-    , [step_name]
-    , [row_count]
-    , [Msg_Description1])
-    VALUES ( @batch_id
-           , @Dataflow_Name
-           , @Package_Name
-           , 'START'
-           , 0
-           , LEFT('Pre ID-' + @cc_uids, 199)
-           , 0
-           , LEFT(@cc_uids, 199));
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        ( batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES ( @batch_id
+               , @Dataflow_Name
+               , @Package_Name
+               , 'START'
+               , 0
+               , LEFT('Pre ID-' + @cc_uids, 199)
+               , 0
+               , LEFT(@cc_uids, 199));
+    END;
 
     BEGIN TRANSACTION;
     SET
@@ -166,10 +169,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -249,10 +255,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -293,10 +302,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -336,10 +348,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -400,10 +415,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -440,10 +458,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -485,10 +506,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -532,10 +556,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -579,10 +606,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -637,10 +667,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -678,10 +711,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -711,10 +747,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -756,10 +795,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -808,10 +850,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -867,10 +912,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -906,10 +954,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -946,10 +997,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -992,10 +1046,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -1024,10 +1081,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -1076,10 +1136,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1131,10 +1194,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1174,10 +1240,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1281,32 +1350,38 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
 
 
-    INSERT INTO [dbo].[job_flow_log]
-    ( batch_id
-    , [Dataflow_Name]
-    , [package_Name]
-    , [Status_Type]
-    , [step_number]
-    , [step_name]
-    , [row_count]
-    , [Msg_Description1])
-    VALUES ( @batch_id
-           , @Dataflow_Name
-           , @Package_Name
-           , 'COMPLETE'
-           , 0
-           , LEFT('Pre ID-' + @cc_uids, 199)
-           , 0
-           , LEFT(@cc_uids, 199));
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        ( batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES ( @batch_id
+               , @Dataflow_Name
+               , @Package_Name
+               , 'COMPLETE'
+               , 0
+               , LEFT('Pre ID-' + @cc_uids, 199)
+               , 0
+               , LEFT(@cc_uids, 199));
+    END;
 
     END TRY
     BEGIN CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/069-sp_contact_record_event-001.sql
@@ -27,6 +27,8 @@ BEGIN
     DECLARE @batch_id BIGINT;
 
     SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
+    DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @cc_uids, 199);
+    DECLARE @job_flow_message VARCHAR(200) = LEFT(@cc_uids, 199);
 
     if
             @debug = 'true'
@@ -40,9 +42,9 @@ BEGIN
             @package_name = @Package_Name,
             @status_type = 'START',
             @step_number = 0,
-            @step_name = LEFT('Pre ID-' + @cc_uids, 199),
+            @step_name = @job_flow_step_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@cc_uids, 199);
+            @msg_description1 = @job_flow_message;
     END;
 
     BEGIN TRANSACTION;
@@ -1454,9 +1456,9 @@ BEGIN
             @package_name = @Package_Name,
             @status_type = 'COMPLETE',
             @step_number = 0,
-            @step_name = LEFT('Pre ID-' + @cc_uids, 199),
+            @step_name = @job_flow_step_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@cc_uids, 199);
+            @msg_description1 = @job_flow_message;
     END;
 
     END TRY
@@ -1480,7 +1482,7 @@ BEGIN
             @step_number = @Proc_Step_no,
             @step_name = @Proc_Step_Name,
             @row_count = 0,
-            @msg_description1 = LEFT(@cc_uids, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
         return -1;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
@@ -25,25 +25,15 @@ BEGIN
         -- Initial log entry
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count]
-            , [Msg_Description1])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'START',
-                       0,
-                       LEFT('Pre ID-' + @treatment_uids, 199),
-                       0,
-                       LEFT(@treatment_uids, 199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'START',
+                @step_number = 0,
+                @step_name = LEFT('Pre ID-' + @treatment_uids, 199),
+                @row_count = 0,
+                @msg_description1 = LEFT(@treatment_uids, 199);
         END;
 
         -- STEP 1: Get base UIDs
@@ -96,23 +86,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'START',
-                       @Proc_Step_no,
-                       @Proc_Step_Name,
-                       @RowCount_no
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
         COMMIT TRANSACTION;
 
@@ -140,23 +121,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            ( batch_id
-            , [Dataflow_Name]
-            , [package_Name]
-            , [Status_Type]
-            , [step_number]
-            , [step_name]
-            , [row_count])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'START',
-                       @Proc_Step_no,
-                       @Proc_Step_Name,
-                       @RowCount_no
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
         COMMIT TRANSACTION;
 
@@ -207,17 +179,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'START',
-                       @Proc_Step_no,
-                       @Proc_Step_Name,
-                       @RowCount_no
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
         COMMIT TRANSACTION;
 
@@ -262,35 +231,29 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'START',
-                       @Proc_Step_no,
-                       @Proc_Step_Name,
-                       @RowCount_no
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'START',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @RowCount_no;
         END;
         COMMIT TRANSACTION;
 
         -- Log successful completion
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log]
-            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count],[Msg_Description1])
-            VALUES (
-                       @batch_id,
-                       @DATAFLOW_NAME,
-                       @PACKAGE_NAME,
-                       'COMPLETE',
-                       @PROC_STEP_NO,
-                       @Proc_Step_Name,
-                       0,
-                       LEFT(@treatment_uids, 199)
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = @DATAFLOW_NAME,
+                @package_name = @PACKAGE_NAME,
+                @status_type = 'COMPLETE',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @Proc_Step_Name,
+                @row_count = 0,
+                @msg_description1 = LEFT(@treatment_uids, 199);
         END;
     END TRY
     BEGIN CATCH
@@ -299,27 +262,16 @@ BEGIN
 
         DECLARE @ErrorMessage NVARCHAR(4000) = ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1],
-          [Error_Description])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'ERROR',
-                   @PROC_STEP_NO,
-                   @PROC_STEP_NAME,
-                   0,
-                   LEFT(@treatment_uids, 199),
-                   @ErrorMessage
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @DATAFLOW_NAME,
+            @package_name = @PACKAGE_NAME,
+            @status_type = 'ERROR',
+            @step_number = @PROC_STEP_NO,
+            @step_name = @PROC_STEP_NAME,
+            @row_count = 0,
+            @msg_description1 = LEFT(@treatment_uids, 199),
+            @error_description = @ErrorMessage;
 
         return @ErrorMessage;
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
@@ -21,6 +21,8 @@ BEGIN
     BEGIN TRY
         DECLARE @batch_id BIGINT;
         SET @batch_id = CAST((FORMAT(GETDATE(), 'yyMMddHHmmssffff')) AS BIGINT);
+        DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @treatment_uids, 199);
+        DECLARE @job_flow_message VARCHAR(200) = LEFT(@treatment_uids, 199);
 
         -- Initial log entry
         IF @debug_logging = 1
@@ -31,9 +33,9 @@ BEGIN
                 @package_name = @PACKAGE_NAME,
                 @status_type = 'START',
                 @step_number = 0,
-                @step_name = LEFT('Pre ID-' + @treatment_uids, 199),
+                @step_name = @job_flow_step_name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@treatment_uids, 199);
+                @msg_description1 = @job_flow_message;
         END;
 
         -- STEP 1: Get base UIDs
@@ -253,7 +255,7 @@ BEGIN
                 @step_number = @PROC_STEP_NO,
                 @step_name = @Proc_Step_Name,
                 @row_count = 0,
-                @msg_description1 = LEFT(@treatment_uids, 199);
+                @msg_description1 = @job_flow_message;
         END;
     END TRY
     BEGIN CATCH
@@ -270,7 +272,7 @@ BEGIN
             @step_number = @PROC_STEP_NO,
             @step_name = @PROC_STEP_NAME,
             @row_count = 0,
-            @msg_description1 = LEFT(@treatment_uids, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @ErrorMessage;
 
         return @ErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/070-sp_treatment_event-001.sql
@@ -8,7 +8,7 @@ GO
 
 CREATE PROCEDURE [dbo].[sp_treatment_event]
     @treatment_uids nvarchar(max),
-    @debug bit = 'false'
+    @debug bit = 0, @debug_logging bit = 0
 AS
 BEGIN
 
@@ -23,25 +23,28 @@ BEGIN
         SET @batch_id = CAST((FORMAT(GETDATE(), 'yyMMddHHmmssffff')) AS BIGINT);
 
         -- Initial log entry
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'START',
-                   0,
-                   LEFT('Pre ID-' + @treatment_uids, 199),
-                   0,
-                   LEFT(@treatment_uids, 199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count]
+            , [Msg_Description1])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'START',
+                       0,
+                       LEFT('Pre ID-' + @treatment_uids, 199),
+                       0,
+                       LEFT(@treatment_uids, 199)
+                   );
+        END;
 
         -- STEP 1: Get base UIDs
         BEGIN TRANSACTION;
@@ -91,23 +94,26 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'START',
-                   @Proc_Step_no,
-                   @Proc_Step_Name,
-                   @RowCount_no
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'START',
+                       @Proc_Step_no,
+                       @Proc_Step_Name,
+                       @RowCount_no
+                   );
+        END;
         COMMIT TRANSACTION;
 
         -- STEP 2: CREATE #ASSOCIATED_PHC_UIDS
@@ -132,23 +138,26 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'START',
-                   @Proc_Step_no,
-                   @Proc_Step_Name,
-                   @RowCount_no
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            ( batch_id
+            , [Dataflow_Name]
+            , [package_Name]
+            , [Status_Type]
+            , [step_number]
+            , [step_name]
+            , [row_count])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'START',
+                       @Proc_Step_no,
+                       @Proc_Step_Name,
+                       @RowCount_no
+                   );
+        END;
         COMMIT TRANSACTION;
 
         -- STEP 3: Get Treatment Details
@@ -196,17 +205,20 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'START',
-                   @Proc_Step_no,
-                   @Proc_Step_Name,
-                   @RowCount_no
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'START',
+                       @Proc_Step_no,
+                       @Proc_Step_Name,
+                       @RowCount_no
+                   );
+        END;
         COMMIT TRANSACTION;
 
 
@@ -248,32 +260,38 @@ BEGIN
 
         SELECT @RowCount_no = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'START',
-                   @Proc_Step_no,
-                   @Proc_Step_Name,
-                   @RowCount_no
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'START',
+                       @Proc_Step_no,
+                       @Proc_Step_Name,
+                       @RowCount_no
+                   );
+        END;
         COMMIT TRANSACTION;
 
         -- Log successful completion
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count],[Msg_Description1])
-        VALUES (
-                   @batch_id,
-                   @DATAFLOW_NAME,
-                   @PACKAGE_NAME,
-                   'COMPLETE',
-                   @PROC_STEP_NO,
-                   @Proc_Step_Name,
-                   0,
-                   LEFT(@treatment_uids, 199)
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log]
+            (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count],[Msg_Description1])
+            VALUES (
+                       @batch_id,
+                       @DATAFLOW_NAME,
+                       @PACKAGE_NAME,
+                       'COMPLETE',
+                       @PROC_STEP_NO,
+                       @Proc_Step_Name,
+                       0,
+                       LEFT(@treatment_uids, 199)
+                   );
+        END;
     END TRY
     BEGIN CATCH
         IF @@TRANCOUNT > 0

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE [dbo].[sp_vaccination_event] @vac_uids nvarchar(max), @debug bit = 'false'
+CREATE PROCEDURE [dbo].[sp_vaccination_event] @vac_uids nvarchar(max), @debug bit = 0, @debug_logging bit = 0
 as
 BEGIN
  DECLARE
@@ -30,23 +30,26 @@ BEGIN
         @debug = 'true'
         select @batch_id as Batch_id;
 
-    INSERT INTO [dbo].[job_flow_log]
-    ( batch_id
-    , [Dataflow_Name]
-    , [package_Name]
-    , [Status_Type]
-    , [step_number]
-    , [step_name]
-    , [row_count]
-    , [Msg_Description1])
-    VALUES ( @batch_id
-           , @Dataflow_Name
-           , @Package_Name
-           , 'START'
-           , 0
-           , LEFT('Pre ID-' + @vac_uids, 199)
-           , 0
-           , LEFT(@vac_uids, 199));
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        ( batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES ( @batch_id
+               , @Dataflow_Name
+               , @Package_Name
+               , 'START'
+               , 0
+               , LEFT('Pre ID-' + @vac_uids, 199)
+               , 0
+               , LEFT(@vac_uids, 199));
+    END;
 
 
  	BEGIN TRANSACTION;
@@ -115,10 +118,13 @@ BEGIN
 
 
 	SELECT @RowCount_no = @@ROWCOUNT;
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
 	COMMIT TRANSACTION;
@@ -199,10 +205,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -243,10 +252,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -286,10 +298,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -350,10 +365,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -390,10 +408,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -435,10 +456,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -482,10 +506,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -529,10 +556,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -586,10 +616,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -627,10 +660,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -659,10 +695,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -704,10 +743,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -756,10 +798,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -815,10 +860,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -854,10 +902,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -894,10 +945,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -940,10 +994,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -972,10 +1029,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
     COMMIT TRANSACTION;
 
@@ -1020,10 +1080,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1070,10 +1133,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1112,10 +1178,13 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-            @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
+                @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
@@ -1221,30 +1290,36 @@ BEGIN
 
     SELECT @RowCount_no = @@ROWCOUNT;
 
-    INSERT INTO [dbo].[job_flow_log]
-    (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-    VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+    IF @debug_logging = 1
+    BEGIN
+        INSERT INTO [dbo].[job_flow_log]
+        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
+        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+    END;
 
 
     COMMIT TRANSACTION;
 
-     INSERT INTO [dbo].[job_flow_log]
-    ( batch_id
-    , [Dataflow_Name]
-    , [package_Name]
-    , [Status_Type]
-    , [step_number]
-    , [step_name]
-    , [row_count]
-    , [Msg_Description1])
-    VALUES ( @batch_id
-           , @Dataflow_Name
-           , 'sp_vaccination_record_event'
-           , 'COMPLETE'
-           , 0
-           , LEFT('Pre ID-' + @vac_uids, 199)
-           , 0
-           , LEFT(@vac_uids, 199));
+     IF @debug_logging = 1
+     BEGIN
+         INSERT INTO [dbo].[job_flow_log]
+        ( batch_id
+        , [Dataflow_Name]
+        , [package_Name]
+        , [Status_Type]
+        , [step_number]
+        , [step_name]
+        , [row_count]
+        , [Msg_Description1])
+        VALUES ( @batch_id
+               , @Dataflow_Name
+               , 'sp_vaccination_record_event'
+               , 'COMPLETE'
+               , 0
+               , LEFT('Pre ID-' + @vac_uids, 199)
+               , 0
+               , LEFT(@vac_uids, 199));
+     END;
 
 END TRY
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
@@ -32,23 +32,15 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , @Dataflow_Name
-               , @Package_Name
-               , 'START'
-               , 0
-               , LEFT('Pre ID-' + @vac_uids, 199)
-               , 0
-               , LEFT(@vac_uids, 199));
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = 0,
+            @step_name = LEFT('Pre ID-' + @vac_uids, 199),
+            @row_count = 0,
+            @msg_description1 = LEFT(@vac_uids, 199);
     END;
 
 
@@ -120,10 +112,14 @@ BEGIN
 	SELECT @RowCount_no = @@ROWCOUNT;
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -207,10 +203,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -254,10 +254,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -300,10 +304,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -367,10 +375,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -410,10 +422,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -458,10 +474,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -508,10 +528,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -558,10 +582,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -618,10 +646,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -662,10 +694,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -697,10 +733,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -745,10 +785,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -800,10 +844,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -862,10 +910,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -904,10 +956,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -947,10 +1003,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -996,10 +1056,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -1031,10 +1095,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
     COMMIT TRANSACTION;
@@ -1082,10 +1150,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1135,10 +1207,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1180,10 +1256,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name,
-                @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1292,9 +1372,14 @@ BEGIN
 
     IF @debug_logging = 1
     BEGIN
-        INSERT INTO [dbo].[job_flow_log]
-        (batch_id, [Dataflow_Name], [package_Name], [Status_Type], [step_number], [step_name], [row_count])
-        VALUES (@batch_id, @Dataflow_Name, @Package_Name, 'START', @Proc_Step_no, @Proc_Step_Name, @RowCount_no);
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = @Dataflow_Name,
+            @package_name = @Package_Name,
+            @status_type = 'START',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_Name,
+            @row_count = @RowCount_no;
     END;
 
 
@@ -1302,23 +1387,15 @@ BEGIN
 
      IF @debug_logging = 1
      BEGIN
-         INSERT INTO [dbo].[job_flow_log]
-        ( batch_id
-        , [Dataflow_Name]
-        , [package_Name]
-        , [Status_Type]
-        , [step_number]
-        , [step_name]
-        , [row_count]
-        , [Msg_Description1])
-        VALUES ( @batch_id
-               , @Dataflow_Name
-               , 'sp_vaccination_record_event'
-               , 'COMPLETE'
-               , 0
-               , LEFT('Pre ID-' + @vac_uids, 199)
-               , 0
-               , LEFT(@vac_uids, 199));
+         EXEC dbo.sp_add_job_flow_log
+             @batch_id = @batch_id,
+             @dataflow_name = @Dataflow_Name,
+             @package_name = 'sp_vaccination_record_event',
+             @status_type = 'COMPLETE',
+             @step_number = 0,
+             @step_name = LEFT('Pre ID-' + @vac_uids, 199),
+             @row_count = 0,
+             @msg_description1 = LEFT(@vac_uids, 199);
      END;
 
 END TRY
@@ -1336,22 +1413,15 @@ BEGIN CATCH
         'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
         'Error Message: ' + ERROR_MESSAGE();
 
-    INSERT INTO [dbo].[job_flow_log] ( batch_id
-                                     , [Dataflow_Name]
-                                     , [package_Name]
-                                     , [Status_Type]
-                                     , [step_number]
-                                     , [step_name]
-                                     , [Error_Description]
-                                     , [row_count])
-    VALUES ( @batch_id
-           , @Dataflow_Name
-           , @Package_Name
-           , 'ERROR'
-           , @Proc_Step_no
-           , @Proc_Step_name
-           , @FullErrorMessage
-           , 0);
+    EXEC dbo.sp_add_job_flow_log
+        @batch_id = @batch_id,
+        @dataflow_name = @Dataflow_Name,
+        @package_name = @Package_Name,
+        @status_type = 'ERROR',
+        @step_number = @Proc_Step_no,
+        @step_name = @Proc_Step_name,
+        @row_count = 0,
+        @error_description = @FullErrorMessage;
 
 
 	return -1 ;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/071-sp_vaccination_event-001.sql
@@ -25,6 +25,8 @@ BEGIN
     DECLARE @batch_id BIGINT;
 
     SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
+    DECLARE @job_flow_step_name VARCHAR(200) = LEFT('Pre ID-' + @vac_uids, 199);
+    DECLARE @job_flow_message VARCHAR(200) = LEFT(@vac_uids, 199);
 
     if
         @debug = 'true'
@@ -38,9 +40,9 @@ BEGIN
             @package_name = @Package_Name,
             @status_type = 'START',
             @step_number = 0,
-            @step_name = LEFT('Pre ID-' + @vac_uids, 199),
+            @step_name = @job_flow_step_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@vac_uids, 199);
+            @msg_description1 = @job_flow_message;
     END;
 
 
@@ -1393,9 +1395,9 @@ BEGIN
              @package_name = 'sp_vaccination_record_event',
              @status_type = 'COMPLETE',
              @step_number = 0,
-             @step_name = LEFT('Pre ID-' + @vac_uids, 199),
+             @step_name = @job_flow_step_name,
              @row_count = 0,
-             @msg_description1 = LEFT(@vac_uids, 199);
+             @msg_description1 = @job_flow_message;
      END;
 
 END TRY

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
@@ -83,24 +83,14 @@ BEGIN
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -165,24 +155,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
         COMMIT TRANSACTION;
         -------------------PHCSUBJECT
@@ -330,24 +310,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -414,24 +384,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
         COMMIT TRANSACTION;
 
@@ -453,24 +413,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
         COMMIT TRANSACTION;
 
@@ -630,24 +580,14 @@ BEGIN
         ALTER TABLE #TEMP_PHCINFO1 DROP column LEGACY_HSPTL_DISCHARGE_DT, LEGACY_HSPTL_ADMISSION_DT;
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -682,24 +622,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -729,24 +659,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -774,24 +694,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -809,24 +719,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1056,24 +956,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1087,24 +977,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,0
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = 0;
         END;
 
         COMMIT TRANSACTION;
@@ -1200,24 +1080,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1261,24 +1131,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1337,24 +1197,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1491,24 +1341,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1546,24 +1386,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1678,24 +1508,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,0
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = 0;
         END;
 
         COMMIT TRANSACTION;
@@ -1739,24 +1559,14 @@ BEGIN
         --IF OBJECT_ID ('TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL DROP TABLE TEMP_MIN_MAX_NOTIFICATION;
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1805,24 +1615,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1860,24 +1660,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -1902,24 +1692,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2038,24 +1818,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2085,24 +1855,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2164,24 +1924,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2218,24 +1968,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,0
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = 0;
         END;
 
         COMMIT TRANSACTION;
@@ -2346,24 +2086,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2440,24 +2170,14 @@ BEGIN
 */
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'STEP-AVOIDED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,0
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'STEP-AVOIDED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = 0;
         END;
 
         COMMIT TRANSACTION;
@@ -2790,24 +2510,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@PROC_STEP_NO
-                   ,@PROC_STEP_NAME
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @PROC_STEP_NO,
+                @step_name = @PROC_STEP_NAME,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2837,24 +2547,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @Batch_id
-                   ,'PCHMartETL'
-                   ,'PublicHealthCaseFact RTR'
-                   ,'COMPLETED'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_Name
-                   ,@ROWCOUNT_NO
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @Batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PublicHealthCaseFact RTR',
+                @status_type = 'COMPLETED',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_Name,
+                @row_count = @ROWCOUNT_NO;
         END;
 
         COMMIT TRANSACTION;
@@ -2866,24 +2566,14 @@ BEGIN
 
         IF @debug_logging = 1
         BEGIN
-            INSERT INTO [dbo].[job_flow_log] (
-                                                            batch_id
-                                                          ,[Dataflow_Name]
-                                                          ,[package_Name]
-                                                          ,[Status_Type]
-                                                          ,[step_number]
-                                                          ,[step_name]
-                                                          ,[row_count]
-            )
-            VALUES (
-                     @batch_id
-                   ,'PCHMartETL'
-                   ,'PCHMartETL'
-                   ,'COMPLETE'
-                   ,@Proc_Step_no
-                   ,@Proc_Step_name
-                   ,@RowCount_no
-                   );
+            EXEC dbo.sp_add_job_flow_log
+                @batch_id = @batch_id,
+                @dataflow_name = 'PCHMartETL',
+                @package_name = 'PCHMartETL',
+                @status_type = 'COMPLETE',
+                @step_number = @Proc_Step_no,
+                @step_name = @Proc_Step_name,
+                @row_count = @RowCount_no;
         END;
 
         COMMIT TRANSACTION;
@@ -2905,28 +2595,16 @@ BEGIN
             'Error Line: ' + CAST(ERROR_LINE() AS VARCHAR(10)) + CHAR(13) + CHAR(10) +
             'Error Message: ' + ERROR_MESSAGE();
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[Error_Description]
-                                                      ,[row_count]
-                                                      ,[Msg_Description1]
-        )
-        VALUES (
-                 @batch_id
-               ,'PCHMartETL'
-               ,'PCHMartETL'
-               ,'ERROR'
-               ,@Proc_Step_no
-               , @Proc_Step_name
-               ,@FullErrorMessage
-               ,0
-               , LEFT(@phc_id_list, 199)
-               );
+        EXEC dbo.sp_add_job_flow_log
+            @batch_id = @batch_id,
+            @dataflow_name = 'PCHMartETL',
+            @package_name = 'PCHMartETL',
+            @status_type = 'ERROR',
+            @step_number = @Proc_Step_no,
+            @step_name = @Proc_Step_name,
+            @row_count = 0,
+            @msg_description1 = LEFT(@phc_id_list, 199),
+            @error_description = @FullErrorMessage;
 
         RETURN @FullErrorMessage;
     END CATCH

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
@@ -19,6 +19,7 @@ BEGIN
     DECLARE @return_value INT = 0;
     DECLARE @batch_id bigint;
     SET @batch_id = cast((format(getdate(), 'yyMMddHHmmssffff')) as bigint);
+    DECLARE @job_flow_message VARCHAR(200) = LEFT(@phc_id_list, 199);
 
 
 
@@ -2603,7 +2604,7 @@ BEGIN
             @step_number = @Proc_Step_no,
             @step_name = @Proc_Step_name,
             @row_count = 0,
-            @msg_description1 = LEFT(@phc_id_list, 199),
+            @msg_description1 = @job_flow_message,
             @error_description = @FullErrorMessage;
 
         RETURN @FullErrorMessage;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/072-sp_public_health_case_fact_datamart_event-001.sql
@@ -6,7 +6,7 @@ BEGIN
 END
 GO 
 
-CREATE PROCEDURE dbo.sp_public_health_case_fact_datamart_event @phc_id_list nvarchar(max), @debug bit = 'false'
+CREATE PROCEDURE dbo.sp_public_health_case_fact_datamart_event @phc_id_list nvarchar(max), @debug bit = 0, @debug_logging bit = 0
 AS
 BEGIN
     DECLARE @RowCount_no INT;
@@ -81,24 +81,27 @@ BEGIN
 
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
         BEGIN TRANSACTION;
@@ -160,24 +163,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
         COMMIT TRANSACTION;
         -------------------PHCSUBJECT
         BEGIN TRANSACTION;
@@ -322,24 +328,27 @@ BEGIN
         PRINT '1. endtime' + LEFT(CONVERT(VARCHAR, @batch_end_time, 120), 10)
 
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -403,24 +412,27 @@ BEGIN
                  LEFT JOIN NBS_ODSE.DBO.OBS_VALUE_DATE  WITH (NOLOCK) ON OBSERVATION2.OBSERVATION_UID =OBS_VALUE_DATE.OBSERVATION_UID
         WHERE OBSERVATION2.CD IN ('INV132', 'INV133') AND ACT_RELATIONSHIP.TYPE_CD ='PHCInvForm';
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
         COMMIT TRANSACTION;
 
         BEGIN TRANSACTION;
@@ -439,24 +451,27 @@ BEGIN
                  INNER JOIN NBS_ODSE.DBO.OBS_VALUE_CODED  WITH (NOLOCK) ON ACT_RELATIONSHIP2.SOURCE_ACT_UID =OBS_VALUE_CODED.OBSERVATION_UID
         WHERE OBSERVATION2.CD IN ('INV128') AND ACT_RELATIONSHIP.TYPE_CD ='PHCInvForm';
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
         COMMIT TRANSACTION;
 
         BEGIN TRANSACTION;
@@ -613,24 +628,27 @@ BEGIN
 		WHERE HOSPITALIZED_IND = LTRIM(RTRIM(''));
 */
         ALTER TABLE #TEMP_PHCINFO1 DROP column LEGACY_HSPTL_DISCHARGE_DT, LEGACY_HSPTL_ADMISSION_DT;
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
         BEGIN TRANSACTION;
@@ -662,24 +680,27 @@ BEGIN
             FROM #TEMP_PHCINFO1
         );
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -706,24 +727,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -748,24 +772,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -780,24 +807,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1024,24 +1054,27 @@ BEGIN
             AND FLAG2=1; /* Optimization */
 
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1052,24 +1085,27 @@ BEGIN
 
 
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,0
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,0
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1162,24 +1198,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1220,24 +1259,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1293,24 +1335,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1444,24 +1489,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1496,24 +1544,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1625,24 +1676,27 @@ BEGIN
         UPDATE #TEMP_MIN_MAX_NOTIFICATION set NOTIFCREATEDCOUNT = NOTIFCREATEDCOUNT-1 where NOTIFCREATEDPENDINGSCOUNT>0 and NOTIFCREATEDCOUNT>0;
         UPDATE #TEMP_MIN_MAX_NOTIFICATION set NOTIFCREATEDCOUNT = 1 where NOTIFCREATEDPENDINGSCOUNT>0 and NOTIFCREATEDCOUNT=0 and NOTIFREJECTEDCOUNT=0;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,0
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,0
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1683,24 +1737,27 @@ BEGIN
         WHERE ROWN > 1
         --IF OBJECT_ID ('TEMP_PHCFACT') IS NOT NULL DROP TABLE TEMP_PHCFACT;
         --IF OBJECT_ID ('TEMP_MIN_MAX_NOTIFICATION') IS NOT NULL DROP TABLE TEMP_MIN_MAX_NOTIFICATION;
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1746,24 +1803,27 @@ BEGIN
             AND CODE_SET_NM= 'PHC_CONF_M'
         where t.INVESTIGATION_FORM_CD NOT LIKE 'PG_%' or INVESTIGATION_FORM_CD is null
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1798,24 +1858,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1837,24 +1900,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -1970,24 +2036,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2014,24 +2083,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2090,24 +2162,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2141,24 +2216,27 @@ BEGIN
 
         -- ALTER TABLE #TEMP_PHC_FACT ADD MART_RECORD_CREATION_TIME DATETIME;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,0
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,0
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2266,24 +2344,27 @@ BEGIN
         -- UPDATE #TEMP_PHC_FACT SET cntry_cd = NULL WHERE cntry_cd = LTRIM(RTRIM(''));
 
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2357,24 +2438,27 @@ BEGIN
 		IF OBJECT_ID('tempdb..#TEMP_PHCPERSONRACE_CONCAT') IS NOT NULL
 			DROP TABLE #TEMP_PHCPERSONRACE_CONCAT;
 */
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'STEP-AVOIDED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,0
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'STEP-AVOIDED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,0
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2704,24 +2788,27 @@ BEGIN
 
         SELECT @ROWCOUNT_NO = @@ROWCOUNT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@PROC_STEP_NO
-               ,@PROC_STEP_NAME
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@PROC_STEP_NO
+                   ,@PROC_STEP_NAME
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2748,24 +2835,27 @@ BEGIN
         IF OBJECT_ID('tempdb..#TEMP_PHC_FACT') IS NOT NULL
             DROP TABLE #TEMP_PHC_FACT;
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @Batch_id
-               ,'PCHMartETL'
-               ,'PublicHealthCaseFact RTR'
-               ,'COMPLETED'
-               ,@Proc_Step_no
-               ,@Proc_Step_Name
-               ,@ROWCOUNT_NO
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @Batch_id
+                   ,'PCHMartETL'
+                   ,'PublicHealthCaseFact RTR'
+                   ,'COMPLETED'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_Name
+                   ,@ROWCOUNT_NO
+                   );
+        END;
 
         COMMIT TRANSACTION;
 
@@ -2774,24 +2864,27 @@ BEGIN
         SET @Proc_Step_no = 999;
         SET @Proc_Step_Name = 'SP_COMPLETE';
 
-        INSERT INTO [dbo].[job_flow_log] (
-                                                        batch_id
-                                                      ,[Dataflow_Name]
-                                                      ,[package_Name]
-                                                      ,[Status_Type]
-                                                      ,[step_number]
-                                                      ,[step_name]
-                                                      ,[row_count]
-        )
-        VALUES (
-                 @batch_id
-               ,'PCHMartETL'
-               ,'PCHMartETL'
-               ,'COMPLETE'
-               ,@Proc_Step_no
-               ,@Proc_Step_name
-               ,@RowCount_no
-               );
+        IF @debug_logging = 1
+        BEGIN
+            INSERT INTO [dbo].[job_flow_log] (
+                                                            batch_id
+                                                          ,[Dataflow_Name]
+                                                          ,[package_Name]
+                                                          ,[Status_Type]
+                                                          ,[step_number]
+                                                          ,[step_name]
+                                                          ,[row_count]
+            )
+            VALUES (
+                     @batch_id
+                   ,'PCHMartETL'
+                   ,'PCHMartETL'
+                   ,'COMPLETE'
+                   ,@Proc_Step_no
+                   ,@Proc_Step_name
+                   ,@RowCount_no
+                   );
+        END;
 
         COMMIT TRANSACTION;
 

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
@@ -1,0 +1,51 @@
+IF EXISTS (
+    SELECT *
+    FROM sysobjects
+    WHERE id = object_id(N'[dbo].[sp_add_job_flow_log]')
+      AND OBJECTPROPERTY(id, N'IsProcedure') = 1
+)
+BEGIN
+    DROP PROCEDURE [dbo].[sp_add_job_flow_log]
+END
+GO
+
+CREATE PROCEDURE dbo.sp_add_job_flow_log
+    @batch_id BIGINT,
+    @dataflow_name VARCHAR(200),
+    @package_name VARCHAR(200),
+    @status_type VARCHAR(20),
+    @step_number FLOAT,
+    @step_name VARCHAR(200),
+    @row_count INT,
+    @msg_description1 VARCHAR(200) = NULL,
+    @error_description VARCHAR(8000) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    INSERT INTO dbo.job_flow_log
+    (
+        batch_id,
+        Dataflow_Name,
+        package_Name,
+        Status_Type,
+        step_number,
+        step_name,
+        row_count,
+        Msg_Description1,
+        Error_Description
+    )
+    VALUES
+    (
+        @batch_id,
+        @dataflow_name,
+        @package_name,
+        @status_type,
+        @step_number,
+        @step_name,
+        @row_count,
+        @msg_description1,
+        @error_description
+    );
+END
+GO

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
@@ -19,8 +19,8 @@ CREATE PROCEDURE dbo.sp_add_job_flow_log
     @step_number FLOAT,
     @step_name VARCHAR(199),
     @row_count INT,
-    @msg_description1 VARCHAR(500) = NULL,
-    @error_description VARCHAR(500) = NULL
+    @msg_description1 NVARCHAR(500) = NULL,
+    @error_description NVARCHAR(500) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;

--- a/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
+++ b/reporting-pipeline-service/src/main/resources/db/changelog/migrations/v7.13/rdb/routines/074-sp_add_job_flow_log-001.sql
@@ -1,24 +1,26 @@
-IF EXISTS (
-    SELECT *
-    FROM sysobjects
-    WHERE id = object_id(N'[dbo].[sp_add_job_flow_log]')
-      AND OBJECTPROPERTY(id, N'IsProcedure') = 1
-)
-BEGIN
-    DROP PROCEDURE [dbo].[sp_add_job_flow_log]
-END
+IF
+    EXISTS (
+        SELECT *
+        FROM sysobjects
+        WHERE
+            id = object_id(N'[dbo].[sp_add_job_flow_log]')
+            AND objectproperty(id, N'IsProcedure') = 1
+    )
+    BEGIN
+        DROP PROCEDURE [dbo].[sp_add_job_flow_log]
+    END
 GO
 
 CREATE PROCEDURE dbo.sp_add_job_flow_log
     @batch_id BIGINT,
-    @dataflow_name VARCHAR(200),
-    @package_name VARCHAR(200),
-    @status_type VARCHAR(20),
+    @dataflow_name VARCHAR(199),
+    @package_name VARCHAR(199),
+    @status_type VARCHAR(500),
     @step_number FLOAT,
-    @step_name VARCHAR(200),
+    @step_name VARCHAR(199),
     @row_count INT,
-    @msg_description1 VARCHAR(200) = NULL,
-    @error_description VARCHAR(8000) = NULL
+    @msg_description1 VARCHAR(500) = NULL,
+    @error_description VARCHAR(500) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -26,14 +28,14 @@ BEGIN
     INSERT INTO dbo.job_flow_log
     (
         batch_id,
-        Dataflow_Name,
-        package_Name,
-        Status_Type,
+        dataflow_name,
+        package_name,
+        status_type,
         step_number,
         step_name,
         row_count,
-        Msg_Description1,
-        Error_Description
+        msg_description1,
+        error_description
     )
     VALUES
     (

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/coverage/StoredProcCatalogTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/coverage/StoredProcCatalogTest.java
@@ -39,6 +39,30 @@ class StoredProcCatalogTest {
   }
 
   @Test
+  void keeps_representative_simple_and_detailed_event_procedures_coverable() {
+    ProcDefinition simple = find("sp_organization_event");
+    ProcDefinition detailed = find("sp_public_health_case_fact_datamart_event");
+
+    assertTrue(simple.logsToJobFlowLog());
+    assertTrue(detailed.logsToJobFlowLog());
+    assertTrue(detailed.stepCount() > 0);
+
+    String detailedStep = detailed.stepNumbers().iterator().next();
+    CoverageResult result =
+        CoverageReport.compute(
+            List.of(simple, detailed),
+            JobFlowLogObservations.fromRows(
+                List.of(
+                    new JobFlowLogRow(simple.procName(), null, "COMPLETE"),
+                    new JobFlowLogRow(detailed.procName(), detailedStep, "START"),
+                    new JobFlowLogRow(detailed.procName(), null, "COMPLETE"))));
+
+    assertEquals(2, result.invokedProcs());
+    assertEquals(2, result.completedProcs());
+    assertEquals(1, result.reachedSteps());
+  }
+
+  @Test
   void extracts_create_procedure_name() {
     ProcDefinition organization =
         catalog.stream()
@@ -47,5 +71,12 @@ class StoredProcCatalogTest {
             .findFirst()
             .orElseThrow();
     assertEquals("sp_nrt_organization_postprocessing", organization.procName());
+  }
+
+  private ProcDefinition find(String procedureName) {
+    return catalog.stream()
+        .filter(definition -> definition.procName().equals(procedureName))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/coverage/StoredProcCatalogTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/coverage/StoredProcCatalogTest.java
@@ -12,12 +12,12 @@ class StoredProcCatalogTest {
 
   @Test
   void finds_every_routine_file() {
-    assertEquals(130, catalog.size());
+    assertEquals(131, catalog.size());
   }
 
   @Test
   void counts_procs_that_log_to_job_flow_log() {
-    assertEquals(128, StoredProcCatalog.loggingProcCount(catalog));
+    assertEquals(129, StoredProcCatalog.loggingProcCount(catalog));
   }
 
   @Test
@@ -27,8 +27,9 @@ class StoredProcCatalogTest {
 
   @Test
   void resolves_package_name_for_the_large_majority_of_logging_procs() {
-    // package_name is best-effort: ~113 of 128 logging procs expose a literal identifier; the
-    // remainder (pagebuilder / event-style procs) log it in a shape these patterns don't capture
+    // package_name is best-effort: ~113 of 129 logging procs expose a literal identifier; the
+    // remainder (pagebuilder / event-style/helper procs) log it in a shape these patterns don't
+    // capture
     // and can be matched on procName or via a small override map at coverage time.
     long resolved =
         catalog.stream()

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/InvestigationDataProcessingTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/InvestigationDataProcessingTests.java
@@ -215,12 +215,12 @@ class InvestigationDataProcessingTests {
     investigation.setPublicHealthCaseUid(INVESTIGATION_UID);
     investigation.setActIds(
         """
-                [
-                    {"act_id_seq": 20, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-OLD"},
-                    {"act_id_seq": 10, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-OLDER"},
-                    {"act_id_seq": 30, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-NEWEST"}
-                ]
-                """);
+        [
+            {"act_id_seq": 20, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-OLD"},
+            {"act_id_seq": 10, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-OLDER"},
+            {"act_id_seq": 30, "type_cd": "LEGACY", "root_extension_txt": "LEGACY-NEWEST"}
+        ]
+        """);
 
     InvestigationTransformed transformed =
         transformer.transformInvestigationData(investigation, BATCH_ID);
@@ -902,12 +902,8 @@ class InvestigationDataProcessingTests {
         .when(investigationRepository)
         .updatePhcFact(anyString(), anyString());
 
-    transformer.processPhcFactDatamart("123");
-    ILoggingEvent log = listAppender.list.getLast();
-    assertTrue(log.getFormattedMessage().contains(ERROR_MSG));
-
     transformer.processPhcFactDatamart("NOTF", "123");
-    log = listAppender.list.getLast();
+    ILoggingEvent log = listAppender.list.getLast();
     assertTrue(log.getFormattedMessage().contains(ERROR_MSG));
   }
 

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/InvestigationDataProcessingTests.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/InvestigationDataProcessingTests.java
@@ -885,12 +885,19 @@ class InvestigationDataProcessingTests {
   }
 
   @Test
+  void testProcessPhcFactDatamartPassesLoggingFlag() {
+    transformer.processPhcFactDatamart("123", true);
+
+    verify(investigationRepository).populatePhcFact("123", true);
+  }
+
+  @Test
   void testProcessPhcFactDatamartException() {
     final String ERROR_MSG = "Test Error";
 
     doThrow(new RuntimeException(ERROR_MSG))
         .when(investigationRepository)
-        .populatePhcFact(anyString());
+        .populatePhcFact(anyString(), eq(false));
     doThrow(new RuntimeException(ERROR_MSG))
         .when(investigationRepository)
         .updatePhcFact(anyString(), anyString());

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.investigation.repository.*;
 import gov.cdc.nbs.report.pipeline.investigation.repository.model.dto.*;
 import gov.cdc.nbs.report.pipeline.investigation.repository.model.reporting.*;
@@ -93,6 +94,7 @@ class InvestigationServiceTest {
             contactRepository,
             vaccinationRepository,
             treatmentRepository,
+            new EventProcedureLoggingProperties(false),
             kafkaTemplate,
             transformer,
             new CustomMetrics(new SimpleMeterRegistry()));
@@ -139,7 +141,7 @@ class InvestigationServiceTest {
             + "\", \"prog_area_cd\": \"BMIRD\"}}}";
 
     final Investigation investigation = constructInvestigation(investigationUid);
-    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid)))
+    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid), false))
         .thenReturn(Optional.of(investigation));
     when(kafkaTemplate.send(anyString(), anyString(), isNull()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -147,8 +149,8 @@ class InvestigationServiceTest {
         .thenReturn(CompletableFuture.completedFuture(null));
     validateInvestigationData(payload, investigation);
 
-    verify(investigationRepository).computeInvestigations(String.valueOf(investigationUid));
-    verify(investigationRepository).populatePhcFact(String.valueOf(investigationUid));
+    verify(investigationRepository).computeInvestigations(String.valueOf(investigationUid), false);
+    verify(investigationRepository).populatePhcFact(String.valueOf(investigationUid), false);
   }
 
   @Test
@@ -160,7 +162,7 @@ class InvestigationServiceTest {
             + "\", \"prog_area_cd\": \"BMIRD\"}}}";
 
     final Investigation investigation = constructInvestigation(investigationUid);
-    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid)))
+    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid), false))
         .thenReturn(Optional.of(investigation));
     when(kafkaTemplate.send(anyString(), anyString(), isNull()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -175,7 +177,7 @@ class InvestigationServiceTest {
         .untilAsserted(
             () ->
                 verify(investigationRepository, never())
-                    .populatePhcFact(String.valueOf(investigationUid)));
+                    .populatePhcFact(String.valueOf(investigationUid), false));
   }
 
   @ParameterizedTest
@@ -198,7 +200,7 @@ class InvestigationServiceTest {
     String payload =
         "{\"payload\": {\"after\": {\"public_health_case_uid\": \"" + investigationUid + "\"}}}";
 
-    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid)))
+    when(investigationRepository.computeInvestigations(String.valueOf(investigationUid), false))
         .thenReturn(Optional.empty());
     checkException(investigationTopic, payload, NoDataException.class);
   }
@@ -210,7 +212,7 @@ class InvestigationServiceTest {
         "{\"payload\": {\"after\": {\"notification_uid\": \"" + notificationUid + "\"}}}";
 
     final NotificationUpdate notification = constructNotificationUpdate(notificationUid);
-    when(notificationRepository.computeNotifications(String.valueOf(notificationUid)))
+    when(notificationRepository.computeNotifications(String.valueOf(notificationUid), false))
         .thenReturn(Optional.of(notification));
     investigationService.processMessage(getRecord(notificationTopic, payload));
 
@@ -218,7 +220,8 @@ class InvestigationServiceTest {
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
-              verify(notificationRepository).computeNotifications(String.valueOf(notificationUid));
+              verify(notificationRepository)
+                  .computeNotifications(String.valueOf(notificationUid), false);
               verify(kafkaTemplate).send(topicCaptor.capture(), anyString(), anyString());
               verify(investigationRepository)
                   .updatePhcFact("NOTF", String.valueOf(notificationUid));
@@ -233,7 +236,7 @@ class InvestigationServiceTest {
         "{\"payload\": {\"after\": {\"notification_uid\": \"" + notificationUid + "\"}}}";
 
     final NotificationUpdate notification = constructNotificationUpdate(notificationUid);
-    when(notificationRepository.computeNotifications(String.valueOf(notificationUid)))
+    when(notificationRepository.computeNotifications(String.valueOf(notificationUid), false))
         .thenReturn(Optional.of(notification));
     investigationService.setPhcDatamartEnable(false);
 
@@ -254,7 +257,7 @@ class InvestigationServiceTest {
     Long notificationUid = 123456789L;
     String payload =
         "{\"payload\": {\"after\": {\"notification_uid\": \"" + notificationUid + "\"}}}";
-    when(investigationRepository.computeInvestigations(String.valueOf(notificationUid)))
+    when(investigationRepository.computeInvestigations(String.valueOf(notificationUid), false))
         .thenReturn(Optional.empty());
     checkException(notificationTopic, payload, NoDataException.class);
   }
@@ -268,7 +271,7 @@ class InvestigationServiceTest {
     interview.setRdbCols(readFileData(FILE_PATH_PREFIX + "RdbColumns.json"));
     interview.setAnswers(readFileData(FILE_PATH_PREFIX + "InterviewAnswers.json"));
     interview.setNotes(readFileData(FILE_PATH_PREFIX + "InterviewNotes.json"));
-    when(interviewRepository.computeInterviews(String.valueOf(interviewUid)))
+    when(interviewRepository.computeInterviews(String.valueOf(interviewUid), false))
         .thenReturn(Optional.of(interview));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -307,7 +310,7 @@ class InvestigationServiceTest {
     assertEquals(interviewReportingKey, actualInterviewKey);
     assertEquals(interviewReportingValue, actualInterviewValue);
 
-    verify(interviewRepository).computeInterviews(String.valueOf(interviewUid));
+    verify(interviewRepository).computeInterviews(String.valueOf(interviewUid), false);
   }
 
   @Test
@@ -315,7 +318,7 @@ class InvestigationServiceTest {
     Long interviewUid = 123456789L;
     String payload = "{\"payload\": {\"after\": {\"interview_uid\": \"" + interviewUid + "\"}}}";
 
-    when(interviewRepository.computeInterviews(String.valueOf(interviewUid)))
+    when(interviewRepository.computeInterviews(String.valueOf(interviewUid), false))
         .thenReturn(Optional.empty());
     checkException(interviewTopic, payload, NoDataException.class);
   }
@@ -328,7 +331,7 @@ class InvestigationServiceTest {
     final Contact contact = constructContact(contactUid);
     contact.setRdbCols(readFileData(FILE_PATH_PREFIX + "RdbColumns.json"));
     contact.setAnswers(readFileData(FILE_PATH_PREFIX + "ContactAnswers.json"));
-    when(contactRepository.computeContact(String.valueOf(contactUid)))
+    when(contactRepository.computeContact(String.valueOf(contactUid), false))
         .thenReturn(Optional.of(contact));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -362,7 +365,7 @@ class InvestigationServiceTest {
     assertEquals(contactReportingKey, actualContactKey);
     assertEquals(contactReportingValue, actualContactValue);
 
-    verify(contactRepository).computeContact(String.valueOf(contactUid));
+    verify(contactRepository).computeContact(String.valueOf(contactUid), false);
   }
 
   @Test
@@ -383,7 +386,7 @@ class InvestigationServiceTest {
             + "\"}}";
 
     final Vaccination vaccination = constructVaccination(vaccinationUid);
-    when(vaccinationRepository.computeVaccination(String.valueOf(vaccinationUid)))
+    when(vaccinationRepository.computeVaccination(String.valueOf(vaccinationUid), false))
         .thenReturn(Optional.of(vaccination));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -420,7 +423,7 @@ class InvestigationServiceTest {
     assertEquals(vaccinationReportingKey, actualVaccinationKey);
     assertEquals(vaccinationReportingValue, actualVaccinationValue);
 
-    verify(vaccinationRepository).computeVaccination(String.valueOf(vaccinationUid));
+    verify(vaccinationRepository).computeVaccination(String.valueOf(vaccinationUid), false);
   }
 
   @Test
@@ -432,7 +435,7 @@ class InvestigationServiceTest {
             + "\"}, \"op\": \"c\"}}";
 
     final Vaccination vaccination = constructVaccination(vaccinationUid);
-    when(vaccinationRepository.computeVaccination(String.valueOf(vaccinationUid)))
+    when(vaccinationRepository.computeVaccination(String.valueOf(vaccinationUid), false))
         .thenReturn(Optional.of(vaccination));
 
     investigationService.processMessage(getRecord(vaccinationTopic, payload));
@@ -510,7 +513,7 @@ class InvestigationServiceTest {
 
     final Vaccination vaccination = constructVaccination(sourceActUid);
 
-    when(vaccinationRepository.computeVaccination(String.valueOf(sourceActUid)))
+    when(vaccinationRepository.computeVaccination(String.valueOf(sourceActUid), false))
         .thenReturn(Optional.of(vaccination));
 
     CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
@@ -589,7 +592,7 @@ class InvestigationServiceTest {
 
     final Treatment treatment = constructTreatment(sourceActUid);
 
-    when(treatmentRepository.computeTreatment(String.valueOf(sourceActUid)))
+    when(treatmentRepository.computeTreatment(String.valueOf(sourceActUid), false))
         .thenReturn(Optional.of(treatment));
 
     CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
@@ -612,7 +615,7 @@ class InvestigationServiceTest {
           .atMost(1, TimeUnit.SECONDS)
           .untilAsserted(
               () -> {
-                verify(treatmentRepository).computeTreatment(String.valueOf(sourceActUid));
+                verify(treatmentRepository).computeTreatment(String.valueOf(sourceActUid), false);
                 verify(kafkaTemplate)
                     .send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
               });
@@ -710,7 +713,7 @@ class InvestigationServiceTest {
 
     final Treatment treatment = constructTreatment(treatmentUid);
 
-    when(treatmentRepository.computeTreatment(String.valueOf(treatmentUid)))
+    when(treatmentRepository.computeTreatment(String.valueOf(treatmentUid), false))
         .thenReturn(Optional.of(treatment));
 
     CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
@@ -724,7 +727,7 @@ class InvestigationServiceTest {
         .atMost(1, TimeUnit.SECONDS)
         .untilAsserted(
             () -> {
-              verify(treatmentRepository).computeTreatment(String.valueOf(treatmentUid));
+              verify(treatmentRepository).computeTreatment(String.valueOf(treatmentUid), false);
               verify(kafkaTemplate)
                   .send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
             });
@@ -752,7 +755,7 @@ class InvestigationServiceTest {
         "{\"payload\": {\"after\": {\"treatment_uid\": \"" + treatmentUid + "\"}, \"op\": \"c\"}}";
 
     final Treatment treatment = constructTreatment(treatmentUid);
-    when(treatmentRepository.computeTreatment(String.valueOf(treatmentUid)))
+    when(treatmentRepository.computeTreatment(String.valueOf(treatmentUid), false))
         .thenReturn(Optional.of(treatment));
 
     investigationService.processMessage(getRecord(treatmentTopic, payload));

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/investigation/service/InvestigationServiceTest.java
@@ -203,80 +203,80 @@ class InvestigationServiceTest {
   @ValueSource(strings = {"Investigation_retry-0", "Investigation_retry-1"})
   void testProcessInvestigationRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"public_health_case_uid\": \"1\"}}}";
-    when(investigationRepository.computeInvestigations("1")).thenReturn(Optional.empty());
+    when(investigationRepository.computeInvestigations("1", false)).thenReturn(Optional.empty());
     investigationService.setPhcDatamartEnable(false);
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, investigationTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(investigationRepository).computeInvestigations("1");
+    verify(investigationRepository).computeInvestigations("1", false);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"Notification_retry-0", "Notification_retry-1"})
   void testProcessNotificationRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"notification_uid\": \"2\"}}}";
-    when(notificationRepository.computeNotifications("2")).thenReturn(Optional.empty());
+    when(notificationRepository.computeNotifications("2", false)).thenReturn(Optional.empty());
     investigationService.setPhcDatamartEnable(false);
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, notificationTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(notificationRepository).computeNotifications("2");
+    verify(notificationRepository).computeNotifications("2", false);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"Interview_retry-0", "Interview_retry-1"})
   void testProcessInterviewRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"interview_uid\": \"3\"}}}";
-    when(interviewRepository.computeInterviews("3")).thenReturn(Optional.empty());
+    when(interviewRepository.computeInterviews("3", false)).thenReturn(Optional.empty());
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, interviewTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(interviewRepository).computeInterviews("3");
+    verify(interviewRepository).computeInterviews("3", false);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"Contact_retry-0", "Contact_retry-1"})
   void testProcessContactRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"ct_contact_uid\": \"4\"}}}";
-    when(contactRepository.computeContact("4")).thenReturn(Optional.empty());
+    when(contactRepository.computeContact("4", false)).thenReturn(Optional.empty());
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, contactTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(contactRepository).computeContact("4");
+    verify(contactRepository).computeContact("4", false);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"Vaccination_retry-0", "Vaccination_retry-1"})
   void testProcessVaccinationRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"intervention_uid\": \"5\"}, \"op\": \"u\"}}";
-    when(vaccinationRepository.computeVaccination("5")).thenReturn(Optional.empty());
+    when(vaccinationRepository.computeVaccination("5", false)).thenReturn(Optional.empty());
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, vaccinationTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(vaccinationRepository).computeVaccination("5");
+    verify(vaccinationRepository).computeVaccination("5", false);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"Treatment_retry-0", "Treatment_retry-1"})
   void testProcessTreatmentRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"treatment_uid\": \"6\"}, \"op\": \"u\"}}";
-    when(treatmentRepository.computeTreatment("6")).thenReturn(Optional.empty());
+    when(treatmentRepository.computeTreatment("6", false)).thenReturn(Optional.empty());
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, treatmentTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(treatmentRepository).computeTreatment("6");
+    verify(treatmentRepository).computeTreatment("6", false);
   }
 
   @ParameterizedTest
@@ -285,13 +285,13 @@ class InvestigationServiceTest {
     String payload =
         "{\"payload\": {\"after\": {\"source_act_uid\": \"7\", \"type_cd\": \"1180\"},"
             + " \"op\": \"c\"}}";
-    when(vaccinationRepository.computeVaccination("7")).thenReturn(Optional.empty());
+    when(vaccinationRepository.computeVaccination("7", false)).thenReturn(Optional.empty());
 
     CompletableFuture<Void> future =
         investigationService.processMessage(retryRecord(retryTopic, actRelationshipTopic, payload));
 
     assertThrows(CompletionException.class, future::join);
-    verify(vaccinationRepository).computeVaccination("7");
+    verify(vaccinationRepository).computeVaccination("7", false);
   }
 
   @Test

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/ldfdata/service/LdfDataServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.ldfdata.model.dto.LdfData;
 import gov.cdc.nbs.report.pipeline.ldfdata.model.dto.LdfDataKey;
 import gov.cdc.nbs.report.pipeline.ldfdata.repository.LdfDataRepository;
@@ -54,7 +55,10 @@ class LdfDataServiceTest {
 
     ldfDataService =
         new LdfDataService(
-            ldfDataRepository, kafkaTemplate, new CustomMetrics(new SimpleMeterRegistry()));
+            ldfDataRepository,
+            new EventProcedureLoggingProperties(false),
+            kafkaTemplate,
+            new CustomMetrics(new SimpleMeterRegistry()));
     ldfDataService.setThreadPoolSize(1);
     ldfDataService.initMetrics();
 
@@ -90,13 +94,13 @@ class LdfDataServiceTest {
 
     final LdfData ldfData = constructLdfData(busObjNm, ldfUid, busObjUid);
     when(ldfDataRepository.computeLdfData(
-            busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid)))
+            busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid), false))
         .thenReturn(Optional.of(ldfData));
 
     validateData(ldfTopic, ldfTopicOutput, payload, ldfData);
 
     verify(ldfDataRepository)
-        .computeLdfData(busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid));
+        .computeLdfData(busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid), false);
   }
 
   @Test
@@ -215,7 +219,7 @@ class LdfDataServiceTest {
             + "\"}}}";
 
     when(ldfDataRepository.computeLdfData(
-            busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid)))
+            busObjNm, String.valueOf(ldfUid), String.valueOf(busObjUid), false))
         .thenReturn(Optional.empty());
     setupLdfService(ldfTopic, ldfTopicOutput);
     CompletableFuture<Void> future = ldfDataService.processMessage(getRecord(payload, ldfTopic));

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.Observation;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.ObservationKey;
 import gov.cdc.nbs.report.pipeline.observation.model.dto.observation.ObservationReporting;
@@ -58,28 +59,60 @@ class ObservationServiceTest {
   @BeforeEach
   void setUp() {
     closeable = MockitoAnnotations.openMocks(this);
+    observationService = createObservationService(false);
+  }
+
+  private ObservationService createObservationService(boolean debugLogging) {
     ProcessObservationDataUtil transformer = new ProcessObservationDataUtil(kafkaTemplate);
     transformer.setMaterialTopicName("materialTopic");
-    observationService =
+    ObservationService service =
         new ObservationService(
             observationRepository,
+            new EventProcedureLoggingProperties(debugLogging),
             kafkaTemplate,
             transformer,
             new CustomMetrics(new SimpleMeterRegistry()));
-    observationService.setObservationTopic(inputTopicNameObservation);
-    observationService.setActRelationshipTopic(inputTopicNameActRelationship);
-    observationService.setObservationTopicOutputReporting(outputTopicNameObservation);
-    observationService.setThreadPoolSize(1);
-    observationService.initMetrics();
+    service.setObservationTopic(inputTopicNameObservation);
+    service.setActRelationshipTopic(inputTopicNameActRelationship);
+    service.setObservationTopicOutputReporting(outputTopicNameObservation);
+    service.setThreadPoolSize(1);
+    service.initMetrics();
 
     transformer.setCodedTopicName("ObservationCoded");
     transformer.setReasonTopicName("ObservationReason");
     transformer.setTxtTopicName("ObservationTxt");
+    return service;
   }
 
   @AfterEach
   void closeService() throws Exception {
     closeable.close();
+  }
+
+  @Test
+  void passesEnabledLoggingToObservationRepository() throws JsonProcessingException {
+    Long observationUid = 123456789L;
+    Observation observation = constructObservation(observationUid, "Order");
+    when(observationRepository.computeObservations(String.valueOf(observationUid), true))
+        .thenReturn(Optional.of(observation));
+    when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    observationService = createObservationService(true);
+    observationService.processMessage(
+        new ConsumerRecord<>(
+            inputTopicNameObservation,
+            0,
+            0L,
+            null,
+            "{\"payload\": {\"after\": {\"observation_uid\": \"123456789\"}}}"));
+
+    Awaitility.await()
+        .atMost(1, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                verify(observationRepository)
+                    .computeObservations(String.valueOf(observationUid), true));
   }
 
   @Test
@@ -91,7 +124,7 @@ class ObservationServiceTest {
         "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
 
     Observation observation = constructObservation(observationUid, obsDomainCdSt);
-    when(observationRepository.computeObservations(String.valueOf(observationUid)))
+    when(observationRepository.computeObservations(String.valueOf(observationUid), false))
         .thenReturn(Optional.of(observation));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -100,7 +133,7 @@ class ObservationServiceTest {
 
     validateData(payload, observation, inputTopicNameObservation);
 
-    verify(observationRepository).computeObservations(String.valueOf(observationUid));
+    verify(observationRepository).computeObservations(String.valueOf(observationUid), false);
   }
 
   @ParameterizedTest
@@ -136,7 +169,7 @@ class ObservationServiceTest {
       verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
     } else {
       Observation observation = constructObservation(sourceActUid, obsDomainCdSt);
-      when(observationRepository.computeObservations(String.valueOf(sourceActUid)))
+      when(observationRepository.computeObservations(String.valueOf(sourceActUid), false))
           .thenReturn(Optional.of(observation));
       when(kafkaTemplate.send(anyString(), anyString(), anyString()))
           .thenReturn(CompletableFuture.completedFuture(null));
@@ -145,7 +178,7 @@ class ObservationServiceTest {
 
       validateData(payload, observation, inputTopicNameActRelationship);
 
-      verify(observationRepository).computeObservations(String.valueOf(sourceActUid));
+      verify(observationRepository).computeObservations(String.valueOf(sourceActUid), false);
     }
   }
 
@@ -227,7 +260,7 @@ class ObservationServiceTest {
         "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
     ConsumerRecord<String, String> rec = getRecord(payload, inputTopicNameObservation);
 
-    when(observationRepository.computeObservations(String.valueOf(observationUid)))
+    when(observationRepository.computeObservations(String.valueOf(observationUid), false))
         .thenReturn(Optional.empty());
     CompletableFuture<Void> future = observationService.processMessage(rec);
     CompletionException ex = assertThrows(CompletionException.class, future::join);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/observation/service/ObservationServiceTest.java
@@ -138,7 +138,7 @@ class ObservationServiceTest {
 
     validateData(getRecord(payload, inputTopicNameObservation), observation);
 
-    verify(observationRepository).computeObservations(String.valueOf(observationUid));
+    verify(observationRepository).computeObservations(String.valueOf(observationUid), false);
   }
 
   @ParameterizedTest
@@ -148,7 +148,7 @@ class ObservationServiceTest {
     String payload =
         "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
     Observation observation = constructObservation(observationUid, "Order");
-    when(observationRepository.computeObservations(String.valueOf(observationUid)))
+    when(observationRepository.computeObservations(String.valueOf(observationUid), false))
         .thenReturn(Optional.of(observation));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -201,7 +201,7 @@ class ObservationServiceTest {
     Long sourceActUid = 123456789L;
     String payload = actRelationshipPayload(sourceActUid, "d", "LabReport", "OBS");
     Observation observation = constructObservation(sourceActUid, "Order");
-    when(observationRepository.computeObservations(String.valueOf(sourceActUid)))
+    when(observationRepository.computeObservations(String.valueOf(sourceActUid), false))
         .thenReturn(Optional.of(observation));
     when(kafkaTemplate.send(anyString(), anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -210,7 +210,7 @@ class ObservationServiceTest {
 
     validateData(getRetryRecord(payload, retryTopic, inputTopicNameActRelationship), observation);
 
-    verify(observationRepository).computeObservations(String.valueOf(sourceActUid));
+    verify(observationRepository).computeObservations(String.valueOf(sourceActUid), false);
   }
 
   @Test

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
@@ -121,7 +121,7 @@ class OrganizationServiceTest {
 
     organizationService = createOrganizationService(true);
     organizationService.processMessage(
-        readFileData("rawDataFiles/organization/OrgChangeData.json"), orgTopic);
+        record(readFileData("rawDataFiles/organization/OrgChangeData.json"), orgTopic));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -202,7 +202,7 @@ class OrganizationServiceTest {
   void testProcessOrganizationRetryMessage(String retryTopic) {
     OrganizationSp organization = new OrganizationSp();
     organization.setOrganizationUid(10036000L);
-    when(orgRepository.computeAllOrganizations("10036000")).thenReturn(Set.of(organization));
+    when(orgRepository.computeAllOrganizations("10036000", false)).thenReturn(Set.of(organization));
     organizationService.setElasticSearchEnable(false);
     organizationService.setPhcDatamartEnable(false);
 
@@ -214,7 +214,7 @@ class OrganizationServiceTest {
                 orgTopic));
     future.join();
 
-    verify(orgRepository).computeAllOrganizations("10036000");
+    verify(orgRepository).computeAllOrganizations("10036000", false);
     verifyNoInteractions(placeRepository);
   }
 
@@ -224,13 +224,14 @@ class OrganizationServiceTest {
     String payload = "{\"payload\": {\"after\": {\"place_uid\": \"10045001\"}}}";
     Place place =
         objectMapper.readValue(readFileData("rawDataFiles/organization/Place.json"), Place.class);
-    when(placeRepository.computeAllPlaces("10045001")).thenReturn(Optional.of(List.of(place)));
+    when(placeRepository.computeAllPlaces("10045001", false))
+        .thenReturn(Optional.of(List.of(place)));
 
     CompletableFuture<Void> future =
         organizationService.processMessage(retryRecord(payload, retryTopic, placeTopic));
     future.join();
 
-    verify(placeRepository).computeAllPlaces("10045001");
+    verify(placeRepository).computeAllPlaces("10045001", false);
     verifyNoInteractions(orgRepository);
   }
 

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/organization/service/OrganizationServiceTest.java
@@ -12,6 +12,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.organization.model.dto.org.OrganizationSp;
 import gov.cdc.nbs.report.pipeline.organization.model.dto.place.*;
 import gov.cdc.nbs.report.pipeline.organization.repository.OrgRepository;
@@ -68,28 +69,33 @@ class OrganizationServiceTest {
   @BeforeEach
   void setUp() {
     closeable = MockitoAnnotations.openMocks(this);
-    DataTransformers transformer = new DataTransformers();
-    organizationService =
-        new OrganizationService(
-            orgRepository,
-            placeRepository,
-            transformer,
-            kafkaTemplate,
-            new CustomMetrics(new SimpleMeterRegistry()));
-    organizationService.setOrgTopic(orgTopic);
-    organizationService.setPlaceTopic(placeTopic);
-    organizationService.setOrgReportingOutputTopic(orgReportingTopic);
-    organizationService.setOrgElasticSearchTopic(orgElasticTopic);
-    organizationService.setPlaceReportingOutputTopic(placeReportingTopic);
-    organizationService.setTeleOutputTopic(teleReportingTopic);
-    organizationService.setElasticSearchEnable(true);
-    organizationService.setPhcDatamartEnable(true);
-    organizationService.setThreadPoolSize(1);
-    organizationService.initMetrics();
+    organizationService = createOrganizationService(false);
 
     Logger logger = (Logger) LoggerFactory.getLogger(OrganizationService.class);
     listAppender.start();
     logger.addAppender(listAppender);
+  }
+
+  private OrganizationService createOrganizationService(boolean debugLogging) {
+    OrganizationService service =
+        new OrganizationService(
+            orgRepository,
+            placeRepository,
+            new EventProcedureLoggingProperties(debugLogging),
+            new DataTransformers(),
+            kafkaTemplate,
+            new CustomMetrics(new SimpleMeterRegistry()));
+    service.setOrgTopic(orgTopic);
+    service.setPlaceTopic(placeTopic);
+    service.setOrgReportingOutputTopic(orgReportingTopic);
+    service.setOrgElasticSearchTopic(orgElasticTopic);
+    service.setPlaceReportingOutputTopic(placeReportingTopic);
+    service.setTeleOutputTopic(teleReportingTopic);
+    service.setElasticSearchEnable(true);
+    service.setPhcDatamartEnable(true);
+    service.setThreadPoolSize(1);
+    service.initMetrics();
+    return service;
   }
 
   @AfterEach
@@ -100,11 +106,29 @@ class OrganizationServiceTest {
   }
 
   @Test
+  void passesEnabledLoggingToOrganizationRepository() throws Exception {
+    OrganizationSp orgSp =
+        objectMapper.readValue(
+            readFileData("rawDataFiles/organization/orgSp.json"), OrganizationSp.class);
+    when(orgRepository.computeAllOrganizations(anyString(), Mockito.eq(true)))
+        .thenReturn(Set.of(orgSp));
+
+    organizationService = createOrganizationService(true);
+    organizationService.processMessage(
+        readFileData("rawDataFiles/organization/OrgChangeData.json"), orgTopic);
+
+    Awaitility.await()
+        .atMost(1, TimeUnit.SECONDS)
+        .untilAsserted(() -> verify(orgRepository).computeAllOrganizations("10036000", true));
+  }
+
+  @Test
   void testProcessOrgMessage() throws Exception {
     OrganizationSp orgSp =
         objectMapper.readValue(
             readFileData("rawDataFiles/organization/orgSp.json"), OrganizationSp.class);
-    when(orgRepository.computeAllOrganizations(anyString())).thenReturn(Set.of(orgSp));
+    when(orgRepository.computeAllOrganizations(anyString(), Mockito.eq(false)))
+        .thenReturn(Set.of(orgSp));
 
     validateOrgTransformation();
     verify(orgRepository).updatePhcFact("ORG", "10036000");
@@ -114,7 +138,8 @@ class OrganizationServiceTest {
   void testProcessOrgMessageNoElasticSearch() {
     OrganizationSp orgSp = new OrganizationSp();
     orgSp.setOrganizationUid(10036000L);
-    when(orgRepository.computeAllOrganizations(anyString())).thenReturn(Set.of(orgSp));
+    when(orgRepository.computeAllOrganizations(anyString(), Mockito.eq(false)))
+        .thenReturn(Set.of(orgSp));
 
     String changeData = readFileData("rawDataFiles/organization/OrgChangeData.json");
 
@@ -137,7 +162,8 @@ class OrganizationServiceTest {
   void testProcessPlaceMessage() throws Exception {
     Place place =
         objectMapper.readValue(readFileData("rawDataFiles/organization/Place.json"), Place.class);
-    when(placeRepository.computeAllPlaces(anyString())).thenReturn(Optional.of(List.of(place)));
+    when(placeRepository.computeAllPlaces(anyString(), Mockito.eq(false)))
+        .thenReturn(Optional.of(List.of(place)));
 
     validatePlaceTransformation();
   }
@@ -149,7 +175,8 @@ class OrganizationServiceTest {
     Place place =
         objectMapper.readValue(readFileData("rawDataFiles/organization/Place.json"), Place.class);
     place.setPlaceTele(null);
-    when(placeRepository.computeAllPlaces(anyString())).thenReturn(Optional.of(List.of(place)));
+    when(placeRepository.computeAllPlaces(anyString(), Mockito.eq(false)))
+        .thenReturn(Optional.of(List.of(place)));
 
     organizationService.processMessage(payload, placeTopic);
 
@@ -176,7 +203,7 @@ class OrganizationServiceTest {
   void testProcessMessageException(String payload, String topic) {
     Class<?> expectedExceptionClass = NoSuchElementException.class;
     if (payload.contains("place_uid")) {
-      when(placeRepository.computeAllPlaces(anyString()))
+      when(placeRepository.computeAllPlaces(anyString(), Mockito.eq(false)))
           .thenReturn(Optional.of(List.of(new Place())));
       expectedExceptionClass = NullPointerException.class;
     }
@@ -194,11 +221,11 @@ class OrganizationServiceTest {
   void testProcessMessageNoDataException(String payload, String inputTopic) {
     if (inputTopic.equals(orgTopic)) {
       Long organizationUid = 123456789L;
-      when(orgRepository.computeAllOrganizations(String.valueOf(organizationUid)))
+      when(orgRepository.computeAllOrganizations(String.valueOf(organizationUid), false))
           .thenReturn(Collections.emptySet());
     } else if (inputTopic.equals(placeTopic)) {
       Long placeUid = 123456789L;
-      when(placeRepository.computeAllPlaces(String.valueOf(placeUid)))
+      when(placeRepository.computeAllPlaces(String.valueOf(placeUid), false))
           .thenReturn(Optional.of(Collections.emptyList()));
     }
     CompletableFuture<Void> future = organizationService.processMessage(payload, inputTopic);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
@@ -12,6 +12,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.report.pipeline.config.EventProcedureLoggingProperties;
 import gov.cdc.nbs.report.pipeline.person.model.dto.patient.PatientSp;
 import gov.cdc.nbs.report.pipeline.person.model.dto.provider.ProviderSp;
 import gov.cdc.nbs.report.pipeline.person.model.dto.user.AuthUser;
@@ -75,30 +76,35 @@ class PersonServiceTest {
   void setUp() {
     closeable = MockitoAnnotations.openMocks(this);
 
-    PersonTransformers transformer = new PersonTransformers();
-    personService =
-        new PersonService(
-            patientRepository,
-            providerRepository,
-            userRepository,
-            transformer,
-            kafkaTemplate,
-            new CustomMetrics(new SimpleMeterRegistry()));
-    personService.setPersonTopic(inputTopicPerson);
-    personService.setUserTopic(inputTopicUser);
-    personService.setPatientReportingOutputTopic(patientReportingTopic);
-    personService.setPatientElasticSearchOutputTopic(patientElasticTopic);
-    personService.setProviderReportingOutputTopic(providerReportingTopic);
-    personService.setProviderElasticSearchOutputTopic(providerElasticTopic);
-    personService.setUserReportingOutputTopic(userReportingTopic);
-    personService.setElasticSearchEnable(true);
-    personService.setPhcDatamartEnable(true);
-    personService.setThreadPoolSize(1);
-    personService.initMetrics();
+    personService = createPersonService(false);
 
     Logger logger = (Logger) LoggerFactory.getLogger(PersonService.class);
     listAppender.start();
     logger.addAppender(listAppender);
+  }
+
+  private PersonService createPersonService(boolean debugLogging) {
+    PersonService service =
+        new PersonService(
+            patientRepository,
+            providerRepository,
+            userRepository,
+            new EventProcedureLoggingProperties(debugLogging),
+            new PersonTransformers(),
+            kafkaTemplate,
+            new CustomMetrics(new SimpleMeterRegistry()));
+    service.setPersonTopic(inputTopicPerson);
+    service.setUserTopic(inputTopicUser);
+    service.setPatientReportingOutputTopic(patientReportingTopic);
+    service.setPatientElasticSearchOutputTopic(patientElasticTopic);
+    service.setProviderReportingOutputTopic(providerReportingTopic);
+    service.setProviderElasticSearchOutputTopic(providerElasticTopic);
+    service.setUserReportingOutputTopic(userReportingTopic);
+    service.setElasticSearchEnable(true);
+    service.setPhcDatamartEnable(true);
+    service.setThreadPoolSize(1);
+    service.initMetrics();
+    return service;
   }
 
   @AfterEach
@@ -113,7 +119,7 @@ class PersonServiceTest {
     PatientSp patientSp = constructPatient();
     PatientSp mprPatient = constructPatient();
     mprPatient.setPersonParentUid(mprPatient.getPersonUid());
-    Mockito.when(patientRepository.computePatients(anyString()))
+    Mockito.when(patientRepository.computePatients(anyString(), Mockito.eq(false)))
         .thenReturn(List.of(patientSp))
         .thenReturn(List.of(mprPatient));
 
@@ -138,6 +144,21 @@ class PersonServiceTest {
                     .updatePhcFact("PAT", String.valueOf(mprPatient.getPersonUid())));
   }
 
+  @Test
+  void passesEnabledLoggingToPatientRepository() throws JsonProcessingException {
+    PatientSp patientSp = constructPatient();
+    when(patientRepository.computePatients(anyString(), Mockito.eq(true)))
+        .thenReturn(List.of(patientSp));
+
+    personService = createPersonService(true);
+    personService.processMessage(
+        readFileData("rawDataFiles/person/PersonPatientChangeData.json"), inputTopicPerson);
+
+    Awaitility.await()
+        .atMost(1, TimeUnit.SECONDS)
+        .untilAsserted(() -> verify(patientRepository).computePatients("9005400", true));
+  }
+
   @ParameterizedTest
   @CsvSource({
     "PersonTelephone.json , rawDataFiles/provider/ProviderReporting.json, rawDataFiles/provider/ProviderElasticSearch.json",
@@ -151,7 +172,7 @@ class PersonServiceTest {
     ProviderSp providerSp = constructProviderCase(personTelephoneFile);
     ProviderSp mprProvider = constructProviderCase(personTelephoneFile);
     mprProvider.setPersonParentUid(mprProvider.getPersonUid());
-    Mockito.when(providerRepository.computeProviders(anyString()))
+    Mockito.when(providerRepository.computeProviders(anyString(), Mockito.eq(false)))
         .thenReturn(List.of(providerSp))
         .thenReturn(List.of(mprProvider));
 
@@ -179,7 +200,8 @@ class PersonServiceTest {
   @Test
   void testProcessPatientDataNoElasticSearch() {
     PatientSp patientSp = PatientSp.builder().personUid(10000001L).build();
-    Mockito.when(patientRepository.computePatients(anyString())).thenReturn(List.of(patientSp));
+    Mockito.when(patientRepository.computePatients(anyString(), Mockito.eq(false)))
+        .thenReturn(List.of(patientSp));
 
     String patientData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
 
@@ -199,7 +221,8 @@ class PersonServiceTest {
   @Test
   void testProcessProviderDataNoElasticSearch() {
     ProviderSp providerSp = ProviderSp.builder().personUid(10000001L).build();
-    Mockito.when(providerRepository.computeProviders(anyString())).thenReturn(List.of(providerSp));
+    Mockito.when(providerRepository.computeProviders(anyString(), Mockito.eq(false)))
+        .thenReturn(List.of(providerSp));
 
     String providerData = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PRV\"}}}";
 
@@ -240,7 +263,7 @@ class PersonServiceTest {
 
     AuthUser user = constructAuthUser();
     AuthUserKey userKey = AuthUserKey.builder().authUserUid(11L).build();
-    Mockito.when(userRepository.computeAuthUsers(anyString()))
+    Mockito.when(userRepository.computeAuthUsers(anyString(), Mockito.eq(false)))
         .thenReturn(Optional.of(List.of(user)));
 
     personService.processMessage(payload, inputTopicUser);
@@ -292,11 +315,11 @@ class PersonServiceTest {
   void testProcessMessageNoDataException(String payload, String inputTopic) {
     if (inputTopic.equals(inputTopicPerson)) {
       Long personUid = 123456789L;
-      when(providerRepository.computeProviders(String.valueOf(personUid)))
+      when(providerRepository.computeProviders(String.valueOf(personUid), false))
           .thenReturn(Collections.emptyList());
     } else if (inputTopic.equals(inputTopicUser)) {
       Long authUserUid = 11L;
-      when(userRepository.computeAuthUsers(String.valueOf(authUserUid)))
+      when(userRepository.computeAuthUsers(String.valueOf(authUserUid), false))
           .thenReturn(Optional.of(Collections.emptyList()));
     }
     CompletableFuture<Void> future = personService.processMessage(payload, inputTopic);

--- a/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
+++ b/reporting-pipeline-service/src/test/java/gov/cdc/nbs/report/pipeline/person/service/PersonServiceTest.java
@@ -156,7 +156,7 @@ class PersonServiceTest {
 
     personService = createPersonService(true);
     personService.processMessage(
-        readFileData("rawDataFiles/person/PersonPatientChangeData.json"), inputTopicPerson);
+        record(readFileData("rawDataFiles/person/PersonPatientChangeData.json"), inputTopicPerson));
 
     Awaitility.await()
         .atMost(1, TimeUnit.SECONDS)
@@ -303,14 +303,14 @@ class PersonServiceTest {
   void testProcessPersonRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"person_uid\": 10000001,\"cd\": \"PAT\"}}}";
     PatientSp patient = PatientSp.builder().personUid(10000001L).build();
-    when(patientRepository.computePatients("10000001")).thenReturn(List.of(patient));
+    when(patientRepository.computePatients("10000001", false)).thenReturn(List.of(patient));
     personService.setPhcDatamartEnable(false);
 
     CompletableFuture<Void> future =
         personService.processMessage(retryRecord(payload, retryTopic, inputTopicPerson));
     future.join();
 
-    verify(patientRepository).computePatients("10000001");
+    verify(patientRepository).computePatients("10000001", false);
     verifyNoInteractions(providerRepository, userRepository);
   }
 
@@ -318,14 +318,14 @@ class PersonServiceTest {
   @ValueSource(strings = {"User_retry-0", "User_retry-1"})
   void testProcessAuthUserRetryMessage(String retryTopic) {
     String payload = "{\"payload\": {\"after\": {\"auth_user_uid\": \"11\"}}}";
-    when(userRepository.computeAuthUsers("11"))
+    when(userRepository.computeAuthUsers("11", false))
         .thenReturn(Optional.of(List.of(constructAuthUser())));
 
     CompletableFuture<Void> future =
         personService.processMessage(retryRecord(payload, retryTopic, inputTopicUser));
     future.join();
 
-    verify(userRepository).computeAuthUsers("11");
+    verify(userRepository).computeAuthUsers("11", false);
     verifyNoInteractions(patientRepository, providerRepository);
   }
 

--- a/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/expected.json
@@ -1,0 +1,22 @@
+{
+  "0": [
+    {
+      "total_count": 2,
+      "start_count": 1,
+      "error_count": 1,
+      "start_batch_id": 990000001,
+      "error_batch_id": 990000002,
+      "dataflow_name": "Job Flow Log Test",
+      "package_name": "sp_add_job_flow_log_test",
+      "start_step_number": 1.0,
+      "error_step_number": 2.0,
+      "start_step_name": "Test start",
+      "error_step_name": "Test error",
+      "start_row_count": 7,
+      "error_row_count": 0,
+      "start_message": "Test message",
+      "error_message": "Test error message",
+      "error_description": "Test error description"
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/query.sql
@@ -1,0 +1,19 @@
+SELECT
+    COUNT(*) AS total_count,
+    SUM(CASE WHEN Status_Type = 'START' THEN 1 ELSE 0 END) AS start_count,
+    SUM(CASE WHEN Status_Type = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
+    MAX(CASE WHEN Status_Type = 'START' THEN batch_id END) AS start_batch_id,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN batch_id END) AS error_batch_id,
+    MAX(Dataflow_Name) AS dataflow_name,
+    MAX(package_Name) AS package_name,
+    MAX(CASE WHEN Status_Type = 'START' THEN step_number END) AS start_step_number,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN step_number END) AS error_step_number,
+    MAX(CASE WHEN Status_Type = 'START' THEN step_name END) AS start_step_name,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN step_name END) AS error_step_name,
+    MAX(CASE WHEN Status_Type = 'START' THEN row_count END) AS start_row_count,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN row_count END) AS error_row_count,
+    MAX(CASE WHEN Status_Type = 'START' THEN Msg_Description1 END) AS start_message,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN Msg_Description1 END) AS error_message,
+    MAX(CASE WHEN Status_Type = 'ERROR' THEN Error_Description END) AS error_description
+FROM dbo.job_flow_log
+WHERE package_Name = 'sp_add_job_flow_log_test';

--- a/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/addJobFlowLog/setup.sql
@@ -1,0 +1,25 @@
+USE [RDB_MODERN]
+
+DELETE FROM dbo.job_flow_log
+WHERE package_Name = 'sp_add_job_flow_log_test';
+
+EXEC dbo.sp_add_job_flow_log
+    @batch_id = 990000001,
+    @dataflow_name = 'Job Flow Log Test',
+    @package_name = 'sp_add_job_flow_log_test',
+    @status_type = 'START',
+    @step_number = 1,
+    @step_name = 'Test start',
+    @row_count = 7,
+    @msg_description1 = 'Test message';
+
+EXEC dbo.sp_add_job_flow_log
+    @batch_id = 990000002,
+    @dataflow_name = 'Job Flow Log Test',
+    @package_name = 'sp_add_job_flow_log_test',
+    @status_type = 'ERROR',
+    @step_number = 2,
+    @step_name = 'Test error',
+    @row_count = 0,
+    @msg_description1 = 'Test error message',
+    @error_description = 'Test error description';

--- a/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/expected.json
@@ -1,0 +1,46 @@
+{
+  "0": [
+    {
+      "procedure_name": "sp_contact_record_event",
+      "start_count": 48,
+      "complete_count": 2,
+      "error_count": 0,
+      "total_count": 50
+    },
+    {
+      "procedure_name": "sp_interview_event",
+      "start_count": 2,
+      "complete_count": 2,
+      "error_count": 0,
+      "total_count": 4
+    },
+    {
+      "procedure_name": "nrt_interview",
+      "start_count": 50,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 50
+    },
+    {
+      "procedure_name": "sp_treatment_event",
+      "start_count": 10,
+      "complete_count": 2,
+      "error_count": 0,
+      "total_count": 12
+    },
+    {
+      "procedure_name": "sp_vaccination_event",
+      "start_count": 48,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 48
+    },
+    {
+      "procedure_name": "sp_vaccination_record_event",
+      "start_count": 0,
+      "complete_count": 2,
+      "error_count": 0,
+      "total_count": 2
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/query.sql
@@ -1,0 +1,17 @@
+SELECT
+    package_Name AS procedure_name,
+    SUM(CASE WHEN Status_Type = 'START' THEN 1 ELSE 0 END) AS start_count,
+    SUM(CASE WHEN Status_Type IN ('COMPLETE', 'COMPLETED') THEN 1 ELSE 0 END) AS complete_count,
+    SUM(CASE WHEN Status_Type = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
+    COUNT(*) AS total_count
+FROM dbo.job_flow_log
+WHERE package_Name IN (
+    'sp_interview_event',
+    'nrt_interview',
+    'sp_contact_record_event',
+    'sp_treatment_event',
+    'sp_vaccination_event',
+    'sp_vaccination_record_event'
+)
+GROUP BY package_Name
+ORDER BY package_Name

--- a/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/detailedEventDebugLogging/setup.sql
@@ -1,0 +1,29 @@
+USE [RDB_MODERN]
+
+DELETE FROM dbo.job_flow_log
+WHERE package_Name IN (
+    'sp_interview_event',
+    'sp_contact_record_event',
+    'sp_treatment_event',
+    'sp_vaccination_event'
+)
+
+EXEC dbo.sp_interview_event @ix_uids = '990000071', @debug = 0, @debug_logging = 0
+EXEC dbo.sp_interview_event @ix_uids = '990000071', @debug = 0, @debug_logging = 1
+EXEC dbo.sp_interview_event @ix_uids = '990000071', @debug = 1, @debug_logging = 0
+EXEC dbo.sp_interview_event @ix_uids = '990000071', @debug = 1, @debug_logging = 1
+
+EXEC dbo.sp_contact_record_event @cc_uids = '990000072', @debug = 0, @debug_logging = 0
+EXEC dbo.sp_contact_record_event @cc_uids = '990000072', @debug = 0, @debug_logging = 1
+EXEC dbo.sp_contact_record_event @cc_uids = '990000072', @debug = 1, @debug_logging = 0
+EXEC dbo.sp_contact_record_event @cc_uids = '990000072', @debug = 1, @debug_logging = 1
+
+EXEC dbo.sp_treatment_event @treatment_uids = '990000073', @debug = 0, @debug_logging = 0
+EXEC dbo.sp_treatment_event @treatment_uids = '990000073', @debug = 0, @debug_logging = 1
+EXEC dbo.sp_treatment_event @treatment_uids = '990000073', @debug = 1, @debug_logging = 0
+EXEC dbo.sp_treatment_event @treatment_uids = '990000073', @debug = 1, @debug_logging = 1
+
+EXEC dbo.sp_vaccination_event @vac_uids = '990000074', @debug = 0, @debug_logging = 0
+EXEC dbo.sp_vaccination_event @vac_uids = '990000074', @debug = 0, @debug_logging = 1
+EXEC dbo.sp_vaccination_event @vac_uids = '990000074', @debug = 1, @debug_logging = 0
+EXEC dbo.sp_vaccination_event @vac_uids = '990000074', @debug = 1, @debug_logging = 1

--- a/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/expected.json
@@ -1,0 +1,116 @@
+{
+  "0": [
+    {
+      "procedure_name": "sp_ldf_data_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_data_event",
+      "debug_logging": "on",
+      "start_count": 6,
+      "complete_count": 6,
+      "error_count": 0,
+      "total_count": 12
+    },
+    {
+      "procedure_name": "sp_ldf_intervention_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_intervention_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_ldf_observation_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_observation_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_ldf_organization_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_organization_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_ldf_patient_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_patient_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_ldf_phc_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_phc_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_ldf_provider_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_ldf_provider_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/query.sql
@@ -1,0 +1,42 @@
+WITH invocations (procedure_name, debug_logging, entity_id) AS (
+    SELECT *
+    FROM (VALUES
+        ('sp_ldf_data_event',         'off', '99100001'),
+        ('sp_ldf_data_event',         'on',  '99100002'),
+        ('sp_ldf_data_event',         'off', '99100003'),
+        ('sp_ldf_data_event',         'on',  '99100004'),
+        ('sp_ldf_data_event',         'off', '99100005'),
+        ('sp_ldf_data_event',         'on',  '99100006'),
+        ('sp_ldf_data_event',         'off', '99100007'),
+        ('sp_ldf_data_event',         'on',  '99100008'),
+        ('sp_ldf_data_event',         'off', '99100009'),
+        ('sp_ldf_data_event',         'on',  '99100010'),
+        ('sp_ldf_data_event',         'off', '99100011'),
+        ('sp_ldf_data_event',         'on',  '99100012'),
+        ('sp_ldf_patient_event',      'off', '99100001'),
+        ('sp_ldf_patient_event',      'on',  '99100002'),
+        ('sp_ldf_provider_event',     'off', '99100003'),
+        ('sp_ldf_provider_event',     'on',  '99100004'),
+        ('sp_ldf_organization_event', 'off', '99100005'),
+        ('sp_ldf_organization_event', 'on',  '99100006'),
+        ('sp_ldf_observation_event',  'off', '99100007'),
+        ('sp_ldf_observation_event',  'on',  '99100008'),
+        ('sp_ldf_phc_event',          'off', '99100009'),
+        ('sp_ldf_phc_event',          'on',  '99100010'),
+        ('sp_ldf_intervention_event', 'off', '99100011'),
+        ('sp_ldf_intervention_event', 'on',  '99100012')
+    ) configured(procedure_name, debug_logging, entity_id)
+)
+SELECT
+    invocation.procedure_name,
+    invocation.debug_logging,
+    SUM(CASE WHEN log.Status_Type = 'START' THEN 1 ELSE 0 END) AS start_count,
+    SUM(CASE WHEN log.Status_Type = 'COMPLETE' THEN 1 ELSE 0 END) AS complete_count,
+    SUM(CASE WHEN log.Status_Type = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
+    COUNT(log.Status_Type) AS total_count
+FROM invocations invocation
+LEFT JOIN dbo.job_flow_log log
+    ON log.package_Name = invocation.procedure_name
+    AND log.Msg_Description1 = invocation.entity_id
+GROUP BY invocation.procedure_name, invocation.debug_logging
+ORDER BY invocation.procedure_name, invocation.debug_logging

--- a/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/ldfEventDebugLogging/setup.sql
@@ -1,0 +1,33 @@
+USE [RDB_MODERN]
+
+DELETE FROM dbo.job_flow_log
+WHERE package_Name IN (
+    'sp_ldf_data_event',
+    'sp_ldf_patient_event',
+    'sp_ldf_provider_event',
+    'sp_ldf_organization_event',
+    'sp_ldf_observation_event',
+    'sp_ldf_phc_event',
+    'sp_ldf_intervention_event'
+)
+AND Msg_Description1 IN (
+    '99100001', '99100002',
+    '99100003', '99100004',
+    '99100005', '99100006',
+    '99100007', '99100008',
+    '99100009', '99100010',
+    '99100011', '99100012'
+)
+
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PAT', @ldf_uid = '99000100', @bus_obj_uid_list = '99100001', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PAT', @ldf_uid = '99000100', @bus_obj_uid_list = '99100002', @debug_logging = 1
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PRV', @ldf_uid = '99000100', @bus_obj_uid_list = '99100003', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PRV', @ldf_uid = '99000100', @bus_obj_uid_list = '99100004', @debug_logging = 1
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'ORG', @ldf_uid = '99000100', @bus_obj_uid_list = '99100005', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'ORG', @ldf_uid = '99000100', @bus_obj_uid_list = '99100006', @debug_logging = 1
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'LAB', @ldf_uid = '99000100', @bus_obj_uid_list = '99100007', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'LAB', @ldf_uid = '99000100', @bus_obj_uid_list = '99100008', @debug_logging = 1
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PHC', @ldf_uid = '99000100', @bus_obj_uid_list = '99100009', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'PHC', @ldf_uid = '99000100', @bus_obj_uid_list = '99100010', @debug_logging = 1
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'VAC', @ldf_uid = '99000100', @bus_obj_uid_list = '99100011', @debug_logging = 0
+EXEC dbo.sp_ldf_data_event @bus_obj_nm = 'VAC', @ldf_uid = '99000100', @bus_obj_uid_list = '99100012', @debug_logging = 1

--- a/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/expected.json
@@ -1,0 +1,25 @@
+{
+  "0": [
+    {
+      "procedure_name": "PCHMartETL",
+      "Status_Type": "COMPLETE",
+      "status_count": 2,
+      "minimum_row_count": 0,
+      "maximum_row_count": 0
+    },
+    {
+      "procedure_name": "PublicHealthCaseFact RTR",
+      "Status_Type": "COMPLETED",
+      "status_count": 58,
+      "minimum_row_count": 0,
+      "maximum_row_count": 12553
+    },
+    {
+      "procedure_name": "PublicHealthCaseFact RTR",
+      "Status_Type": "STEP-AVOIDED",
+      "status_count": 2,
+      "minimum_row_count": 0,
+      "maximum_row_count": 0
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/query.sql
@@ -1,0 +1,10 @@
+SELECT
+    package_Name AS procedure_name,
+    Status_Type,
+    COUNT(*) AS status_count,
+    MIN(row_count) AS minimum_row_count,
+    MAX(row_count) AS maximum_row_count
+FROM dbo.job_flow_log
+WHERE package_Name IN ('PublicHealthCaseFact RTR', 'PCHMartETL')
+GROUP BY package_Name, Status_Type
+ORDER BY package_Name, Status_Type

--- a/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/phcFactEventDebugLogging/setup.sql
@@ -1,0 +1,9 @@
+USE [RDB_MODERN]
+
+DELETE FROM dbo.job_flow_log
+WHERE package_Name = 'PublicHealthCaseFact RTR'
+
+EXEC dbo.sp_public_health_case_fact_datamart_event @phc_id_list = '990000076', @debug = 0, @debug_logging = 0
+EXEC dbo.sp_public_health_case_fact_datamart_event @phc_id_list = '990000076', @debug = 0, @debug_logging = 1
+EXEC dbo.sp_public_health_case_fact_datamart_event @phc_id_list = '990000076', @debug = 1, @debug_logging = 0
+EXEC dbo.sp_public_health_case_fact_datamart_event @phc_id_list = '990000076', @debug = 1, @debug_logging = 1

--- a/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/expected.json
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/expected.json
@@ -1,0 +1,132 @@
+{
+  "0": [
+    {
+      "procedure_name": "sp_auth_user_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_auth_user_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_investigation_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_investigation_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_notification_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_notification_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_observation_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_observation_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_organization_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_organization_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_patient_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_patient_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_place_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_place_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    },
+    {
+      "procedure_name": "sp_provider_event",
+      "debug_logging": "off",
+      "start_count": 0,
+      "complete_count": 0,
+      "error_count": 0,
+      "total_count": 0
+    },
+    {
+      "procedure_name": "sp_provider_event",
+      "debug_logging": "on",
+      "start_count": 1,
+      "complete_count": 1,
+      "error_count": 0,
+      "total_count": 2
+    }
+  ]
+}

--- a/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/query.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/query.sql
@@ -1,0 +1,34 @@
+WITH invocations (procedure_name, debug_logging, entity_id) AS (
+    SELECT *
+    FROM (VALUES
+        ('sp_organization_event', 'off', '990000001'),
+        ('sp_organization_event', 'on',  '990000002'),
+        ('sp_provider_event',     'off', '990000011'),
+        ('sp_provider_event',     'on',  '990000012'),
+        ('sp_observation_event',  'off', '990000021'),
+        ('sp_observation_event',  'on',  '990000022'),
+        ('sp_investigation_event','off', '990000031'),
+        ('sp_investigation_event','on',  '990000032'),
+        ('sp_notification_event', 'off', '990000041'),
+        ('sp_notification_event', 'on',  '990000042'),
+        ('sp_auth_user_event',    'off', '990000051'),
+        ('sp_auth_user_event',    'on',  '990000052'),
+        ('sp_place_event',        'off', '990000061'),
+        ('sp_place_event',        'on',  '990000062'),
+        ('sp_patient_event',       'off', '990000071'),
+        ('sp_patient_event',       'on',  '990000072')
+    ) configured(procedure_name, debug_logging, entity_id)
+)
+SELECT
+    invocation.procedure_name,
+    invocation.debug_logging,
+    SUM(CASE WHEN log.Status_Type = 'START' THEN 1 ELSE 0 END) AS start_count,
+    SUM(CASE WHEN log.Status_Type = 'COMPLETE' THEN 1 ELSE 0 END) AS complete_count,
+    SUM(CASE WHEN log.Status_Type = 'ERROR' THEN 1 ELSE 0 END) AS error_count,
+    COUNT(log.Status_Type) AS total_count
+FROM invocations invocation
+LEFT JOIN dbo.job_flow_log log
+    ON log.package_Name = invocation.procedure_name
+    AND log.Msg_Description1 = invocation.entity_id
+GROUP BY invocation.procedure_name, invocation.debug_logging
+ORDER BY invocation.procedure_name, invocation.debug_logging

--- a/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/setup.sql
+++ b/reporting-pipeline-service/src/test/resources/testData/unit/simpleEventProcedureDebugLogging/setup.sql
@@ -1,0 +1,47 @@
+USE [RDB_MODERN]
+
+DELETE FROM dbo.job_flow_log
+WHERE package_Name IN (
+    'sp_auth_user_event',
+    'sp_patient_event',
+    'sp_investigation_event',
+    'sp_notification_event',
+    'sp_observation_event',
+    'sp_organization_event',
+    'sp_place_event',
+    'sp_provider_event'
+)
+AND Msg_Description1 IN (
+    '990000001', '990000002',
+    '990000011', '990000012',
+    '990000021', '990000022',
+    '990000031', '990000032',
+    '990000041', '990000042',
+    '990000051', '990000052',
+    '990000061', '990000062',
+    '990000071', '990000072'
+)
+
+EXEC dbo.sp_organization_event @org_id_list = '990000001', @debug_logging = 0
+EXEC dbo.sp_organization_event @org_id_list = '990000002', @debug_logging = 1
+
+EXEC dbo.sp_provider_event @user_id_list = '990000011', @debug_logging = 0
+EXEC dbo.sp_provider_event @user_id_list = '990000012', @debug_logging = 1
+
+EXEC dbo.sp_observation_event @obs_id_list = '990000021', @debug_logging = 0
+EXEC dbo.sp_observation_event @obs_id_list = '990000022', @debug_logging = 1
+
+EXEC dbo.sp_investigation_event @phc_id_list = '990000031', @debug_logging = 0
+EXEC dbo.sp_investigation_event @phc_id_list = '990000032', @debug_logging = 1
+
+EXEC dbo.sp_notification_event @notification_list = '990000041', @debug_logging = 0
+EXEC dbo.sp_notification_event @notification_list = '990000042', @debug_logging = 1
+
+EXEC dbo.sp_auth_user_event @user_id_list = '990000051', @debug_logging = 0
+EXEC dbo.sp_auth_user_event @user_id_list = '990000052', @debug_logging = 1
+
+EXEC dbo.sp_place_event @id_list = '990000061', @debug_logging = 0
+EXEC dbo.sp_place_event @id_list = '990000062', @debug_logging = 1
+
+EXEC dbo.sp_patient_event @user_id_list = '990000071', @debug_logging = 0
+EXEC dbo.sp_patient_event @user_id_list = '990000072', @debug_logging = 1


### PR DESCRIPTION
## Description
Made routine job_flow_log writes optional across RTR event stored procedures, defaulting logging off to reduce database and transaction-log volume. Errors remain logged unconditionally, while existing diagnostics, result sets, transactions, nested calls, and positional compatibility are preserved. The EVENT_PROCEDURE_DEBUG_LOGGING setting is propagated through all relevant Java call paths and can be enabled temporarily or for coverage runs. SQL-backed tests, coverage checks, and operational documentation were updated accordingly.

## Related Issues
- [APP-904](https://cdc-nbs.atlassian.net/browse/APP-904)

## Additional Notes
- sp_patient_race_event is intentionally unchanged because it only writes unconditional errors.
- The new setting controls application-invoked routine logging; direct SQL callers must pass @debug_logging = 1 explicitly when needed.
- Functional coverage enables logging automatically, as to capture accurate coverage stats.

## Checklist
- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
